### PR TITLE
Code delivery for Sprint 8 (02/06/2025 – 13/06/2025)

### DIFF
--- a/docs/manifest/sprints/manifest_core_sprint7.md
+++ b/docs/manifest/sprints/manifest_core_sprint7.md
@@ -1,0 +1,372 @@
+# PR Manifest – Sprint 7 (05/12/2025 - 05/30/2025)
+
+## Target Branch
+`mvp_epic2` ← `mvp_sprint7_epic2`
+
+---
+
+## Key points
+- The transformation package provides a set of operations for modifying datasets to prepare them for anonymization, synthetic generation, and privacy analysis. The operations under the transformation package are listed below.
+- Encryption is applied to intermediate artifacts and task results, with integrating focused on the `fake_data`, `profiling`, `tranformation` packages.
+- Apply `Dask` and `JobLib` for large dataset and parallel processing. This affects in the `fake_data`, `profiling`, `tranformation` packages. Their flags are controlled via Task configuration file. 
+- Integrate Caching and progress tracking for the `fake_data`, `profiling`, `tranformation` packages. Currently, the `HierarchicalProgressTracker` class is used for progress tracking.
+- Apply Visualization context for thread safety, not only to avoid inconsistent outputs or failures, but also to improve performance during concurrent execution. This affects in the `fake_data`, `profiling`, `tranformation` packages.
+
+---
+
+## Performance options
+
+### Dask
+- `use_dask`: Whether to use Dask for large dataset processing
+- `chunk_size`: Size of data chunks for processing
+- `npartition`: number of jobs
+
+### JobLib
+- `use_vectorization`: Whether to use vectorized (parallel) processing
+- `parallel_processes`: Number of parallel processes to use
+- `chunk_size`: Size of data chunks for processing
+
+### Chunk
+- `chunk_size`: Size of data chunks for processing
+
+### Acknowledgement
+- Based on the specific logical inner process per operation, some of them can not be applied for JobLib and/or Dask that leads incurrate calculation. Therefore, the parallel processing is forcibly ignored for those operations. The table below details the operations for which parallel processing is marked as 'No'.
+
+---
+
+## Remaining tasks
+- Complete encryption and performance optimization with applying the libraries of Dask and JobLib for the remaining operations of the `fake_data`, `profiling`, `tranformation` packages are listed in the table below.
+- Bug fixing for integration tests.
+- Update Unit tests and documentations.
+
+---
+
+## New package: Transformation
+
+```
+pamola_core/
+└── transformations/
+    ├── base_transformation_op.py
+    ├── __init__.py
+    ├── cleaning/
+    │   ├── clean_invalid_values.py
+    │   └── __init__.py
+    ├── commons/
+    │   ├── aggregation_utils.py
+    │   ├── merging_utils.py
+    │   ├── metric_utils.py
+    │   ├── processing_utils.py
+    │   ├── validation_utils.py
+    │   ├── visualization_utils.py
+    │   └── __init__.py
+    ├── field_ops/
+    │   ├── add_modify_fields.py
+    │   ├── remove_fields.py
+    │   └── __init__.py
+    ├── grouping/
+    │   ├── aggregate_records_op.py
+    │   └── __init__.py
+    ├── imputation/
+    │   ├── impute_missing_values.py
+    │   └── __init__.py
+    ├── merging/
+    │   ├── merge_datasets_op.py
+    │   └── __init__.py
+    └── splitting/
+        ├── split_by_id_values_op.py
+        ├── split_fields_op.py
+        └── __init__.py
+```
+
+---
+
+## Functionalities
+|Packages            |Operations            |Encryption |Dask       |JobLib     |Visualization context|Cache      |Tracker Progress|Reporter|Notes                                                                                                                                                                                                                                                                                                                                          |
+|--------------------|----------------------|-----------|-----------|-----------|-------------|-----------|----------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|core/profiling/     |Anonymity             |Yes        |No         |No         |In-Progress  |Yes        |Yes             |Yes     |Reason: Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward.|
+|core/profiling/     |Attribute             |Yes        |No         |No         |In-Progress  |Yes        |Yes             |Yes     |Reason: Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward.|
+|core/profiling/     |Categorical           |Yes        |No         |No         |In-Progress  |In-Progress|No              |Yes     |Parallelizing categorical by splitting rows is not feasible because the function requires the entire column to compute accurate statistics such as value_counts, entropy, and top_n. Row-wise chunking would result in incorrect results since partial calculations from chunks cannot be simply merged to match the global column statistics. |
+|core/profiling/     |Correlation           |Yes        |No         |No         |In-Progress  |In-Progress|No              |Yes     |Parallelizing correlation analysis by splitting rows using Dask or joblib (joblist) is not feasible because accurate correlation statistics—such as value_counts, contingency tables, and correlation coefficients—require access to the entire columns or all relevant data for each field.                                                   |
+|core/profiling/     |Date                  |Yes        |No         |In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Email                 |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Group                 |Yes        |No         |No         |In-Progress  |In-Progress|No              |Yes     |Parallelizing group-based analysis by splitting rows or partitions is not feasible because group metrics such as variance and duplication require access to all records of each group. If groups are fragmented across partitions, the calculated statistics will be incorrect                                                                 |
+|core/profiling/     |Identity              |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Mvf                   |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Numeric               |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Phone                 |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Text                  |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/profiling/     |Currency              |Yes        |In-Progress|In-Progress|In-Progress  |In-Progress|No              |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/fake_data/     |Email                 |Yes        |Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/fake_data/     |Name                  |Yes        |Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/fake_data/     |Organization          |Yes        |Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/fake_data/     |Phone                 |Yes        |Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|split_fields          |Yes        |In-Progress|In-Progress|In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|split_by_id_values    |Yes        |In-Progress|In-Progress|In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|clean_invalid_values  |Yes        |Yes        |Yes        |In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|impute_missing_values |Yes        |Yes        |Yes        |In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|aggregate_records     |Yes        |In-Progress|No         |In-Progress  |Yes        |Yes             |Yes     |Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.)                                                                                                                                                                |
+|core/transformation/|merge_datasets        |Yes        |In-Progress|No         |In-Progress  |Yes        |Yes             |Yes     |Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.)                                                                                                                                                                |
+|core/transformation/|remove_fields         |Yes        |Yes        |Yes        |In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|add_modify_fields     |Yes        |Yes        |Yes        |In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/transformation/|base_transformation_op|Yes        |In-Progress|In-Progress|In-Progress  |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/anonymization  |numeric               |In-Progress|Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|core/anonymization  |base_anonymization_op |In-Progress|Yes        |Yes        |Yes          |Yes        |Yes             |Yes     |                                                                                                                                                                                                                                                                                                                                               |
+|                    |                      |           |           |           |             |           |                |        |                                                                                                                                                                                                                                                                                                                                               |
+
+---
+
+## Improvement for consistency (if needed)
+- Handle the parameter `include_timestamp` consistently across all packages. Currently, handling is inconsistent among packages/operations, and it's also missing from the `fake_data` package.
+- Handle the parameter `output_format` across all packages. It is currently required for the `transformation` package but is not mentioned or updated for other packages.
+
+---
+
+## End of the sprint 7
+
+---
+
+# PREVIOUS CHANGES
+
+---
+
+# Previous Manifest – Sprint 7 - Week 1 (05/12/2025 - 05/23/2025)
+
+## Key points
+
+- The transformation package provides a set of operations for modifying datasets to prepare them for anonymization, synthetic generation, and privacy analysis.
+- Encryption is applied to intermediate artifacts and task results, with initial integrating focused on the fake_data package.
+- Dask is used for parallel, distributed processing, with initial implementation focused on the fake_data package.
+
+---
+
+## Implementations changed
+
+### Added
+- pamola/pamola_core/common/enum/relationship_type.py
+- pamola/pamola_core/common/helpers/custom_aggregations_helper.py
+- pamola/pamola_core/transformations/__init__.py
+- pamola/pamola_core/transformations/base_transformation_op.py
+- pamola/pamola_core/transformations/cleaning/clean_invalid_values.py
+- pamola/pamola_core/transformations/cleaning__old_02_05/__init__.py
+- pamola/pamola_core/transformations/commons/__init__.py
+- pamola/pamola_core/transformations/commons/aggregation_utils.py
+- pamola/pamola_core/transformations/commons/merging_utils.py
+- pamola/pamola_core/transformations/commons/metric_utils.py
+- pamola/pamola_core/transformations/commons/processing_utils.py
+- pamola/pamola_core/transformations/commons/validation_utils.py
+- pamola/pamola_core/transformations/commons/visualization_utils.py
+- pamola/pamola_core/transformations/field_ops/__init__.py
+- pamola/pamola_core/transformations/field_ops/add_modify_fields.py
+- pamola/pamola_core/transformations/field_ops/remove_fields.py
+- pamola/pamola_core/transformations/grouping/__init__.py
+- pamola/pamola_core/transformations/grouping/aggregate_records_op.py
+- pamola/pamola_core/transformations/imputation/__init__.py
+- pamola/pamola_core/transformations/imputation/impute_missing_values.py
+- pamola/pamola_core/transformations/merging/__init__.py
+- pamola/pamola_core/transformations/merging/merge_datasets_op.py
+- pamola/pamola_core/transformations/splitting/__init__.py
+- pamola/pamola_core/transformations/splitting/split_by_id_values_op.py
+- pamola/pamola_core/transformations/splitting/split_fields_op.py
+- pamola/pamola_core/utils/vis_helpers/venn_diagram.py
+
+#### Modified
+- pamola/pamola_core/anonymization/base_anonymization_op.py
+- pamola/pamola_core/anonymization/commons/visualization_utils.py
+- pamola/pamola_core/anonymization/generalization/numeric.py
+- pamola/pamola_core/common/constants.py
+- pamola/pamola_core/fake_data/commons/operations.py
+- pamola/pamola_core/fake_data/operations/email_op.py
+- pamola/pamola_core/fake_data/operations/name_op.py
+- pamola/pamola_core/fake_data/operations/organization_op.py
+- pamola/pamola_core/fake_data/operations/phone_op.py
+- pamola/pamola_core/profiling/analyzers/anonymity.py
+- pamola/pamola_core/profiling/analyzers/attribute.py
+- pamola/pamola_core/profiling/analyzers/categorical.py
+- pamola/pamola_core/profiling/analyzers/correlation.py
+- pamola/pamola_core/profiling/analyzers/currency.py
+- pamola/pamola_core/profiling/analyzers/date.py
+- pamola/pamola_core/profiling/analyzers/email.py
+- pamola/pamola_core/profiling/analyzers/group.py
+- pamola/pamola_core/profiling/analyzers/identity.py
+- pamola/pamola_core/profiling/analyzers/mvf.py
+- pamola/pamola_core/profiling/analyzers/numeric.py
+- pamola/pamola_core/profiling/analyzers/phone.py
+- pamola/pamola_core/profiling/analyzers/text.py
+- pamola/pamola_core/profiling/commons/anonymity_utils.py
+- pamola/pamola_core/transformations/cleaning/__init__.py
+- pamola/pamola_core/utils/io.py
+- pamola/pamola_core/utils/ops/op_data_writer.py
+- pamola/pamola_core/utils/tasks/base_task.py
+- pamola/pamola_core/utils/vis_helpers/__init__.py
+- pamola/pamola_core/utils/visualization.py
+
+---
+
+## Public API Changes
+
+### Added
+
+#### Transformation
+- `MergeDatasetsOperation`
+- `ImputeMissingValuesOperation`
+- `AddOrModifyFieldsOperation`
+- `RemoveFieldsOperation`
+- `SplitByIDValuesOperation`
+- `SplitFieldsOperation`
+- `AggregateRecordsOperation`  
+- `CleanInvalidValuesOperation` 
+
+### Changed
+- ...
+
+### Deprecated
+- None
+
+---
+
+## Bug fixing
+- None
+
+
+## Unit tests
+
+### Test Coverage Summary
+
+| Module         | Coverage (%) |
+| -------------- | ------------ |
+| Tasks utils    | 94           |
+| Nlp utils      | 94           |
+| profiling      | 99           |
+| fake_data      | 99           |
+| transformation | 97           |
+| **Total**      | 96.6         |
+ 
+#### fake_data
+coverage run -m pytest tests/fake_data
+coverage report --include="tests/fake_data/**/*.py"
+
+#### profiling
+coverage run -m pytest tests/profiling
+coverage report --include="tests/profiling/**/*.py"
+
+#### nlp
+coverage run -m pytest tests/utils/nlp
+coverage report --include="tests/utils/nlp/**/*.py"
+
+#### transformations
+coverage run -m pytest tests/transformations
+coverage report --include="tests/transformations/**/*.py"
+
+### Added
+- pamola/tests/profiling/analyzers/test_anonymity.py
+- pamola/tests/profiling/analyzers/test_categorical.py
+- pamola/tests/profiling/analyzers/test_correlation.py
+- pamola/tests/profiling/analyzers/test_currency.py
+- pamola/tests/profiling/analyzers/test_group.py
+- pamola/tests/profiling/analyzers/test_mvf.py
+- pamola/tests/profiling/analyzers/test_numeric.py
+- pamola/tests/profiling/analyzers/test_phone.py
+- pamola/tests/profiling/analyzers/test_text.py
+- pamola/tests/profiling/commons/test_anonymity_utils.py
+- pamola/tests/profiling/commons/test_attribute_utils.py
+- pamola/tests/profiling/commons/test_base.py
+- pamola/tests/profiling/commons/test_categorical_utils.py
+- pamola/tests/profiling/commons/test_correlation_utils.py
+- pamola/tests/profiling/commons/test_currency_analysis.py
+- pamola/tests/profiling/commons/test_currency_utils.py
+- pamola/tests/profiling/commons/test_data_processing.py
+- pamola/tests/profiling/commons/test_data_types.py
+- pamola/tests/profiling/commons/test_date_utils.py
+- pamola/tests/profiling/commons/test_dtype_helpers.py
+- pamola/tests/profiling/commons/test_email_utils.py
+- pamola/tests/profiling/commons/test_group_utils.py
+- pamola/tests/profiling/commons/test_helpers.py
+- pamola/tests/profiling/commons/test_identity_utils.py
+- pamola/tests/profiling/commons/test_mvf_utils.py
+- pamola/tests/profiling/commons/test_numeric_utils.py
+- pamola/tests/profiling/commons/test_phone_utils.py
+- pamola/tests/profiling/commons/test_statistical_analysis.py
+- pamola/tests/profiling/commons/test_text_utils.py
+- pamola/tests/profiling/commons/test_visualization_utils.py
+- pamola/tests/transformations/cleaning/test_clean_invalid_values.py
+- pamola/tests/transformations/commons/test_aggregation_utils.py
+- pamola/tests/transformations/commons/test_merging_utils.py
+- pamola/tests/transformations/commons/test_metric_utils.py
+- pamola/tests/transformations/commons/test_processing_utils.py
+- pamola/tests/transformations/commons/test_validation_utils.py
+- pamola/tests/transformations/commons/test_visualization_utils.py
+- pamola/tests/transformations/field_ops/test_add_modify_fields.py
+- pamola/tests/transformations/field_ops/test_remove_fields.py
+- pamola/tests/transformations/grouping/test_aggregate_records_op.py
+- pamola/tests/transformations/imputation/test_impute_missing_values.py
+- pamola/tests/transformations/merging/test_merge_datasets_op.py
+- pamola/tests/transformations/splitting/test_split_by_id_values_op.py
+- pamola/tests/transformations/splitting/test_split_fields_op.py
+- pamola/tests/transformations/test_base_transformation_op.py
+- pamola/tests/utils/tasks/test_context_manager.py
+- pamola/tests/utils/tasks/test_dependency_manager.py
+- pamola/tests/utils/tasks/test_directory_manager.py
+- pamola/tests/utils/tasks/test_encryption_manager.py
+- pamola/tests/utils/tasks/test_operation_executor.py
+- pamola/tests/utils/tasks/test_path_security.py
+- pamola/tests/utils/tasks/test_progress_manager.py
+- pamola/tests/utils/tasks/test_project_config_loader.py
+
+### Modified
+- None
+
+---
+
+## Documentations
+
+### Summary
+- Tasks utils (DONE)
+- NLP utils (DONE)
+- Transformation package (DONE)
+
+### Added
+- pamola/docs/en/core/transformations/base_transformation_op.md
+- pamola/docs/en/core/transformations/cleaning/clean_invalid_values.md
+- pamola/docs/en/core/transformations/commons/aggregation_utils.md
+- pamola/docs/en/core/transformations/commons/merging_utils.md
+- pamola/docs/en/core/transformations/commons/metric_utils.md
+- pamola/docs/en/core/transformations/commons/processing_utils.md
+- pamola/docs/en/core/transformations/commons/validation_utils.md
+- pamola/docs/en/core/transformations/commons/visualization_utils.md
+- pamola/docs/en/core/transformations/field_ops/add_modify_fields.md
+- pamola/docs/en/core/transformations/field_ops/remove_fields.md
+- pamola/docs/en/core/transformations/grouping/aggregate_records_op.md
+- pamola/docs/en/core/transformations/imputation/impute_missing_values.md
+- pamola/docs/en/core/transformations/merging/merge_datasets_op.md
+- pamola/docs/en/core/transformations/splitting/split_by_id_values_op.md
+- pamola/docs/en/core/transformations/splitting/split_fields_op.md
+- pamola/docs/en/core/utils/nlp/base.md
+- pamola/docs/en/core/utils/nlp/cache.md
+- pamola/docs/en/core/utils/nlp/category_matching.md
+- pamola/docs/en/core/utils/nlp/clustering.md
+- pamola/docs/en/core/utils/nlp/compatibility.md
+- pamola/docs/en/core/utils/nlp/entity/base.md
+- pamola/docs/en/core/utils/nlp/entity/dictionary.md
+- pamola/docs/en/core/utils/nlp/entity/job.md
+- pamola/docs/en/core/utils/nlp/entity/organization.md
+- pamola/docs/en/core/utils/nlp/entity/skill.md
+- pamola/docs/en/core/utils/nlp/entity/transaction.md
+- pamola/docs/en/core/utils/nlp/entity_extraction.md
+- pamola/docs/en/core/utils/nlp/model_manager.md
+- pamola/docs/en/core/utils/nlp/tokenization_ext.md
+- pamola/docs/en/core/utils/nlp/tokenization_helpers.md
+- pamola/docs/sprints/manifest_s7.md
+- pamola/docs/sprints/mr_manifest_per_sprint.md
+
+### Modified
+- None
+
+---
+
+## Remaining tasks (Week 2)
+- Integrate encryption across all operations in the implemented packages, including `fake_data`, `profiling`, and `transformation`.
+- Apply `Dask` and `JobLib` for large dataset and parallel processing.
+- Migrate code of Visualization utils from HHR and adopt code changes as needed.
+- Integrate other packages if delivered.
+
+---

--- a/docs/manifest/sprints/manifest_core_sprint8.md
+++ b/docs/manifest/sprints/manifest_core_sprint8.md
@@ -1,0 +1,110 @@
+# PR Manifest – Sprint 8 (02/06/2025 - 13/06/2025)
+
+## Key points
+- Encryption integration: fake_data, profiling, transformation packages
+- Parallel processing with Dask and JobLib: fake_data, profiling, transformation packages
+- Cache and progress tracking: fake_data, profiling, transformation packages
+- Thread-safe visualization context: fake_data, profiling, transformation packages
+- Enhancement log to file for Task execution, including operation log
+
+---
+
+## Summary of Changes
+
+| Category | Package | MRs | Changes |
+|----------|---------|-----|---------|
+| Package & Integration | fake_data | [MR-902, MR-963, MR-907, MR-948] | - Applied encryption across operations<br>- Applied parallel processing using Dask and JobLib |
+| | profiling | [MR-931, MR-963, MR-929, MR-962, MR-948, MR-1031, MR-1035] | - Applied encryption across operations<br>- Applied parallel processing using Dask and JobLib |
+| | transformation | [MR-902, MR-905, MR-924, MR-948] | - Applied encryption across operations<br>- Applied parallel processing using Dask and JobLib |
+| | anonymization | [MR-1027] | - Applied encryption across operations |
+| Bug Fixing | transformation | [MR-910, MR-980, MR-1008, MR-1038, MR-1039] | - Fixed issues in transformation operations<br>- Fixed import encryption mode |
+| | fake_data | [MR-941, MR-961, MR-967, MR-1038, MR-1039] | - Fixed bugs in operations<br>- Fixed cache application issues<br>- Fixed import encryption mode |
+| | profiling | [MR-941, MR-980, MR-1008, MR-1038, MR-1039] | - Fixed bugs in operations<br>- Fixed import encryption mode |
+| Logging Improvements | transformation | [MR-954, MR-962, MR-948] | - Enhanced logging to file instead of console-only output<br>- Added logging for operations |
+| | profiling | [MR-962, MR-948] | - Added logging for operations |
+| | fake_data | [MR-948] | - Added logging for operations |
+| Visualization & Context | transformation | [MR-902] | - Implemented visualization context with thread safety |
+| | profiling | [MR-931, MR-963] | - Applied context to packages<br>- Enhanced safety measures for thread handling |
+| Cache & Progress Tracking | profiling | [MR-915, MR-936] | - Integrated caching mechanism across operations<br>- Implemented progress tracking<br>- Enhanced caching with encryption key parameter |
+| | fake_data | [MR-967] | - Integrated caching mechanism across operations<br>- Implemented progress tracking |
+| | transformation | [MR-967] | - Integrated caching mechanism across operations<br>- Implemented progress tracking |
+| Code Improvements | profiling | [MR-963] | - Removed unused parameters<br>- Standardized parameter handling across packages<br>- Optimized code organization |
+| Unit Tests | fake_data | [MR-907] | - Added tests for parallel processing using Dask and JobLib<br>- Added tests for transformation operations<br>- Maintained high test coverage (96.6% total coverage) |
+
+---
+
+### MRs (Incorporated into Summary Table Above)
+All the MRs below have been integrated into the Summary of Changes table above:
+
+- MR-902: Package & Integration and Visualization & Context for fake_data and transformation packages
+- MR-905: Package & Integration for transformation package
+- MR-907: Package & Integration and Unit Tests for fake_data package
+- MR-910: Bug Fixing for transformation package
+- MR-915: Cache & Progress Tracking for profiling package
+- MR-924: Package & Integration for transformation package
+- MR-929: Package & Integration for profiling package
+- MR-931: Package & Integration and Visualization & Context for profiling package
+- MR-936: Cache & Progress Tracking for profiling package
+- MR-941: Bug Fixing for fake_data and profiling packages
+- MR-948: Package & Integration and Logging Improvements for fake_data, profiling, and transformation packages
+- MR-954: Logging Improvements for transformation package
+- MR-961: Bug Fixing for fake_data package
+- MR-962: Package & Integration and Logging Improvements for profiling package
+- MR-963: Package & Integration, Visualization & Context, and Code Improvements for fake_data and profiling packages
+- MR-967: Bug Fixing for fake_data and Cache & Progress Tracking for fake_data and transformation packages
+- MR-980: Bug Fixing for profiling and transformation packages
+- MR-1008: Bug Fixing for profiling and transformation packages
+- MR-1027: Package & Integration and encryption across operations for anonymization package
+- MR-1031: Package & Integration for profiling package
+- MR-1035: Package & Integration for profiling package
+- MR-1038: Bug Fixing for import encryption mode in profiling, transformation, and fake_data packages
+- MR-1039: Bug Fixing for profiling, transformation, and fake_data packages
+
+## Functionalities
+
+### Summary of functionalities per each package
+| Functionality | Fake Data | Profiling | Transformation |
+| --- | --- | --- | --- |
+| Encryption | 100% | 100% | 100% |
+| Dask | 100% | 100% | 100% |
+| JobLib | 100% | 100% | 100% |
+| Metrics & Visualization | 100% | 100% | 100% |
+| Threads for Visualization | 0% | 85% | 78% |
+| Cache | 100% | 100% | 100% |
+| Standardized Error Handling | 100% | 100% | 100% |
+| Progress Tracker | 100% | 100% | 100% |
+| Reporter | 100% | 100% | 100% |
+
+
+### Details of functionalities
+
+| Packages | Operations | DataSource utils | Encryption | Encryption mode per Task | Encryption provider for output dataset | Encryption provider for artifacts | Dask | JobLib | Metrics & Visualization | Threads for Visualization | Cache | Standardized Error Handling | Tracker Progress | Reporter | Log to files | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| core/profiling/ | Anonymity | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. - To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward. |
+| core/profiling/ | Attribute | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. - To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward. |
+| core/profiling/ | Categorical | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Parallelizing categorical by splitting rows is not feasible because the function requires the entire column to compute accurate statistics such as value_counts, entropy, and top_n. Row-wise chunking would result in incorrect results since partial calculations from chunks cannot be simply merged to match the global column statistics. |
+| core/profiling/ | Correlation | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Parallelizing correlation analysis by splitting rows using Dask or joblib (joblist) is not feasible because accurate correlation statisticssuch as value_counts, contingency tables, and correlation coefficientsrequire access to the entire columns or all relevant data for each field. |
+| core/profiling/ | Date | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/profiling/ | Email | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/profiling/ | Group | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Parallelizing group-based analysis by splitting rows or partitions is not feasible because group metrics such as variance and duplication require access to all records of each group. If groups are fragmented across partitions, the calculated statistics will be incorrect |
+| core/profiling/ | Identity | Yes | Yes | Yes | Simple | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Identity analysis cannot be parallelized by splitting rows using Dask or joblib. This is because accurate statisticssuch as value_counts, groupby, distribution, and top_nrequire access to the entire column or all groups to compute correct results. If the data is split by rows, partial results from each chunk cannot be simply merged to produce the correct global statistics. - Do not use output_format because the data only returns analysis results. |
+| core/profiling/ | Mvf | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/profiling/ | Numeric | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/profiling/ | Phone | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/profiling/ | Text | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | The flow will get a sample to detect if it's a large dataset, so there's no need to apply parallelization |
+| core/profiling/ | Currency | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/fake_data/ | Email | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
+| core/fake_data/ | Name | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
+| core/fake_data/ | Organization | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
+| core/fake_data/ | Phone | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | split_fields | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Dask and Joblib are not used here because we are only splitting the DataFrame by column groups, which is a lightweight operation. Pandas handles column selection efficiently even with millions of rows, so adding parallelism would introduce unnecessary overhead without performance benefits. |
+| core/transformation/ | split_by_id_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | clean_invalid_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | impute_missing_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | aggregate_records | Yes | Yes | Yes | Auto-determined  | Simple | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.) |
+| core/transformation/ | merge_datasets | Yes | Yes | Yes | Auto-determined  | Simple | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.) |
+| core/transformation/ | remove_fields | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | add_modify_fields | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+| core/transformation/ | base_transformation_op | Yes | Yes | Yes | Simple | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
+
+---

--- a/pamola_core/common/enum/encryption_mode.py
+++ b/pamola_core/common/enum/encryption_mode.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class EncryptionMode(Enum):
+    """
+    Encryption modes supported by the task framework.
+
+    - NONE: No encryption
+    - SIMPLE: Simple symmetric encryption
+    - AGE: Age encryption (more secure, supports key rotation)
+    """
+    NONE = "none"
+    SIMPLE = "simple"
+    AGE = "age"
+
+    @classmethod
+    def from_string(cls, value: str) -> 'EncryptionMode':
+        """Convert string to EncryptionMode enum value."""
+        try:
+            return cls(value.lower())
+        except (ValueError, AttributeError):
+            return cls.SIMPLE

--- a/pamola_core/common/enum/relationship_type.py
+++ b/pamola_core/common/enum/relationship_type.py
@@ -2,5 +2,5 @@ from enum import Enum
 
 class RelationshipType(str, Enum):
     AUTO = "auto"
-    ONE_TO_ONE = "one_to_one"
-    ONE_TO_MANY = "one_to_many"
+    ONE_TO_ONE = "one-to-one"
+    ONE_TO_MANY = "one-to-many"

--- a/pamola_core/common/regex/patterns.py
+++ b/pamola_core/common/regex/patterns.py
@@ -18,7 +18,7 @@ Author: Realm Inveo Inc. & DGT Network Inc.
 """
 class Patterns:
     EMAIL_REGEX = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-    PHONE_REGEX = r"^\+?(\d[\d\-. ]+)?(\([\d\-. ]+\))?[\d\-. ]+\d$"
+    PHONE_REGEX = r"^\+?(?:\d[\d\-. ]+)?(?:\([\d\-. ]+\))?[\d\-. ]+\d$"
     CREDIT_CARD = r"^\d{4}[ -]?\d{4}[ -]?\d{4}[ -]?\d{4}$"
     DOMAIN_REGEX = r"@([\w.-]+)"
     PCI_PATTERNS = r'^\d{16}$|^(\d{4}[ ]{1}){3}\d{4}$|^(\d{4}[-]{1}){3}\d{4}$'

--- a/pamola_core/fake_data/commons/mapping_store.py
+++ b/pamola_core/fake_data/commons/mapping_store.py
@@ -11,9 +11,7 @@ import datetime
 import pickle
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
-
 import pandas as pd
-
 from pamola_core.utils import io as pamola_io
 from pamola_core.utils import logging as pamola_logging
 

--- a/pamola_core/fake_data/commons/metrics.py
+++ b/pamola_core/fake_data/commons/metrics.py
@@ -6,25 +6,17 @@ properties of generated fake data, including distribution comparison,
 format validation, and performance assessment.
 """
 
-import time
 import logging
-from typing import Dict, List, Any, Optional, Union, Tuple
+from typing import Dict, Any, Optional, Union
 from pathlib import Path
-import statistics
-import json
-from collections import Counter
-
 import pandas as pd
 import numpy as np
 
 from pamola_core.utils.visualization import (
     create_bar_plot,
-    create_histogram,
-    create_line_plot,
     create_combined_chart,
     create_pie_chart
 )
-from pamola_core.utils.io import ensure_directory
 
 # Configure logger
 logger = logging.getLogger(__name__)

--- a/pamola_core/fake_data/commons/name_utils.py
+++ b/pamola_core/fake_data/commons/name_utils.py
@@ -8,11 +8,8 @@ manipulating personal names for use in fake data generation.
 import re
 import unicodedata
 from typing import Dict, List, Optional, Tuple, Any, Union
-
 import pandas as pd
-
 from pamola_core.utils import logging
-from pamola_core.fake_data.commons import dict_helpers
 
 # Configure logger
 logger = logging.get_logger("pamola_core.fake_data.commons.name_utils")
@@ -69,7 +66,7 @@ def parse_full_name(full_name: str, language: str = "ru") -> Dict[str, str]:
                 result["middle_name"] = parts[1]
         if len(parts) >= 3:
             result["last_name"] = " ".join(parts[2:])
-    elif language == "vn":
+    elif language in ["vn", "vi"]:
         # Vietnamese convention: Last Middle First
         if len(parts) >= 1:
             result["last_name"] = parts[0]
@@ -126,7 +123,7 @@ def format_name(name_parts: Dict[str, str], format_type: str = "full", language:
             # English: First Middle Last
             parts = [first, middle, last]
             return " ".join(p for p in parts if p)
-        elif language == "vn":
+        elif language in ["vn", "vi"]:
             # Vietnamese: Last Middle First
             parts = [last, middle, first]
             return " ".join(p for p in parts if p)

--- a/pamola_core/fake_data/commons/operations.py
+++ b/pamola_core/fake_data/commons/operations.py
@@ -5,13 +5,13 @@ This module provides standardized operation classes for fake data generation
 that integrate with PAMOLA's operation system to generate synthetic data while
 maintaining statistical properties of the original data.
 """
+
 import psutil
 import hashlib
 import json
-import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Tuple
 import pandas as pd
 from pamola_core.fake_data.commons.mapping_store import MappingStore
 from pamola_core.fake_data.commons.base import (
@@ -38,8 +38,7 @@ from pamola_core.utils.progress import ProgressTracker
 import dask.dataframe as dd
 from joblib import Parallel, delayed
 from pamola_core.common.constants import Constants
-# Configure logger
-logger = logging.getLogger(__name__)
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 
 class BaseOperation(PAMOLABaseOperation):
@@ -82,7 +81,7 @@ class BaseOperation(PAMOLABaseOperation):
         OperationResult
             Operation result
         """
-        logger.info(f"Executing {self.name} operation")
+        self.logger.info(f"Executing {self.name} operation")
 
         # Initialize result with default error status
         result = OperationResult(
@@ -106,12 +105,13 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
     description: str = "Base operation for field processing"
 
     def __init__(self, field_name: str, mode: str = "REPLACE", output_field_name: Optional[str] = None,
-                 batch_size: int = 10000, null_strategy: Union[str, NullStrategy] = NullStrategy.PRESERVE,
+                 chunk_size: int = 10000, null_strategy: Union[str, NullStrategy] = NullStrategy.PRESERVE,
+                 save_output: bool = True, generate_visualization: bool = True,
                  use_cache: bool = True, force_recalculation: bool = False,
                  use_dask: bool = False, npartitions: int = 1,
                  use_vectorization: bool = False, parallel_processes: int = 1,
-                 use_encryption: bool = False, encryption_key: Optional[Union[str, Path]] = None,
-                 visualization_backend: Optional[str] = None, vis_theme: Optional[str] = None, vis_strict: bool = False):
+                 visualization_backend: Optional[str] = None, visualization_theme: Optional[str] = None, visualization_strict: bool = False,
+                 use_encryption: bool = False, encryption_key: Optional[Union[str, Path]] = None, encryption_mode: Optional[str] = None):
         """
         Initializes the field operation.
 
@@ -123,7 +123,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             Operation mode: "REPLACE" or "ENRICH"
         output_field_name : str, optional
             Name of the output field (used in ENRICH mode)
-        batch_size : int
+        chunk_size : int
             Size of batches for processing
         null_strategy : str or NullStrategy
             Strategy for handling NULL values: "PRESERVE", "REPLACE", "EXCLUDE", "ERROR"
@@ -151,7 +151,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             try:
                 null_strategy = NullStrategy(null_strategy.lower())
             except ValueError:
-                logger.warning(f"Unknown NULL strategy: {null_strategy}. Using PRESERVE.")
+                self.logger.warning(f"Unknown NULL strategy: {null_strategy}. Using PRESERVE.")
                 null_strategy = NullStrategy.PRESERVE
 
         BaseFieldOperation.__init__(
@@ -166,7 +166,9 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         BaseOperation.__init__(self)
 
         # Additional field operation parameters
-        self.batch_size = batch_size
+        self.chunk_size = chunk_size
+        self.save_output = save_output
+        self.generate_visualization = generate_visualization
         self.use_cache = use_cache
         self.force_recalculation = force_recalculation
         self.use_dask = use_dask
@@ -181,10 +183,11 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         
         self.use_encryption = use_encryption
         self.encryption_key = encryption_key
+        self.encryption_mode = encryption_mode
 
         self.visualization_backend = visualization_backend
-        self.vis_theme = vis_theme
-        self.vis_strict = vis_strict
+        self.visualization_theme = visualization_theme
+        self.visualization_strict = visualization_strict
 
     def execute(self, data_source: Any, task_dir: Path, reporter: Any, progress_tracker: Optional[HierarchicalProgressTracker] = None, **kwargs) -> OperationResult:
         """
@@ -206,19 +209,18 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         OperationResult
             Operation result
         """
-        start_time = time.time()
 
-        logger.info(f"Executing {self.name} operation on field {self.field_name}")
+        self.start_time = time.time()
+
+        caller_operation = self.__class__.__name__
+        self.logger = kwargs.get('logger', self.logger)
 
         try:
-            if reporter:
-                reporter.add_operation(f"Operation {self.name}", status="info",
-                                       details={"message": "Starting operation execution"})
-
-            step_count = 0
+            # Start operation
+            self.logger.info(f"Operation: {caller_operation}, Start operation")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Preparation", "operation": self.name})
-                step_count += 1
+                progress_tracker.total = self._compute_total_steps(**kwargs)
+                progress_tracker.update(1, {"step": "Start operation - Preparation", "operation": caller_operation})
 
             # Create output directory for data output and maps
             dirs = self._prepare_directories(task_dir)
@@ -226,86 +228,91 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             visualizations_dir = dirs['visualizations']
 
             if reporter:
-                reporter.add_operation(f"Operation {self.name}", status="info",
-                                       details={"message": "Prepared output directories"})
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Preparation",
+                                                "message": "Preparation successfully",
+                                                "directories": {k: str(v) for k, v in dirs.items()}
+                                       })
 
+            # Load data and validate input parameters
+            self.logger.info(f"Operation: {caller_operation}, Load data and validate input parameters")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Loading dataset", "operation": self.name})
-                step_count += 1
+                progress_tracker.update(1, {"step": "Load data and validate input parameters", "operation": caller_operation})
 
-            # Load data
-            dataset_name = kwargs.get('dataset_name', "main")
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
-            df = load_data_operation(data_source, dataset_name, **settings_operation)
+            df, is_valid = self._load_data_and_validate_input_parameters(data_source, **kwargs)
 
-            # Store original data for metrics comparison
-            self._original_df = df.copy()
+            if is_valid:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters successfully",
+                                                    "shape": df.shape
+                                           })
+            else:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters failed"
+                                           })
+                    return OperationResult(status=OperationStatus.ERROR,
+                                           error_message="Load data and validate input parameters failed",
+                                           execution_time=time.time() - self.start_time)
 
-            # Check if field exists
-            if self.field_name not in df.columns:
-                error_message = f"Field {self.field_name} not found in the data"
-                logger.error(error_message)
-
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message=error_message,
-                    execution_time=time.time() - start_time
-                )
-
-
-            # Progress bar for batch processing
-            total_records = len(df)
-            total_batches = (total_records + self.batch_size - 1) // self.batch_size
-           
-            # Preprocess data
-            df = self.preprocess_data(df)
-
-            # Handle NULL values
-            df = self.handle_null_values(df)
-
-            if reporter:
-                reporter.add_operation(f"Operation {self.name}", status="info",
-                                       details={"message": f"Dataset '{dataset_name}' loaded and verify successfully"})
-
-            # Handle caching
+            # Handle cache if required
             if self.use_cache and not self.force_recalculation:
+                self.logger.info(f"Operation: {caller_operation}, Load result from cache")
                 if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Use cache", "operation": self.name})
-                    step_count += 1
+                    progress_tracker.update(1, {"step": "Load result from cache", "operation": caller_operation})
 
-                cached_result = self._get_cache(df.copy())  # _get_cache now returns OperationResult or None
+                cached_result = self._get_cache(df.copy(), **kwargs)  # _get_cache now returns OperationResult or None
                 if cached_result is not None and isinstance(cached_result, OperationResult):
                     if reporter:
-                        reporter.add_operation(f"Operation {self.name}", status="info",
-                                               details={"message": "Result loaded from cache – execution skipped"})
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache successfully"
+                                               })
                     return cached_result
                 else:
-                    self.logger.info("No valid cached result found — proceeding with execution.")
+                    self.logger.info(f"Operation: {caller_operation}, Load result from cache failed — proceeding with execution.")
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache failed - proceeding with execution"
+                                               })
 
-            if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Processing data", "operation": self.name})
-                step_count += 1
-
+            total_records = len(df)
             # Handle dask
             if self.use_dask and self.npartitions > 1:
+                self.logger.info(f"Operation: {caller_operation}, Processing data using dask")
                 if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Use dask", "operation": self.name})
-                    step_count += 1
+                    progress_tracker.update(1, {"step": "Processing data using dask", "operation": caller_operation})
 
                 ddf = dd.from_pandas(df, npartitions=self.npartitions)
+
+                # Map process_batch to each partition
                 processed_ddf = ddf.map_partitions(self.process_batch)
-                df = processed_ddf.compute()
+
+                # Compute result
+                result_df = processed_ddf.compute()
+
+                # Apply result based on self.mode
+                if self.mode == "REPLACE":
+                    df = result_df
+                elif self.mode == "ENRICH":
+                    for col in result_df.columns:
+                        if col not in df.columns or col == self.output_field_name:
+                            df[col] = result_df[col]
 
             # Handle joblib
-            elif self.use_vectorization:
+            elif self.use_vectorization and self.parallel_processes > 1:
+                self.logger.info(f"Operation: {caller_operation}, Processing data using joblib")
                 if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Use joblib", "operation": self.name})
-                    step_count += 1
+                    progress_tracker.update(1, {"step": "Processing data using joblib", "operation": caller_operation})
 
                 # Split data into batches
                 batches = [
-                    (i, df.iloc[batch_start:batch_start + self.batch_size].copy())
-                    for i, batch_start in enumerate(range(0, total_records, self.batch_size))
+                    (i, df.iloc[batch_start:batch_start + self.chunk_size].copy())
+                    for i, batch_start in enumerate(range(0, total_records, self.chunk_size))
                 ]
 
                 # Process batches in parallel using joblib
@@ -315,8 +322,8 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
 
                 # Merge the results
                 for (i, batch), batch_result in zip(batches, results):
-                    batch_start = i * self.batch_size
-                    batch_end = min(batch_start + self.batch_size, total_records)
+                    batch_start = i * self.chunk_size
+                    batch_end = min(batch_start + self.chunk_size, total_records)
                     if self.mode == "REPLACE":
                         df.iloc[batch_start:batch_end] = batch_result
                     elif self.mode == "ENRICH":
@@ -324,19 +331,19 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
                             if col not in df.columns or col == self.output_field_name:
                                 df.loc[batch_start:batch_end - 1, col] = batch_result[col].values
 
-            # Handle chunk
+            # Normal
             else:
+                self.logger.info(f"Operation: {caller_operation}, Processing data normal")
                 if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Chunk processing", "operation": self.name})
-                    step_count += 1
+                    progress_tracker.update(1, {"step": "Processing data normal", "operation": caller_operation})
 
-                for i, batch_start in enumerate(range(0, total_records, self.batch_size)):
-                    batch_end  = min(batch_start + self.batch_size, total_records)
+                for i, batch_start in enumerate(range(0, total_records, self.chunk_size)):
+                    batch_end = min(batch_start + self.chunk_size, total_records)
                     batch = df.iloc[batch_start:batch_end].copy()
 
                     # Process batch
                     batch = self.process_batch(batch)
-                    
+
                     # Update processed data
                     if self.mode == "REPLACE":
                         df.iloc[batch_start:batch_end] = batch
@@ -345,16 +352,20 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
                             if col not in df.columns or col == self.output_field_name:
                                 df.loc[batch_start:batch_end - 1, col] = batch[col].values
 
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"message": "Process data successfully"})
+
+            # Collect metrics
+            self.logger.info(f"Operation: {caller_operation}, Collecting metrics")
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Collecting metrics", "operation": caller_operation})
+
             # Calculate execution time
-            execution_time = time.time() - start_time
+            execution_time = time.time() - self.start_time
 
             # Update performance metrics
             records_per_second = int(total_records / execution_time) if execution_time > 0 else 0
-
-            # Collect metrics
-            if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Collecting metrics", "operation": self.name})
-                step_count += 1
 
             metrics = self._collect_metrics(df)
             # Add performance metrics
@@ -366,72 +377,76 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
                 memory_info = process.memory_info()
                 metrics["performance"]["memory_usage_mb"] = memory_info.rss / (1024 * 1024)
 
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"message": "Collect metrics successfully"})
+
             except Exception as e:
-                logger.warning(f"Error collecting memory usage: {str(e)}")
+                self.logger.info(f"Operation: {caller_operation}, Error collecting memory usage: {str(e)}")
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"message": "Collect metrics failed"})
 
-            # Generate visualizations
-            if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Generating visualizations", "operation": self.name})
-                step_count += 1
+            # Generate visualizations if required
+            if self.generate_visualization:
+                self.logger.info(f"Operation: {caller_operation}, Generate visualizations")
+                if progress_tracker:
+                    progress_tracker.update(1,{"step": "Generate visualizations", "operation": caller_operation})
 
-            try:
-                if self.mode == "REPLACE":
-                    gen_series = df[self.field_name]
-                elif self.mode == "ENRICH" and self.output_field_name in df.columns:
-                    gen_series = df[self.output_field_name]
-                else:
-                    gen_series = None
-
-                kwargs_visualization = {
-                    "use_encryption": kwargs.get("use_encryption", False),
-                    "encryption_key": kwargs.get("encryption_key", None),
-                    "backend": kwargs.get("visualization_backend", self.visualization_backend),
-                    "theme": kwargs.get("vis_theme", self.vis_theme),
-                    "strict": kwargs.get("vis_strict", self.vis_strict)
-                }
-
-                if gen_series is not None:
-                    visualizations = self._metrics_collector.visualize_metrics(
-                        metrics=metrics,
-                        field_name=self.field_name,
-                        output_dir=visualizations_dir,
-                        op_type=self.name,
-                        **kwargs_visualization
-                    )
-
-                    # Add visualizations to metrics
-                    metrics["visualizations"] = {name: str(path) for name, path in visualizations.items()}
-            except Exception as e:
-                logger.warning(f"Error generating visualizations: {str(e)}")
-
-            # Save result
-            if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Saving results", "operation": self.name})
-                step_count += 1
-
-            # Save data if required
-            save_data = kwargs.get("save_data", True)
-            if save_data:
-                output_path = self._save_result(df, output_dir, **kwargs)
-            else:
-                output_path = None
-
-            if reporter:
-                reporter.add_operation(f"Operation {self.name} ", status="info",
-                    details={
-                        "message": "save data successfully",
-                        "path": str(output_path),
-                    },
+                is_success = self._generate_visualizations(
+                    df=df,
+                    metrics=metrics,
+                    visualizations_dir=visualizations_dir,
+                    **kwargs
                 )
+                if is_success:
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"message": "Generated visualizations successfully"})
+                else:
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"message": "Generated visualizations failed"})
+
+            # Save output if required
+            output_path = None
+            if self.save_output:
+                self.logger.info(f"Operation: {caller_operation}, Save output")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Save output", "operation": caller_operation})
+
+                output_path = self._save_output(df, output_dir, **kwargs)
+
+                if reporter:
+                    if output_path:
+                        reporter.add_operation(
+                            f"Operation {caller_operation}",
+                            status="info",
+                            details={"step": "Save output", "message": "Save output successfully",
+                                     "path": str(output_path)}
+                        )
+                    else:
+                        reporter.add_operation(
+                            f"Operation {caller_operation}",
+                            status="info",
+                            details={"step": "Save output", "message": "Save output failed"}
+                        )
 
             # Save metrics
+            self.logger.info(f"Operation: {caller_operation}, Save metrics")
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Save metrics", "operation": caller_operation})
+
             metrics_path = self._save_metrics(metrics, task_dir, **kwargs)
 
             if reporter:
-                reporter.add_operation(f"Operation {self.name}", status="info",
-                                       details={"message": "Metrics saved successfully", "path": str(metrics_path)})
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"message": "Save metrics successfully", "path": str(metrics_path)})
 
             # Generate and save metrics report
+            self.logger.info(f"Operation: {caller_operation}, Generate and save metrics report")
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Generate and save metrics report", "operation": caller_operation})
             try:
                 report_dir = task_dir / "reports"
                 ensure_directory(report_dir)
@@ -441,13 +456,20 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
                     op_type=self.name,
                     field_name=self.field_name
                 )
+
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"message": "Generate and save metrics report successfully"})
             except Exception as e:
-                logger.warning(f"Error generating metrics report: {str(e)}")
+                self.logger.info(f"Operation: {caller_operation}, Error generating metrics report: {str(e)}")
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"message": "Generate and save metrics report failed"})
 
             # Create result
+            self.logger.info(f"Operation: {caller_operation}, Create result")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Create OperationResult", "operation": self.name})
-                step_count += 1
+                progress_tracker.update(1, {"step": "Create OperationResult", "operation": caller_operation})
 
             result = OperationResult(
                 status=OperationStatus.SUCCESS,
@@ -461,7 +483,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             # Add artifacts
             if output_path:
                 result.add_artifact(
-                    path=output_path,                   
+                    path=output_path,
                     artifact_type="csv",
                     description=f"Processed data with {self.mode.lower()}d {self.field_name} field",
                     category=Constants.Artifact_Category_Output
@@ -470,7 +492,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             result.add_artifact(
                 path=metrics_path,
                 artifact_type="json",
-                description=f"Metrics for {self.name} operation on {self.field_name}",
+                description=f"Metrics for {caller_operation} operation on {self.field_name}",
                 category=Constants.Artifact_Category_Metrics
             )
 
@@ -487,80 +509,59 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             # Add metrics
             result.metrics = metrics
 
-            if self.use_cache:
-                self._save_cache(task_dir, result)
-
             if reporter:
-                reporter.add_operation(f"Operation {self.name} ", status="info",
-                                       details={f"message: {self.name} cached result saved successfully"})
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"message": "Create result successfully"})
+
+            if self.use_cache:
+                self.logger.info(f"Operation: {caller_operation}, Save cache")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Save cache", "operation": caller_operation})
+
+                self._save_cache(task_dir, result, **kwargs)
+
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation} ", status="info",
+                                           details={f"message: {caller_operation} save cached successfully"})
 
             return result
 
         except Exception as e:
-            print(f"Operations execute failed: {e}")
-            logger.error(f"Operations execute failed: {e}")
+            self.logger.info(f"Operation: {caller_operation}, Operations execute failed: {e}")
             if reporter:
-                reporter.add_operation(f"Operation {self.name}", status="error",
+                reporter.add_operation(f"Operation {caller_operation}", status="error",
                                        details={"message": str(e)})
 
             return OperationResult(
                 status=OperationStatus.ERROR,
                 error_message=str(e),
-                execution_time=time.time() - start_time
+                execution_time=time.time() - self.start_time
             )
 
-    @staticmethod
-    def _load_data(data_source: Any) -> pd.DataFrame:
+    def _save_output(self, df: pd.DataFrame, output_dir: Path, **kwargs) -> Optional[Path]:
         """
-        Loads data from the data source.
+        Saves the result to a CSV file.
 
-        Parameters:
-        -----------
-        data_source : Any
-            Source of data
-
-        Returns:
-        --------
-        pd.DataFrame
-            Loaded data
+        Returns
+        -------
+        Path or None
+            Path to saved file if success, otherwise None
         """
-        if hasattr(data_source, "get_dataframe"):
-            return data_source.get_dataframe("maim")
-        elif isinstance(data_source, pd.DataFrame):
-            return data_source
-        elif isinstance(data_source, str) or isinstance(data_source, Path):
-            # Load from file path
-            try:
-                from pamola_core.utils.io import read_full_csv
-                return read_full_csv(data_source)
-            except Exception as e:
-                raise ValueError(f"Unable to load data from path {data_source}: {str(e)}")
-        else:
-            raise ValueError(f"Unsupported data source type: {type(data_source)}")
+        try:
+            file_name = get_timestamped_filename(f"{self.name}_{self.field_name}", "csv")
+            output_path = output_dir / file_name
 
-    def _save_result(self, df: pd.DataFrame, output_dir: Path, **kwargs) -> Path:
-        """
-        Saves the result to a file.
+            use_encryption = kwargs.get('use_encryption', False)
+            encryption_key = kwargs.get('encryption_key', None)
+            encryption_mode = get_encryption_mode(df, **kwargs)
+            write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key, use_encryption=use_encryption, encryption_mode=encryption_mode)
 
-        Parameters:
-        -----------
-        df : pd.DataFrame
-            DataFrame to save
-        output_dir : Path
-            Directory to save the file
+            self.logger.info(f"Output saved to: {output_path}")
+            return output_path
 
-        Returns:
-        --------
-        Path
-            Path to the saved file
-        """
-        file_name = get_timestamped_filename(f"{self.name}_{self.field_name}", "csv")
-        output_path = output_dir / file_name
-
-        use_encryption = kwargs.get('use_encryption', False)
-        encryption_key= kwargs.get('encryption_key', None) if use_encryption else None
-        write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key)
-        return output_path
+        except Exception as e:
+            self.logger.warning(f"Failed to save output: {str(e)}")
+            return None
 
     def _save_metrics(self, metrics: Dict[str, Any], task_dir: Path, **kwargs) -> Path:
         """
@@ -642,9 +643,47 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
                     elif isinstance(metrics[key], dict) and isinstance(value, dict):
                         metrics[key].update(value)
         except Exception as e:
-            logger.warning(f"Error collecting detailed metrics: {str(e)}")
+            self.logger.warning(f"Error collecting detailed metrics: {str(e)}")
 
         return metrics
+
+    def _generate_visualizations(
+            self,
+            df: pd.DataFrame,
+            metrics: dict,
+            visualizations_dir: Path,
+            **kwargs
+    ) -> bool:
+        try:
+            if self.mode == "REPLACE":
+                gen_series = df[self.field_name]
+            elif self.mode == "ENRICH" and self.output_field_name in df.columns:
+                gen_series = df[self.output_field_name]
+            else:
+                gen_series = None
+
+            kwargs_visualization = {
+                "use_encryption": kwargs.get("use_encryption", False),
+                "encryption_key": kwargs.get("encryption_key", None),
+                "backend": kwargs.get("visualization_backend", self.visualization_backend),
+                "theme": kwargs.get("visualization_theme", self.visualization_theme),
+                "strict": kwargs.get("visualization_strict", self.visualization_strict)
+            }
+
+            if gen_series is not None:
+                visualizations = self._metrics_collector.visualize_metrics(
+                    metrics=metrics,
+                    field_name=self.field_name,
+                    output_dir=visualizations_dir,
+                    op_type=self.name,
+                    **kwargs_visualization
+                )
+                metrics["visualizations"] = {name: str(path) for name, path in visualizations.items()}
+            return True
+
+        except Exception as e:
+            self.logger.warning(f"Error generating visualizations: {str(e)}")
+            return False
 
     def process_batch(self, batch: pd.DataFrame) -> pd.DataFrame:
         """
@@ -662,7 +701,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         """
         raise NotImplementedError("Subclasses must implement process_batch method")
 
-    def _get_cache(self, df: pd.DataFrame) -> Optional[OperationResult]:
+    def _get_cache(self, df: pd.DataFrame, **kwargs) -> Optional[OperationResult]:
         """
         Retrieve cached result if available and valid.
 
@@ -679,7 +718,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         try:
             cache_key = operation_cache.generate_cache_key(
                 operation_name=self.__class__.__name__,
-                parameters=self._get_cache_parameters(),
+                parameters=self._get_cache_parameters(**kwargs),
                 data_hash=self._generate_data_hash(df)
             )
 
@@ -724,27 +763,6 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         except Exception as e:
             self.logger.warning(f"Failed to load cache: {e}")
             return None
-
-    def _get_cache_parameters(self) -> Dict[str, Any]:
-        """
-        Get operation-specific parameters required for generating a cache key.
-
-        These parameters define the behavior of the transformation and are used
-        to determine cache uniqueness.
-
-        Returns
-        -------
-        Dict[str, Any]
-            Dictionary of relevant parameters to identify the operation configuration.
-        """
-        params = {
-            "operation": self.__class__.__name__,
-            "version": self.version,  # To support invalidation on version changes
-            "field_name": self.field_name,
-            "mode": self.mode,
-            "null_strategy": self.null_strategy
-        }
-        return params
 
     def _generate_data_hash(self, data: pd.DataFrame) -> str:
         """
@@ -802,7 +820,7 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
             fallback = f"{data.shape}_{list(data.dtypes)}"
             return hashlib.md5(fallback.encode()).hexdigest()
 
-    def _save_cache(self, task_dir: Path, result: OperationResult) -> None:
+    def _save_cache(self, task_dir: Path, result: OperationResult, **kwargs) -> None:
         """
         Save the operation result to cache.
 
@@ -825,12 +843,12 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
 
             cache_data = {
                 "result": result_data,
-                "parameters": self._get_cache_parameters(),
+                "parameters": self._get_cache_parameters(**kwargs),
             }
 
             cache_key = operation_cache.generate_cache_key(
                 operation_name=self.__class__.__name__,
-                parameters=self._get_cache_parameters(),
+                parameters=self._get_cache_parameters(**kwargs),
                 data_hash=self._generate_data_hash(self._original_df.copy())
             )
 
@@ -845,6 +863,284 @@ class FieldOperation(BaseFieldOperation, BaseOperation):
         except Exception as e:
             self.logger.warning(f"Failed to save cache: {e}")
 
+    def _get_cache_parameters(self, **kwargs) -> Dict[str, Any]:
+            """
+            Get operation-specific parameters required for generating a cache key.
+
+            These parameters define the behavior of the transformation and are used
+            to determine cache uniqueness.
+
+            Returns
+            -------
+            Dict[str, Any]
+                Dictionary of relevant parameters to identify the operation configuration.
+            """
+            # Get base parameters first
+            params = self._get_base_cache_parameters(**kwargs)
+
+            # Add domain-specific parameters based on operation type
+            caller_class = self.__class__.__name__
+            if caller_class == "FakeEmailOperation":
+                params.update(self._get_cache_parameters_for_email(**kwargs))
+            elif caller_class == "FakeNameOperation":
+                params.update(self._get_cache_parameters_for_name(**kwargs))
+            elif caller_class == "FakeOrganizationOperation":
+                params.update(self._get_cache_parameters_for_organization(**kwargs))
+            elif caller_class == "FakePhoneOperation":
+                params.update(self._get_cache_parameters_for_phone(**kwargs))
+
+            return params
+
+    def _get_base_cache_parameters(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get base parameters common to all operations (from kwargs only).
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of common parameters used for caching.
+        """
+        return {
+            "operation": self.__class__.__name__,
+            "version": self.version,
+            "field_name": kwargs.get("field_name"),
+            "mode": kwargs.get("mode"),
+            "output_field_name": kwargs.get("output_field_name"),
+            "null_strategy": kwargs.get("null_strategy"),
+            "chunk_size": kwargs.get("chunk_size"),
+            "use_cache": kwargs.get("use_cache"),
+            "force_recalculation": kwargs.get("force_recalculation"),
+            "use_dask": kwargs.get("use_dask"),
+            "npartitions": kwargs.get("npartitions"),
+            "use_vectorization": kwargs.get("use_vectorization"),
+            "parallel_processes": kwargs.get("parallel_processes"),
+            "visualization_backend": kwargs.get("visualization_backend"),
+            "visualization_theme": kwargs.get("visualization_theme"),
+            "visualization_strict": kwargs.get("visualization_strict"),
+            "use_encryption": kwargs.get("use_encryption"),
+            "encryption_key": str(kwargs.get("encryption_key")) if kwargs.get("encryption_key") else None
+        }
+
+    def _get_cache_parameters_for_email(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get email-specific cache parameters.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of email-specific parameters
+        """
+        return {
+            "domains": kwargs.get("domains"),
+            "format": kwargs.get("format"),
+            "format_ratio": kwargs.get("format_ratio"),
+            "first_name_field": kwargs.get("first_name_field"),
+            "last_name_field": kwargs.get("last_name_field"),
+            "full_name_field": kwargs.get("full_name_field"),
+            "name_format": kwargs.get("name_format"),
+            "validate_source": kwargs.get("validate_source"),
+            "handle_invalid_email": kwargs.get("handle_invalid_email"),
+            "nicknames_dict": kwargs.get("nicknames_dict"),
+            "max_length": kwargs.get("max_length"),
+            "consistency_mechanism": kwargs.get("consistency_mechanism"),
+            "mapping_store_path": kwargs.get("mapping_store_path"),
+            "id_field": kwargs.get("id_field"),
+            "key": kwargs.get("key"),
+            "context_salt": kwargs.get("context_salt"),
+            "save_mapping": kwargs.get("save_mapping"),
+            "column_prefix": kwargs.get("column_prefix"),
+            "separator_options": kwargs.get("separator_options"),
+            "number_suffix_probability": kwargs.get("number_suffix_probability"),
+            "preserve_domain_ratio": kwargs.get("preserve_domain_ratio"),
+            "business_domain_ratio": kwargs.get("business_domain_ratio"),
+            "detailed_metrics": kwargs.get("detailed_metrics"),
+            "error_logging_level": kwargs.get("error_logging_level"),
+            "max_retries": kwargs.get("max_retries")
+        }
+
+    def _get_cache_parameters_for_name(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get name-specific cache parameters.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of name-specific parameters
+        """
+        return {
+            "language": kwargs.get("language"),
+            "gender_field": kwargs.get("gender_field"),
+            "gender_from_name": kwargs.get("gender_from_name"),
+            "format": kwargs.get("format"),
+            "f_m_ratio": kwargs.get("f_m_ratio"),
+            "use_faker": kwargs.get("use_faker"),
+            "case": kwargs.get("case"),
+            "dictionaries": kwargs.get("dictionaries"),
+            "consistency_mechanism": kwargs.get("consistency_mechanism"),
+            "mapping_store_path": kwargs.get("mapping_store_path"),
+            "id_field": kwargs.get("id_field"),
+            "key": kwargs.get("key"),
+            "context_salt": kwargs.get("context_salt"),
+            "save_mapping": kwargs.get("save_mapping"),
+            "column_prefix": kwargs.get("column_prefix")
+        }
+
+    def _get_cache_parameters_for_organization(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get organization-specific cache parameters.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of organization-specific parameters
+        """
+        return {
+            "organization_type": kwargs.get("organization_type"),
+            "dictionaries": kwargs.get("dictionaries"),
+            "prefixes": kwargs.get("prefixes"),
+            "suffixes": kwargs.get("suffixes"),
+            "add_prefix_probability": kwargs.get("add_prefix_probability"),
+            "add_suffix_probability": kwargs.get("add_suffix_probability"),
+            "region": kwargs.get("region"),
+            "preserve_type": kwargs.get("preserve_type"),
+            "industry": kwargs.get("industry"),
+            "consistency_mechanism": kwargs.get("consistency_mechanism"),
+            "mapping_store_path": kwargs.get("mapping_store_path"),
+            "id_field": kwargs.get("id_field"),
+            "key": kwargs.get("key"),
+            "context_salt": kwargs.get("context_salt"),
+            "save_mapping": kwargs.get("save_mapping"),
+            "column_prefix": kwargs.get("column_prefix"),
+            "collect_type_distribution": kwargs.get("collect_type_distribution"),
+            "type_field": kwargs.get("type_field"),
+            "region_field": kwargs.get("region_field"),
+            "detailed_metrics": kwargs.get("detailed_metrics"),
+            "error_logging_level": kwargs.get("error_logging_level"),
+            "max_retries": kwargs.get("max_retries")
+        }
+
+    def _get_cache_parameters_for_phone(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get phone-specific cache parameters.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of phone-specific parameters
+        """
+        return {
+            "format": kwargs.get("format"),
+            "country": kwargs.get("country"),
+            "region": kwargs.get("region"),
+            "area_codes": kwargs.get("area_codes"),
+            "preserve_area_code": kwargs.get("preserve_area_code"),
+            "handle_invalid_phone": kwargs.get("handle_invalid_phone"),
+            "consistency_mechanism": kwargs.get("consistency_mechanism"),
+            "mapping_store_path": kwargs.get("mapping_store_path"),
+            "id_field": kwargs.get("id_field"),
+            "key": kwargs.get("key"),
+            "context_salt": kwargs.get("context_salt"),
+            "save_mapping": kwargs.get("save_mapping"),
+            "column_prefix": kwargs.get("column_prefix"),
+            "detailed_metrics": kwargs.get("detailed_metrics")
+        }
+
+    def _set_input_parameters(self, **kwargs):
+        """
+        Set common configurable operation parameters from keyword arguments.
+        """
+
+        self.field_name = kwargs.get("field_name", getattr(self, "field_name", None))
+        self.mode = kwargs.get("mode", getattr(self, "mode", "REPLACE"))
+        self.output_field_name = kwargs.get("output_field_name", getattr(self, "output_field_name", None))
+        self.chunk_size = kwargs.get("chunk_size", getattr(self, "chunk_size", 10000))
+        self.null_strategy = kwargs.get("null_strategy", getattr(self, "null_strategy", NullStrategy.PRESERVE))
+
+        self.save_output = kwargs.get("save_output", getattr(self, "save_output", True))
+        self.generate_visualization = kwargs.get("generate_visualization", getattr(self, "generate_visualization", True))
+
+        self.use_cache = kwargs.get("use_cache", getattr(self, "use_cache", True))
+        self.force_recalculation = kwargs.get("force_recalculation", getattr(self, "force_recalculation", False))
+
+        self.use_dask = kwargs.get("use_dask", getattr(self, "use_dask", False))
+        self.npartitions = kwargs.get("npartitions", getattr(self, "npartitions", 1))
+
+        self.use_vectorization = kwargs.get("use_vectorization", getattr(self, "use_vectorization", False))
+        self.parallel_processes = kwargs.get("parallel_processes", getattr(self, "parallel_processes", 1))
+
+        self.visualization_backend = kwargs.get("visualization_backend", getattr(self, "visualization_backend", False))
+        self.visualization_theme = kwargs.get("visualization_theme", getattr(self, "visualization_theme", None))
+        self.visualization_strict = kwargs.get("visualization_strict", getattr(self, "visualization_strict", None))
+
+        self.use_encryption = kwargs.get("use_encryption", getattr(self, "use_encryption", False))
+        self.encryption_key = kwargs.get("encryption_key",
+                                         getattr(self, "encryption_key", None)) if self.use_encryption else None
+
+    def _validate_input_parameters(self, df: pd.DataFrame) -> bool:
+        # Check if the field_name is provided
+        if not self.field_name:
+            self.logger.error("Validation failed: No 'field_name' was specified.")
+            return False
+
+        # Check if the field_name exists in DataFrame columns
+        if self.field_name not in df.columns:
+            self.logger.error(
+                f"Validation failed: Field name '{self.field_name}' not found in DataFrame columns. "
+                f"Available columns: {list(df.columns)}"
+            )
+            return False
+
+        return True
+
+    def _load_data_and_validate_input_parameters(self, data_source, **kwargs) -> Tuple[Optional[pd.DataFrame], bool]:
+        self._set_input_parameters(**kwargs)
+
+        dataset_name = kwargs.get('dataset_name', "main")
+        settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+        df = load_data_operation(data_source, dataset_name, **settings_operation)
+
+        if df is None or df.empty:
+            self.logger.error("Error data frame is None or empty")
+            return None, False
+
+        # Handle NULL values
+        df = self.handle_null_values(df)
+
+        self._input_dataset = dataset_name
+        self._original_df = df.copy(deep=True)
+
+        return df, self._validate_input_parameters(df)
+
+    def _compute_total_steps(self, **kwargs) -> int:
+        use_cache = kwargs.get("use_cache", self.use_cache)
+        force_recalculation = kwargs.get("force_recalculation", self.force_recalculation)
+        save_output = kwargs.get("save_output", self.save_output)
+        generate_visualization = kwargs.get("generate_visualization", self.generate_visualization)
+
+        steps = 0
+        steps += 1  # Step 1: Preparation
+        steps += 1  # Step 2: Load data and validate input parameters
+
+        if use_cache and not force_recalculation:
+            steps += 1  # Step 3: Load from cache (optional)
+
+        steps += 1  # Step 4: Process data
+        steps += 1  # Step 5: Collect metrics
+
+        if generate_visualization:
+            steps += 1  # Step 6: Generate visualizations
+
+        if save_output:
+            steps += 1  # Step 7: Save output
+
+        steps += 1  # Step 8: Save metrics
+        steps += 1  # Step 9: Generate and save metrics report
+        steps += 1  # Step 10: Create OperationResult
+
+        if use_cache:
+            steps += 1  # Step 11: Save cache
+
+        return steps
 
 class GeneratorOperation(FieldOperation):
     """
@@ -859,7 +1155,7 @@ class GeneratorOperation(FieldOperation):
 
     def __init__(self, field_name: str, generator: BaseGenerator,
                  mode: str = "REPLACE", output_field_name: Optional[str] = None,
-                 batch_size: int = 10000, null_strategy: Union[str, NullStrategy] = NullStrategy.PRESERVE,
+                 chunk_size: int = 10000, null_strategy: Union[str, NullStrategy] = NullStrategy.PRESERVE,
                  consistency_mechanism: str = "prgn", mapping_store: Optional[MappingStore] = None,
                  generator_params: Optional[Dict[str, Any]] = None,
                  use_cache: bool = True, force_recalculation: bool = False,
@@ -868,8 +1164,9 @@ class GeneratorOperation(FieldOperation):
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
                  visualization_backend: Optional[str] = None,
-                 vis_theme: Optional[str] = None,
-                 vis_strict: bool = False):
+                 visualization_theme: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 encryption_mode: Optional[str] = None):
         """
         Initializes the generator operation.
 
@@ -883,7 +1180,7 @@ class GeneratorOperation(FieldOperation):
             Operation mode: "REPLACE" or "ENRICH"
         output_field_name : str, optional
             Name of the output field (used in ENRICH mode)
-        batch_size : int
+        chunk_size : int
             Size of batches for processing
         null_strategy : str or NullStrategy
             Strategy for handling NULL values: "PRESERVE", "REPLACE", "EXCLUDE", "ERROR"
@@ -916,7 +1213,7 @@ class GeneratorOperation(FieldOperation):
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
-            batch_size=batch_size,
+            chunk_size=chunk_size,
             null_strategy=null_strategy,
             use_cache=use_cache,
             force_recalculation=force_recalculation,
@@ -926,9 +1223,10 @@ class GeneratorOperation(FieldOperation):
             parallel_processes=parallel_processes,
             use_encryption=use_encryption,
             encryption_key=encryption_key,
+            encryption_mode=encryption_mode,
             visualization_backend=visualization_backend,
-            vis_theme=vis_theme,
-            vis_strict=vis_strict
+            visualization_theme=visualization_theme,
+            visualization_strict=visualization_strict
         )
 
         self.generator = generator
@@ -1050,7 +1348,7 @@ class GeneratorOperation(FieldOperation):
 
         # Add mapping metrics if using mapping mechanism
         if self.consistency_mechanism == "mapping":
-            field_mappings = self.mapping_store.get_all_mappings_for_field(self.field_name)
+            field_mappings = self.mapping_store.get_field_mappings(self.field_name)
             metrics["mapping"] = {
                 "total_mappings": len(field_mappings),
             }
@@ -1062,7 +1360,7 @@ class GeneratorOperation(FieldOperation):
                 if dictionary_info:
                     metrics["dictionary_metrics"].update(dictionary_info)
             except Exception as e:
-                logger.warning(f"Error getting dictionary info: {str(e)}")
+                self.logger.warning(f"Error getting dictionary info: {str(e)}")
 
         # Add operation parameters
         operation_params = {
@@ -1127,7 +1425,7 @@ class GeneratorOperation(FieldOperation):
                 maps_detail_file = maps_dir / f"{self.field_name}_mappings.json"
 
                 # Convert mappings to serializable format
-                field_mappings = self.mapping_store.get_all_mappings_for_field(self.field_name)
+                field_mappings = self.mapping_store.get_field_mappings(self.field_name)
 
                 serializable_mappings = []
                 for original, synthetic in field_mappings.items():
@@ -1151,10 +1449,10 @@ class GeneratorOperation(FieldOperation):
 
                 # Also save to detailed maps directory for analysis
                 write_json(serializable_mappings, maps_detail_file)
-                logger.info(f"Saved {len(serializable_mappings)} mappings to {mappings_file} and {maps_detail_file}")
+                self.logger.info(f"Saved {len(serializable_mappings)} mappings to {mappings_file} and {maps_detail_file}")
 
             except Exception as e:
-                logger.warning(f"Failed to save mappings: {str(e)}")
+                self.logger.warning(f"Failed to save mappings: {str(e)}")
 
         return result
 
@@ -1210,5 +1508,5 @@ try:
         description = "Operation for generating fake data using generators"
         category = "fake_data"
 
-except ImportError:
-    logger.warning("PAMOLA operation registry not available. Operations will not be registered.")
+except ImportError as e:
+    raise ImportError("PAMOLA operation registry not available. Operations will not be registered.") from e

--- a/pamola_core/fake_data/commons/prgn.py
+++ b/pamola_core/fake_data/commons/prgn.py
@@ -12,7 +12,6 @@ import hmac
 import random
 import struct
 from typing import Any, Dict, List, Optional, Union, Callable
-
 from pamola_core.utils import logging
 
 # Configure logger

--- a/pamola_core/fake_data/commons/utils.py
+++ b/pamola_core/fake_data/commons/utils.py
@@ -21,13 +21,9 @@ import os
 import random
 import re
 import string
-from collections import defaultdict
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, Callable
-
-import pandas as pd
-import numpy as np
+from typing import Any, Dict, List, Optional, Union
 
 # Import from pamola_core utils
 from pamola_core.utils import io

--- a/pamola_core/fake_data/commons/validators.py
+++ b/pamola_core/fake_data/commons/validators.py
@@ -293,11 +293,17 @@ def validate_id_number(id_number: str, id_type: str, region: str = "RU") -> Dict
             if not re.match(r'^\d{12}$', id_number):
                 result["errors"].append("Russian INN should be 12 digits")
 
+        else:
+            result["errors"].append(f"Region: {region}. Unsupported id_type: {id_type}")
+
     elif region == "US":
         if id_type == "ssn":
             # US Social Security Number: 9 digits, often written as XXX-XX-XXXX
             if not re.match(r'^\d{3}-?\d{2}-?\d{4}$', id_number):
                 result["errors"].append("US SSN should have format: 123-45-6789")
+
+        else:
+            result["errors"].append(f"Region: {region}. Unsupported id_type: {id_type}")
 
     # Set valid flag if no errors
     result["valid"] = len(result["errors"]) == 0

--- a/pamola_core/fake_data/dictionaries/names.py
+++ b/pamola_core/fake_data/dictionaries/names.py
@@ -1252,7 +1252,7 @@ def get_names(language: str = "ru",
             return get_en_last_names()
 
     # Vietnamese names
-    elif language == "vn":
+    elif language in ["vn", "vi"]:
         if name_type == "full_name":
             if gender_normalized == "M":
                 return get_vn_male_names()

--- a/pamola_core/fake_data/generators/email.py
+++ b/pamola_core/fake_data/generators/email.py
@@ -261,7 +261,7 @@ class EmailGenerator(BaseGenerator):
 
         # If using PRGN generator for deterministic selection
         if self.prgn_generator:
-            rng = self.prgn_generator.get_random_by_value("nickname", salt="nickname-selection")
+            rng = self.prgn_generator.get_random_by_value(self.original_value, salt=self.context_salt)
             index = rng.randint(0, len(self._nicknames) - 1)
             return self._nicknames[index]
 
@@ -389,9 +389,10 @@ class EmailGenerator(BaseGenerator):
         if '.' not in domain:
             return False
 
-        # Check domain doesn't start or end with dash
-        if domain.startswith('-') or domain.endswith('-'):
-            return False
+        # Check each domain label doesn't start or end with a dash
+        for label in domain.split('.'):
+            if label.startswith('-') or label.endswith('-'):
+                return False
 
         return True
 
@@ -725,6 +726,9 @@ class EmailGenerator(BaseGenerator):
         else:
             # If validation is disabled, treat as valid if it has basic structure
             is_valid = isinstance(original_value, str) and '@' in original_value
+
+        self.original_value = original_value
+        self.context_salt = params.get("context_salt", None)
 
         # Select format to use
         format_to_use = format_override or self._select_format()

--- a/pamola_core/fake_data/generators/name.py
+++ b/pamola_core/fake_data/generators/name.py
@@ -42,7 +42,7 @@ class NameGenerator(BaseGenerator):
 
         Args:
             config: Dictionary with configuration parameters
-                - language: Language code (e.g., "ru", "en", "vn")
+                - language: Language code (e.g., "ru", "en", "vi")
                 - gender: Gender code ("M", "F", None for neutral)
                 - format: Format for full names (e.g., "FML", "FL", "LF")
                 - use_faker: Whether to use Faker library if available
@@ -106,7 +106,7 @@ class NameGenerator(BaseGenerator):
             'en_us': 'en', 'en_US': 'en', 'en_uk': 'en', 'en_UK': 'en',
             'en_gb': 'en', 'en_GB': 'en', 'eng': 'en', 'english': 'en',
             # Vietnamese
-            'vi': 'vn', 'vi_VN': 'vn', 'vie': 'vn', 'vietnamese': 'vn'
+            'vn': 'vi', 'vi_VN': 'vi', 'vie': 'vi', 'vietnamese': 'vi'
         }
 
         # Normalize to lowercase
@@ -145,7 +145,7 @@ class NameGenerator(BaseGenerator):
         self._middle_names_female = {}
 
         # Load dictionaries for supported languages
-        for lang in ["en", "ru", "vn"]:
+        for lang in ["en", "ru", "vi"]:
             # Try to load from explicit paths first
             dict_paths = self.dictionaries.get(lang, {})
 
@@ -213,7 +213,7 @@ class NameGenerator(BaseGenerator):
                 self._middle_names_female[lang] = []
 
         # Log dictionary sizes for debugging
-        for lang in ["en", "ru", "vn"]:
+        for lang in ["en", "ru", "vi"]:
             logger.debug(f"Loaded dictionaries for {lang}:")
             logger.debug(f"  - Male first names: {len(self._first_names_male.get(lang, []))} items")
             logger.debug(f"  - Female first names: {len(self._first_names_female.get(lang, []))} items")
@@ -765,7 +765,7 @@ class NameGenerator(BaseGenerator):
                 result["first_name"] = parts[0]
             elif len(parts) == 2:
                 # Two parts, assume first+last
-                if language in ["ru", "vn"]:
+                if language in ["ru", "vi"]:
                     # In Russian and Vietnamese, last name comes first
                     result["last_name"] = parts[0]
                     result["first_name"] = parts[1]
@@ -780,7 +780,7 @@ class NameGenerator(BaseGenerator):
                     result["last_name"] = parts[0]
                     result["first_name"] = parts[1]
                     result["middle_name"] = " ".join(parts[2:])
-                elif language == "vn":
+                elif language in ["vn", "vi"]:
                     # In Vietnamese: last_name middle_name(s) first_name
                     result["last_name"] = parts[0]
                     result["first_name"] = parts[-1]

--- a/pamola_core/fake_data/generators/organization.py
+++ b/pamola_core/fake_data/generators/organization.py
@@ -446,10 +446,7 @@ class OrganizationGenerator(BaseGenerator):
 
         # If using PRGN, ensure deterministic selection
         if self.prgn_generator:
-            rng = self.prgn_generator.get_random_by_value(
-                f"{org_type}_{region}",
-                salt="org-name-selection"
-            )
+            rng = self.prgn_generator.get_random_by_value(self.original_value, salt=self.context_salt)
             index = rng.randint(0, len(names) - 1)
             name = names[index]
         else:
@@ -697,6 +694,9 @@ class OrganizationGenerator(BaseGenerator):
 
         # Allow override via params
         region = params.get('region', region)
+
+        self.original_value = original_value
+        self.context_salt = params.get("context_salt", None)
 
         # Generate base name with detected properties
         new_name = self.generate_organization_name(org_type, region)

--- a/pamola_core/fake_data/generators/phone.py
+++ b/pamola_core/fake_data/generators/phone.py
@@ -461,18 +461,22 @@ class PhoneGenerator(BaseGenerator):
         if not format_template:
             format_template = "+CC AAA XXX XXX"
 
+        # Early return: if template has no placeholders, return as-is
+        if not re.search(r'\b(CC|A{1,4}|X{1,3})\b', format_template):
+            return format_template
+
         # Replace CC placeholder with country code
         result = format_template.replace("CC", country_code)
 
         # Replace operator code placeholder if available
         if operator_code:
             # Handle different area code placeholders
-            if "AAA" in result:
-                result = result.replace("AAA", operator_code)
-            elif "AAAA" in result:
+            if "AAAA" in result:
                 # Pad or truncate to 4 digits if needed
                 op_code = operator_code.ljust(4, '0') if len(operator_code) < 4 else operator_code[:4]
                 result = result.replace("AAAA", op_code)
+            elif "AAA" in result:
+                result = result.replace("AAA", operator_code)
             elif "AA" in result:
                 # Pad or truncate to 2 digits if needed
                 op_code = operator_code.ljust(2, '0') if len(operator_code) < 2 else operator_code[:2]
@@ -482,12 +486,12 @@ class PhoneGenerator(BaseGenerator):
                 result = result.replace("A", operator_code[0])
         else:
             # If no operator code, replace placeholders with appropriate number of digits from number
-            if "AAA" in result:
-                result = result.replace("AAA", number[:3])
-                number = number[3:]
-            elif "AAAA" in result:
+            if "AAAA" in result:
                 result = result.replace("AAAA", number[:4])
                 number = number[4:]
+            elif "AAA" in result:
+                result = result.replace("AAA", number[:3])
+                number = number[3:]
             elif "AA" in result:
                 result = result.replace("AA", number[:2])
                 number = number[2:]

--- a/pamola_core/fake_data/operations/organization_op.py
+++ b/pamola_core/fake_data/operations/organization_op.py
@@ -20,8 +20,6 @@ from pamola_core.utils import io
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.progress import HierarchicalProgressTracker
 
-# Configure logger
-logger = logging.getLogger(__name__)
 
 
 @register()
@@ -50,7 +48,7 @@ class FakeOrganizationOperation(GeneratorOperation):
                  region: str = "en",
                  preserve_type: bool = True,
                  industry: Optional[str] = None,
-                 batch_size: int = 10000,
+                 chunk_size: int = 10000,
                  null_strategy: str = "PRESERVE",
                  consistency_mechanism: str = "prgn",
                  mapping_store_path: Optional[str] = None,
@@ -75,8 +73,9 @@ class FakeOrganizationOperation(GeneratorOperation):
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
                  visualization_backend: Optional[str] = None,
-                 vis_theme: Optional[str] = None,
-                 vis_strict: bool = False):
+                 visualization_theme: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize organization name generation operation.
 
@@ -93,7 +92,7 @@ class FakeOrganizationOperation(GeneratorOperation):
             region: Default region for generation
             preserve_type: Whether to preserve organization type from original
             industry: Specific industry for 'industry' type organizations
-            batch_size: Number of records to process in one batch
+            chunk_size: Number of records to process in one batch
             null_strategy: Strategy for handling NULL values
             consistency_mechanism: Method for ensuring consistency (mapping or prgn)
             mapping_store_path: Path to store mappings
@@ -118,16 +117,13 @@ class FakeOrganizationOperation(GeneratorOperation):
         self.collect_type_distribution = collect_type_distribution
         self.type_field = type_field
         self.region_field = region_field
-        self.batch_size = batch_size
+        self.chunk_size = chunk_size
         self.use_cache = use_cache
         self.force_recalculation = force_recalculation
         self.use_dask = use_dask
         self.npartitions = npartitions
         self.use_vectorization = use_vectorization
         self.parallel_processes = parallel_processes
-
-        # Configure logging level
-        self._configure_logging()
 
         # Store attributes locally that we need to access directly
         self.column_prefix = column_prefix
@@ -165,7 +161,7 @@ class FakeOrganizationOperation(GeneratorOperation):
             generator=base_generator,
             mode=mode,
             output_field_name=output_field_name,
-            batch_size=batch_size,
+            chunk_size=chunk_size,
             null_strategy=null_strategy,
             consistency_mechanism=consistency_mechanism,
             use_cache=use_cache,
@@ -176,9 +172,10 @@ class FakeOrganizationOperation(GeneratorOperation):
             parallel_processes=parallel_processes,
             use_encryption=use_encryption,
             encryption_key=encryption_key,
+            encryption_mode=encryption_mode,
             visualization_backend=visualization_backend,
-            vis_theme=vis_theme,
-            vis_strict=vis_strict
+            visualization_theme=visualization_theme,
+            visualization_strict=visualization_strict
         )
 
         # Set up performance metrics
@@ -206,13 +203,6 @@ class FakeOrganizationOperation(GeneratorOperation):
             }
             self._generation_times = []
 
-    def _configure_logging(self):
-        """
-        Configure logging based on error_logging_level.
-        """
-        log_level = getattr(logging, self.error_logging_level, logging.WARNING)
-        logger.setLevel(log_level)
-
     def _initialize_mapping_store(self, path: Union[str, Path]) -> None:
         """
         Initialize the mapping store if needed.
@@ -229,9 +219,9 @@ class FakeOrganizationOperation(GeneratorOperation):
             path_obj = Path(path)
             if path_obj.exists():
                 self.mapping_store.load(path_obj)
-                logger.info(f"Loaded mapping store from {path}")
+                self.logger.info(f"Loaded mapping store from {path_obj.name}")
         except Exception as e:
-            logger.warning(f"Failed to initialize mapping store: {str(e)}")
+            self.logger.warning(f"Failed to initialize mapping store: {str(e)}")
             self.mapping_store = None
 
     def execute(self, data_source, task_dir, reporter, progress_tracker: Optional[HierarchicalProgressTracker] = None, **kwargs):
@@ -247,6 +237,9 @@ class FakeOrganizationOperation(GeneratorOperation):
         Returns:
             Operation result with processed data and metrics
         """
+        # Config logger task for operatiions
+        self.logger = kwargs.get('logger', self.logger)
+        
         # Start timing for performance metrics
         self.start_time = time.time()
         self.process_count = 0
@@ -271,7 +264,7 @@ class FakeOrganizationOperation(GeneratorOperation):
             io.ensure_directory(mapping_dir)
             mapping_path = mapping_dir / f"{self.name}_{self.field_name}_mapping.json"
             self.mapping_store.save_json(mapping_path)
-            logger.info(f"Saved mapping to {mapping_path}")
+            self.logger.info(f"Saved mapping to {Path(mapping_path).name}")
 
         return result
 
@@ -358,7 +351,7 @@ class FakeOrganizationOperation(GeneratorOperation):
                 generated_values.append(synthetic_value)
                 self.process_count += 1
             except Exception as e:
-                logger.error(f"Error generating organization name for value '{value}': {str(e)}")
+                self.logger.error(f"Error generating organization name for value '{value}': {str(e)}")
                 generated_values.append(value if pd.notna(value) else np.nan)
 
         # Update the dataframe with generated values
@@ -466,10 +459,10 @@ class FakeOrganizationOperation(GeneratorOperation):
 
                 # Log error with appropriate level
                 if retries <= self.max_retries:
-                    logger.debug(
+                    self.logger.debug(
                         f"Retry {retries}/{self.max_retries} generating organization name for value '{value}': {str(e)}")
                 else:
-                    logger.error(
+                    self.logger.error(
                         f"Failed to generate organization name for value '{value}' after {self.max_retries} retries: {str(e)}")
                     self.error_count += 1
 
@@ -681,7 +674,7 @@ class FakeOrganizationOperation(GeneratorOperation):
                 if type_metrics:
                     metrics_data["organization_generator"]["type_distribution"] = type_metrics
             except Exception as e:
-                logger.warning(f"Error collecting organization type distribution: {str(e)}")
+                self.logger.warning(f"Error collecting organization type distribution: {str(e)}")
 
         # Add region distribution
         try:
@@ -690,7 +683,7 @@ class FakeOrganizationOperation(GeneratorOperation):
             if region_metrics:
                 metrics_data["organization_generator"]["region_distribution"] = region_metrics
         except Exception as e:
-            logger.warning(f"Error collecting region distribution: {str(e)}")
+            self.logger.warning(f"Error collecting region distribution: {str(e)}")
 
         # Add prefix/suffix distribution
         try:
@@ -699,7 +692,7 @@ class FakeOrganizationOperation(GeneratorOperation):
             if prefix_suffix_metrics:
                 metrics_data["organization_generator"]["prefix_suffix_distribution"] = prefix_suffix_metrics
         except Exception as e:
-            logger.warning(f"Error collecting prefix/suffix distribution: {str(e)}")
+            self.logger.warning(f"Error collecting prefix/suffix distribution: {str(e)}")
 
         # Add quality metrics if we can collect them
         if self.mode == "ENRICH" and hasattr(self, "_original_df") and self._original_df is not None:
@@ -714,7 +707,7 @@ class FakeOrganizationOperation(GeneratorOperation):
                     )
                     metrics_data["quality_metrics"] = quality_metrics
             except Exception as e:
-                logger.warning(f"Error calculating quality metrics: {str(e)}")
+                self.logger.warning(f"Error calculating quality metrics: {str(e)}")
 
         return metrics_data
 
@@ -836,7 +829,7 @@ class FakeOrganizationOperation(GeneratorOperation):
                         name: str(path) for name, path in visualizations.items()
                     }
             except Exception as e:
-                logger.warning(f"Error generating visualizations: {str(e)}")
+                self.logger.warning(f"Error generating visualizations: {str(e)}")
 
         # Save metrics to file
         use_encryption = kwargs.get('use_encryption', False)

--- a/pamola_core/profiling/analyzers/categorical.py
+++ b/pamola_core/profiling/analyzers/categorical.py
@@ -17,30 +17,29 @@ It integrates with the new utility modules:
 - progress.py: For tracking operation progress
 - logging.py: For operation logging
 """
-
+import hashlib
+import json
 import logging
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
-
+from typing import Dict, List, Any, Optional, Union, Tuple
 import pandas as pd
-
 from pamola_core.profiling.commons.categorical_utils import (
     analyze_categorical_field,
     estimate_resources
 )
 from pamola_core.utils.io import write_json, ensure_directory, get_timestamped_filename, load_data_operation, write_dataframe_to_csv, load_settings_operation
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.ops.op_cache import operation_cache
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register_operation
-from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
+from pamola_core.utils.ops.op_result import OperationResult, OperationStatus, OperationArtifact
 from pamola_core.utils.visualization import (
     plot_value_distribution
 )
 from pamola_core.common.constants import Constants
-# Configure logger
-logger = logging.getLogger(__name__)
-
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 class CategoricalAnalyzer:
     """
@@ -145,13 +144,20 @@ class CategoricalOperation(FieldOperation):
                  field_name: str,
                  top_n: int = 15,
                  min_frequency: int = 1,
-                 include_timestamp: bool = True,
-                 generate_plots: bool = True,
                  profile_type: str = "categorical",
                  analyze_anomalies: bool = True,
                  description: str = "",
+                 include_timestamp: bool = True,
+                 save_output: bool = True,
+                 generate_visualization: bool = True,
+                 use_cache: bool = True,
+                 force_recalculation: bool = False,
+                 visualization_backend: Optional[str] = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_strict: bool = False,
                  use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+                 encryption_key: Optional[Union[str, Path]] = None,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize the categorical operation.
 
@@ -165,7 +171,7 @@ class CategoricalOperation(FieldOperation):
             Minimum frequency for inclusion in the dictionary
         include_timestamp : bool
             Whether to include timestamps in filenames
-        generate_plots : bool
+        generate_visualization : bool
             Whether to generate visualizations
         profile_type : str
             Type of profiling for organizing artifacts
@@ -178,21 +184,31 @@ class CategoricalOperation(FieldOperation):
             field_name=field_name,
             description=description or f"Analysis of categorical field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
             )
         
         self.top_n = top_n
         self.min_frequency = min_frequency
-        self.include_timestamp = include_timestamp
-        self.generate_plots = generate_plots
         self.profile_type = profile_type
         self.analyze_anomalies = analyze_anomalies
+
+        self.include_timestamp = include_timestamp
+        self.save_output = save_output
+        self.generate_visualization = generate_visualization
+
+        self.use_cache = use_cache
+        self.force_recalculation = force_recalculation
+
+        self.visualization_backend = visualization_backend
+        self.visualization_theme = visualization_theme
+        self.visualization_strict = visualization_strict
 
     def execute(self,
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the categorical analysis operation.
@@ -209,7 +225,7 @@ class CategoricalOperation(FieldOperation):
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
-            - generate_plots: bool, whether to generate visualizations
+            - generate_visualization: bool, whether to generate visualizations
             - include_timestamp: bool, whether to include timestamps in filenames
             - profile_type: str, type of profiling for organizing artifacts
             - analyze_anomalies: bool, whether to analyze anomalies
@@ -219,220 +235,224 @@ class CategoricalOperation(FieldOperation):
         OperationResult
             Results of the operation
         """
-        # Extract parameters from kwargs, defaulting to instance variables
-        generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        profile_type = kwargs.get('profile_type', self.profile_type)
-        analyze_anomalies = kwargs.get('analyze_anomalies', self.analyze_anomalies)
-        encryption_key = kwargs.get('encryption_key', None)
 
-        # Set up directories
-        dirs = self._prepare_directories(task_dir)
-        visualizations_dir = dirs['visualizations']
-        dictionaries_dir = dirs['dictionaries']
-        output_dir = dirs['output']
-
-        # Create the main result object with initial status
-        result = OperationResult(status=OperationStatus.SUCCESS)
-
-        # Update progress if tracker provided
-        if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+        caller_operation = self.__class__.__name__
+        self.logger = kwargs.get('logger', self.logger)
 
         try:
-            # Get DataFrame from data source safely
-            dataset_name = kwargs.get('dataset_name', "main")
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
-            df_result = load_data_operation(data_source, dataset_name, **settings_operation)
-            error_info = None  # Initialize error_info to avoid reference before assignment
-
-            if isinstance(df_result, tuple) and len(df_result) >= 2:
-                df, error_info = df_result
-            else:
-                df = df_result
-
-            if df is None:
-                error_message = "No valid DataFrame found in data source"
-                if error_info is not None and isinstance(error_info, dict):
-                    error_message += f": {error_info.get('message', '')}"
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message=error_message
-                )
-
-            # Check if DataFrame has columns attribute and if field exists
-            if not hasattr(df, 'columns'):
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message="DataFrame does not have expected structure (missing columns attribute)"
-                )
-
-            # Check if field exists
-            if self.field_name not in df.columns:
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message=f"Field {self.field_name} not found in DataFrame"
-                )
-
-            # Add operation to reporter
-            reporter.add_operation(f"Analyzing categorical field: {self.field_name}", details={
-                "field_name": self.field_name,
-                "top_n": self.top_n,
-                "min_frequency": self.min_frequency,
-                "operation_type": "categorical_analysis"
-            })
-
-            # Adjust progress tracker total steps if provided
-            total_steps = 4  # Preparation, analysis, saving results, and dictionary
-            if generate_plots:
-                total_steps += 1  # Add step for generating visualizations
-
+            # Start operation
+            self.logger.info(f"Operation: {caller_operation}, Start operation")
             if progress_tracker:
-                progress_tracker.total = total_steps
-                progress_tracker.update(0, {"status": "Analyzing field"})
+                progress_tracker.total = self._compute_total_steps(**kwargs)
+                progress_tracker.update(1, {"step": "Start operation - Preparation", "operation": caller_operation})
 
-            # Execute the analyzer
-            try:
-                analysis_results = CategoricalAnalyzer.analyze(
-                    df=df,
-                    field_name=self.field_name,
-                    top_n=self.top_n,
-                    min_frequency=self.min_frequency,
-                    detect_anomalies=analyze_anomalies
-                )
-            except Exception as analyzer_error:
-                logger.error(f"Error in analyzer for {self.field_name}: {str(analyzer_error)}")
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message=f"Error analyzing field {self.field_name}: {str(analyzer_error)}"
-                )
+            # Set up directories
+            dirs = self._prepare_directories(task_dir)
+            visualizations_dir = dirs['visualizations']
+            dictionaries_dir = dirs['dictionaries']
+            output_dir = dirs['output']
 
-            # Check for errors
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Preparation",
+                                                "message": "Preparation successfully",
+                                                "directories": {k: str(v) for k, v in dirs.items()}
+                                                })
+
+            # Load data and validate input parameters
+            self.logger.info(f"Operation: {caller_operation}, Load data and validate input parameters")
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Load data and validate input parameters",
+                                            "operation": caller_operation})
+
+            df, is_valid = self._load_data_and_validate_input_parameters(data_source, **kwargs)
+
+            if is_valid:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters successfully",
+                                                    "shape": df.shape
+                                                    })
+            else:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters failed"
+                                                    })
+                    return OperationResult(status=OperationStatus.ERROR,
+                                           error_message="Load data and validate input parameters failed")
+
+            # Handle cache if required
+            if self.use_cache and not self.force_recalculation:
+                self.logger.info(f"Operation: {caller_operation}, Load result from cache")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Load result from cache", "operation": caller_operation})
+
+                cached_result = self._get_cache(df.copy(), **kwargs)  # _get_cache now returns OperationResult or None
+                if cached_result is not None and isinstance(cached_result, OperationResult):
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache successfully"
+                                                        })
+                    return cached_result
+                else:
+                    self.logger.info(
+                        f"Operation: {caller_operation}, Load result from cache failed — proceeding with execution.")
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache failed - proceeding with execution"
+                                                        })
+
+            # Analyzing categorical
+            self.logger.info(f"Operation: {caller_operation}, Analyzing categorical")
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Analyzing categorical", "operation": caller_operation})
+
+            analysis_results = CategoricalAnalyzer.analyze(
+                df=df,
+                field_name=self.field_name,
+                top_n=self.top_n,
+                min_frequency=self.min_frequency,
+                detect_anomalies=self.analyze_anomalies
+            )
+
+            # Check analysis results
             if 'error' in analysis_results:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Analyzing categorical",
+                                                    "message": "Analyzing categorical failed",
+                                                    "field_name": self.field_name,
+                                                    "top_n": self.top_n,
+                                                    "min_frequency": self.min_frequency,
+                                                    "operation_type": "categorical_analysis"
+                                           })
                 return OperationResult(
                     status=OperationStatus.ERROR,
                     error_message=analysis_results['error']
                 )
+            else:
+                if reporter:
+                    reporter.add_operation(f"Operation: {caller_operation}", status="info",
+                                           details={"step": "Analyzing categorical",
+                                                    "message": "Analyzing categorical successfully",
+                                                    "field_name": self.field_name,
+                                                    "top_n": self.top_n,
+                                                    "min_frequency": self.min_frequency,
+                                                    "operation_type": "categorical_analysis"
+                                           })
 
-            # Update progress
+            # Collect metric
+            self.logger.info(f"Operation: {caller_operation}, Collect metric")
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Analysis complete", "field": self.field_name})
+                progress_tracker.update(1, {"step": "Collect metric", "operation": caller_operation})
 
-            # Save analysis results to JSON in the task root directory
-            stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
-            stats_path = output_dir / stats_filename
+            result = OperationResult(status=OperationStatus.SUCCESS)
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
-            result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
+            self._collect_metrics(analysis_results, result)
 
-            # Add to reporter
-            reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Collect metric",
+                                                "message": "Collect metric successfully",
+                                                "unique_values": analysis_results.get('unique_values', 0),
+                                                "null_percent": analysis_results.get('null_percent', 0),
+                                                "entropy": round(analysis_results.get('entropy', 0), 2),
+                                                "anomalies_found": len(analysis_results.get('anomalies',
+                                                                                            {})) if 'anomalies' in analysis_results else 0
+                                                })
 
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved analysis results"})
-
-            # Save dictionary to CSV if available
-            if 'value_dictionary' in analysis_results and 'dictionary_data' in analysis_results['value_dictionary']:
-                dict_filename = get_timestamped_filename(f"{self.field_name}_dictionary", "csv", include_timestamp)
-                dict_path = dictionaries_dir / dict_filename
-
-                # Convert dictionary data to DataFrame
-                dict_records = analysis_results['value_dictionary']['dictionary_data']
-                if isinstance(dict_records, list) and len(dict_records) > 0:
-                    dict_df = pd.DataFrame(dict_records)
-                    write_dataframe_to_csv(df=dict_df, file_path=dict_path, index=False, encoding='utf-8', encryption_key=encryption_key)
-
-                    result.add_artifact("csv", dict_path, f"{self.field_name} value dictionary", category=Constants.Artifact_Category_Dictionary)
-                    reporter.add_artifact("csv", str(dict_path), f"{self.field_name} value dictionary")
-                else:
-                    logger.warning(f"Empty dictionary data for {self.field_name}")
-
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved dictionary data"})
-
-            # Generate visualization if requested
-            if generate_plots and 'top_values' in analysis_results:
-                # Update progress
+            # Save output if required
+            if self.save_output:
+                self.logger.info(f"Operation: {caller_operation}, Save output")
                 if progress_tracker:
-                    progress_tracker.update(0, {"step": "Generating visualization"})
+                    progress_tracker.update(1, {"step": "Save output", "operation": caller_operation})
 
-                # Create visualization
-                viz_filename = get_timestamped_filename(f"{self.field_name}_distribution", "png", include_timestamp)
-                viz_path = visualizations_dir / viz_filename
+                self._save_output(
+                    analysis_results=analysis_results,
+                    output_dir=output_dir,
+                    dictionaries_dir=dictionaries_dir,
+                    result=result,
+                    reporter=reporter,
+                    **kwargs
+                )
 
-                # Create visualization using the visualization module
-                title = f"Distribution of {self.field_name}"
-                viz_result = plot_value_distribution(
-                    data=analysis_results['top_values'],
-                    output_path=str(viz_path),
-                    title=title,
-                    max_items=self.top_n,
+                if reporter:
+                    reporter.add_operation(f"Operation: {caller_operation}",
+                                           status="info",
+                                           details={"step": "Save output",
+                                                    "message": "Save output successfully"
+                                           })
+
+            # Generate visualization if required
+            if self.generate_visualization:
+                self.logger.info(f"Operation: {caller_operation}, Generate visualizations")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Generate visualizations", "operation": caller_operation})
+
+                viz_result = self._generate_visualizations(
+                    analysis_results=analysis_results,
+                    visualizations_dir=visualizations_dir,
+                    result=result,
                     **kwargs
                 )
 
                 if not viz_result.startswith("Error"):
-                    result.add_artifact("png", viz_path, f"{self.field_name} distribution visualization", category=Constants.Artifact_Category_Visualization)
-                    reporter.add_artifact("png", str(viz_path), f"{self.field_name} distribution visualization")
+                    if reporter:
+                        reporter.add_operation(f"Operation: {caller_operation}",
+                                               status="info",
+                                               details={"step": "Generate visualizations",
+                                                        "message": "Generate visualizations successfully"
+                                                       })
                 else:
-                    logger.warning(f"Error creating visualization: {viz_result}")
+                    self.logger.warning(f"Operation: {self.name}, Generate visualizations failed {viz_result}")
+                    if reporter:
+                        reporter.add_operation(f"Operation: {caller_operation}",
+                                               status="info",
+                                               details={"step": "Generate visualizations",
+                                                        "message": "Generate visualizations failed",
+                                                        "error": viz_result
+                                               })
 
-                # Update progress
+            # Save cache if required
+            if self.use_cache:
+                self.logger.info(f"Operation: {caller_operation}, Save cache")
                 if progress_tracker:
-                    progress_tracker.update(1, {"step": "Created visualization"})
+                    progress_tracker.update(1, {"step": "Save cache", "operation": caller_operation})
 
-            # Save anomalies to CSV if detected
-            if 'anomalies' in analysis_results and analysis_results['anomalies']:
-                self._save_anomalies_to_csv(
-                    analysis_results,
-                    dictionaries_dir,
-                    include_timestamp,
-                    result,
-                    reporter,
-                    encryption_key=encryption_key
-                )
+                self._save_cache(task_dir, result, **kwargs)
 
-            # Add metrics to the result
-            result.add_metric("total_records", analysis_results.get('total_records', 0))
-            result.add_metric("null_count", analysis_results.get('null_values', 0))
-            result.add_metric("null_percent", analysis_results.get('null_percent', 0))
-            result.add_metric("unique_values", analysis_results.get('unique_values', 0))
-            result.add_metric("entropy", analysis_results.get('entropy', 0))
-            result.add_metric("cardinality_ratio", analysis_results.get('cardinality_ratio', 0))
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Save cache",
+                                                    "message": "Save cache successfully"
+                                                    })
 
-            if 'distribution_type' in analysis_results:
-                result.add_metric("distribution_type", analysis_results.get('distribution_type'))
-
-            if 'anomalies' in analysis_results:
-                result.add_metric("anomalies_count", len(analysis_results['anomalies']))
-
-            # Add final operation status to reporter
-            reporter.add_operation(f"Analysis of {self.field_name} completed", details={
-                "unique_values": analysis_results.get('unique_values', 0),
-                "null_percent": analysis_results.get('null_percent', 0),
-                "entropy": round(analysis_results.get('entropy', 0), 2),
-                "anomalies_found": len(analysis_results.get('anomalies', {})) if 'anomalies' in analysis_results else 0
-            })
+            # Operation completed successfully
+            self.logger.info(f"Operation: {caller_operation}, Completed successfully.")
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Return result",
+                                                "message": "Operation completed successfully"
+                                                })
 
             return result
 
         except Exception as e:
-            logger.exception(f"Error in categorical operation for {self.field_name}: {e}")
+            self.logger.error(f"Operation: {caller_operation}, error occurred: {e}")
 
-            # Update progress tracker on error
-            if progress_tracker:
-                progress_tracker.update(0, {"step": "Error", "error": str(e)})
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="error",
+                                       details={
+                                           "step": "Exception",
+                                           "message": "Operation failed due to an exception",
+                                           "error": str(e)
+                                       })
 
-            # Add error to reporter
-            reporter.add_operation(f"Error analyzing {self.field_name}",
-                                   status="error",
-                                   details={"error": str(e)})
-
-            return OperationResult(
-                status=OperationStatus.ERROR,
-                error_message=f"Error analyzing categorical field {self.field_name}: {str(e)}"
-            )
+            return OperationResult(status=OperationStatus.ERROR, error_message=str(e))
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
@@ -462,6 +482,136 @@ class CategoricalOperation(FieldOperation):
             'visualizations': visualizations_dir,
             'dictionaries': dictionaries_dir
         }
+
+    def _collect_metrics(self, analysis_results: dict, result: OperationResult) -> None:
+        """
+        Collect and add analysis metrics to the result object.
+
+        Parameters
+        ----------
+        analysis_results : dict
+            Dictionary containing results from categorical analysis.
+        result : OperationResult
+            The result object where metrics will be added.
+        """
+        result.add_metric("total_records", analysis_results.get("total_records", 0))
+        result.add_metric("null_count", analysis_results.get("null_values", 0))
+        result.add_metric("null_percent", analysis_results.get("null_percent", 0))
+        result.add_metric("unique_values", analysis_results.get("unique_values", 0))
+        result.add_metric("entropy", analysis_results.get("entropy", 0))
+        result.add_metric("cardinality_ratio", analysis_results.get("cardinality_ratio", 0))
+
+        if "distribution_type" in analysis_results:
+            result.add_metric("distribution_type", analysis_results["distribution_type"])
+
+        if "anomalies" in analysis_results:
+            result.add_metric("anomalies_count", len(analysis_results["anomalies"]))
+
+    def _save_output(
+            self,
+            analysis_results: dict,
+            output_dir: Path,
+            dictionaries_dir: Path,
+            result: OperationResult,
+            reporter: Any,
+            **kwargs
+    ):
+        """
+        Save analysis results to JSON, dictionary to CSV, and anomalies (if any).
+        """
+
+        # Save analysis results to JSON
+        stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", self.include_timestamp)
+        stats_path = output_dir / stats_filename
+
+        encryption_mode_for_json = get_encryption_mode(analysis_results, **kwargs)
+        write_json(analysis_results, stats_path, encryption_key=self.encryption_key, encryption_mode=encryption_mode_for_json)
+        result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis",
+                            category=Constants.Artifact_Category_Output)
+
+        # Save dictionary to CSV
+        if 'value_dictionary' in analysis_results and 'dictionary_data' in analysis_results['value_dictionary']:
+            dict_filename = get_timestamped_filename(f"{self.field_name}_dictionary", "csv", self.include_timestamp)
+            dict_path = dictionaries_dir / dict_filename
+
+            dict_records = analysis_results['value_dictionary']['dictionary_data']
+            if isinstance(dict_records, list) and len(dict_records) > 0:
+                dict_df = pd.DataFrame(dict_records)
+                write_dataframe_to_csv(
+                    df=dict_df,
+                    file_path=dict_path,
+                    index=False,
+                    encoding='utf-8',
+                    encryption_key=self.encryption_key
+                )
+                result.add_artifact("csv", dict_path, f"{self.field_name} value dictionary",
+                                    category=Constants.Artifact_Category_Dictionary)
+            else:
+                self.logger.info(f"Operation: {self.name}, Empty dictionary data for {self.field_name}")
+
+        # Save anomalies to CSV if detected
+        if 'anomalies' in analysis_results and analysis_results['anomalies']:
+            self._save_anomalies_to_csv(
+                analysis_results,
+                dictionaries_dir,
+                self.include_timestamp,
+                result,
+                reporter,
+                encryption_key=self.encryption_key
+            )
+
+    def _generate_visualizations(
+            self,
+            analysis_results: dict,
+            visualizations_dir: Path,
+            result: OperationResult,
+            **kwargs
+    ) -> str:
+        """
+        Generate and save a visualization from top categorical values.
+
+        Parameters
+        ----------
+        analysis_results : dict
+            Dictionary containing the results of categorical analysis.
+        visualizations_dir : Path
+            Directory to save the visualization image.
+        result : OperationResult
+            Object to store generated artifacts.
+        **kwargs : dict
+            Visualization configuration options (theme, backend, strict, etc.).
+
+        Returns
+        -------
+        str
+            The result string from the visualization function (can indicate success or error).
+        """
+        if 'top_values' not in analysis_results:
+            warning_msg = f"Operation: {self.name}, No 'top_values' found in analysis results for visualization."
+            self.logger.warning(warning_msg)
+            return f"Error: {warning_msg}"
+
+        kwargs["backend"] = kwargs.pop("visualization_backend", self.visualization_backend)
+        kwargs["theme"] = kwargs.pop("visualization_theme", self.visualization_theme)
+        kwargs["strict"] = kwargs.pop("visualization_strict", self.visualization_strict)
+
+        viz_filename = get_timestamped_filename(f"{self.field_name}_distribution", "png", self.include_timestamp)
+        viz_path = visualizations_dir / viz_filename
+
+        title = f"Distribution of {self.field_name}"
+        viz_result = plot_value_distribution(
+            data=analysis_results['top_values'],
+            output_path=str(viz_path),
+            title=title,
+            max_items=self.top_n,
+            **kwargs
+        )
+
+        if not viz_result.startswith("Error"):
+            result.add_artifact("png", viz_result, f"{self.field_name} distribution visualization",
+                                category=Constants.Artifact_Category_Visualization)
+
+        return viz_result
 
     def _save_anomalies_to_csv(self,
                                analysis_results: Dict[str, Any],
@@ -538,12 +688,303 @@ class CategoricalOperation(FieldOperation):
 
                 # Add artifact to result and reporter
                 result.add_artifact("csv", anomalies_path, f"{self.field_name} anomalies", category=Constants.Artifact_Category_Dictionary)
-                reporter.add_artifact("csv", str(anomalies_path), f"{self.field_name} anomalies")
+                if reporter:
+                    reporter.add_artifact("csv", str(anomalies_path), f"{self.field_name} anomalies")
 
         except Exception as e:
-            logger.warning(f"Error saving anomalies for {self.field_name}: {e}")
-            reporter.add_operation(f"Saving anomalies for {self.field_name}", status="warning",
-                                   details={"warning": str(e)})
+            self.logger.warning(f"Error saving anomalies for {self.field_name}: {e}")
+            if reporter:
+                reporter.add_operation(f"Saving anomalies for {self.field_name}", status="warning",
+                                       details={"warning": str(e)})
+
+    def _save_cache(self, task_dir: Path, result: OperationResult, **kwargs) -> None:
+        """
+        Save the operation result to cache.
+
+        Parameters
+        ----------
+        task_dir : Path
+            Root directory for the task.
+        result : OperationResult
+            The result object to be cached.
+        """
+        try:
+            result_data = {
+                "status": result.status.name if isinstance(result.status, OperationStatus) else str(result.status),
+                "metrics": result.metrics,
+                "error_message": result.error_message,
+                "execution_time": result.execution_time,
+                "error_trace": result.error_trace,
+                "artifacts": [artifact.to_dict() for artifact in result.artifacts]
+            }
+
+            cache_data = {
+                "result": result_data,
+                "parameters": self._get_cache_parameters(**kwargs),
+            }
+
+            cache_key = operation_cache.generate_cache_key(
+                operation_name=self.__class__.__name__,
+                parameters=self._get_cache_parameters(**kwargs),
+                data_hash=self._generate_data_hash(self._original_df.copy())
+            )
+
+            operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            self.logger.info(f"Saved result to cache with key: {cache_key}")
+        except Exception as e:
+            self.logger.warning(f"Failed to save cache: {e}")
+
+    def _get_cache(self, df: pd.DataFrame, **kwargs) -> Optional[OperationResult]:
+        """
+        Retrieve cached result if available and valid.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The input DataFrame used to generate the cache key.
+
+        Returns
+        -------
+        Optional[OperationResult]
+            The cached OperationResult if available, otherwise None.
+        """
+        try:
+            cache_key = operation_cache.generate_cache_key(
+                operation_name=self.__class__.__name__,
+                parameters=self._get_cache_parameters(**kwargs),
+                data_hash=self._generate_data_hash(df)
+            )
+
+            cached = operation_cache.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            result_data = cached.get("result")
+            if not isinstance(result_data, dict):
+                return None
+
+            # Parse enum safely
+            status_str = result_data.get("status", OperationStatus.ERROR.name)
+            status = OperationStatus[status_str] if isinstance(status_str,
+                                                               str) and status_str in OperationStatus.__members__ else OperationStatus.ERROR
+
+            # Rebuild artifacts
+            artifacts = []
+            for art_dict in result_data.get("artifacts", []):
+                if isinstance(art_dict, dict):
+                    try:
+                        artifacts.append(OperationArtifact(
+                            artifact_type=art_dict.get("type"),
+                            path=art_dict.get("path"),
+                            description=art_dict.get("description", ""),
+                            category=art_dict.get("category", "output"),
+                            tags=art_dict.get("tags", []),
+                        ))
+                    except Exception as e:
+                        self.logger.warning(f"Failed to deserialize artifact: {e}")
+
+            return OperationResult(
+                status=status,
+                artifacts=artifacts,
+                metrics=result_data.get("metrics", {}),
+                error_message=result_data.get("error_message"),
+                execution_time=result_data.get("execution_time"),
+                error_trace=result_data.get("error_trace"),
+            )
+
+        except Exception as e:
+            self.logger.warning(f"Failed to load cache: {e}")
+            return None
+
+    def _get_cache_parameters(self, **kwargs) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters required for generating a cache key.
+
+        These parameters define the behavior of the transformation and are used
+        to determine cache uniqueness.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary of relevant parameters to identify the operation configuration.
+        """
+
+        return {
+            "operation": self.__class__.__name__,
+            "version": self.version,
+            "field_name": kwargs.get("field_name"),
+            "top_n": kwargs.get("top_n", self.top_n),
+            "min_frequency": kwargs.get("min_frequency", self.min_frequency),
+            "include_timestamp": kwargs.get("include_timestamp", self.include_timestamp),
+            "generate_visualization": kwargs.get("generate_visualization", self.generate_visualization),
+            "profile_type": kwargs.get("profile_type", self.profile_type),
+            "analyze_anomalies": kwargs.get("analyze_anomalies", self.analyze_anomalies),
+            "use_cache": kwargs.get("use_cache", self.use_cache),
+            "force_recalculation": kwargs.get("force_recalculation", self.force_recalculation),
+            "visualization_backend": kwargs.get("visualization_backend", self.visualization_backend),
+            "visualization_theme": kwargs.get("visualization_theme", self.visualization_theme),
+            "visualization_strict": kwargs.get("visualization_strict", self.visualization_strict),
+            "use_encryption": kwargs.get("use_encryption"),
+            "encryption_key": str(kwargs.get("encryption_key")) if kwargs.get("encryption_key") else None
+        }
+
+    def _generate_data_hash(self, data: pd.DataFrame) -> str:
+        """
+        Generate a hash that represents key characteristics of the input DataFrame.
+
+        The hash is based on structure and summary statistics to detect changes
+        for caching purposes.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Input DataFrame to generate a representative hash from.
+
+        Returns
+        -------
+        str
+            A hash string representing the structure and key properties of the data.
+        """
+        try:
+            characteristics = {
+                "columns": list(data.columns),
+                "shape": data.shape,
+                "summary": {}
+            }
+
+            for col in data.columns:
+                col_data = data[col]
+                col_info = {
+                    "dtype": str(col_data.dtype),
+                    "null_count": int(col_data.isna().sum()),
+                    "unique_count": int(col_data.nunique())
+                }
+
+                if pd.api.types.is_numeric_dtype(col_data):
+                    non_null = col_data.dropna()
+                    if not non_null.empty:
+                        col_info.update({
+                            "min": float(non_null.min()),
+                            "max": float(non_null.max()),
+                            "mean": float(non_null.mean()),
+                            "median": float(non_null.median()),
+                            "std": float(non_null.std())
+                        })
+                elif pd.api.types.is_object_dtype(col_data) or isinstance(col_data.dtype, pd.CategoricalDtype):
+                    top_values = col_data.value_counts(dropna=True).head(5)
+                    col_info["top_values"] = {str(k): int(v) for k, v in top_values.items()}
+
+                characteristics["summary"][col] = col_info
+
+            json_str = json.dumps(characteristics, sort_keys=True)
+            return hashlib.md5(json_str.encode()).hexdigest()
+
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+            fallback = f"{data.shape}_{list(data.dtypes)}"
+            return hashlib.md5(fallback.encode()).hexdigest()
+
+    def _set_input_parameters(self, **kwargs):
+        """
+        Set common configurable operation parameters from keyword arguments.
+        """
+
+        self.field_name = kwargs.get("field_name", getattr(self, "field_name", None))
+        self.top_n = kwargs.get("top_n", getattr(self, "top_n", None))
+        self.min_frequency = kwargs.get("min_frequency", getattr(self, "min_frequency", True))
+        self.profile_type = kwargs.get("profile_type", getattr(self, "profile_type", "categorical"))
+        self.analyze_anomalies = kwargs.get("analyze_anomalies", getattr(self, "analyze_anomalies", True))
+        self.generate_visualization = kwargs.get("generate_visualization", getattr(self, "generate_visualization", True))
+
+        self.save_output = kwargs.get("save_output", getattr(self, "save_output", True))
+        self.output_format = kwargs.get("output_format", getattr(self, "output_format", "csv"))
+        self.include_timestamp = kwargs.get("include_timestamp", getattr(self, "include_timestamp", True))
+
+        self.use_cache = kwargs.get("use_cache", getattr(self, "use_cache", True))
+        self.force_recalculation = kwargs.get("force_recalculation", getattr(self, "force_recalculation", False))
+
+        self.visualization_backend = kwargs.get("visualization_backend", getattr(self, "visualization_backend", False))
+        self.visualization_theme = kwargs.get("visualization_theme", getattr(self, "visualization_theme", None))
+        self.visualization_strict = kwargs.get("visualization_strict", getattr(self, "visualization_strict", None))
+
+        self.use_encryption = kwargs.get("use_encryption", getattr(self, "use_encryption", False))
+        self.encryption_key = kwargs.get("encryption_key",
+                                         getattr(self, "encryption_key", None)) if self.use_encryption else None
+
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S") if self.include_timestamp else ""
+
+    def _validate_input_parameters(self, df: pd.DataFrame) -> bool:
+        """
+        Validate that all specified fields in field_groups exist in the DataFrame.
+        Optionally check if the ID field exists.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input dataset to validate.
+
+        Returns:
+        --------
+        bool
+            True if all fields are valid; False otherwise.
+        """
+        if self.field_name not in df.columns:
+            self.logger.error(f"Column {self.field_name} not existing in data frame")
+            return False
+
+        # All validations passed
+        return True
+
+    def _load_data_and_validate_input_parameters(self, data_source: DataSource, **kwargs) -> Tuple[Optional[pd.DataFrame], bool]:
+        self._set_input_parameters(**kwargs)
+
+        dataset_name = kwargs.get('dataset_name', "main")
+        settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+        df = load_data_operation(data_source, dataset_name, **settings_operation)
+
+        if df is None or df.empty:
+            self.logger.error("Error data frame is None or empty")
+            return None, False
+
+        self._input_dataset = dataset_name
+        self._original_df = df.copy(deep=True)
+
+        return df, self._validate_input_parameters(df)
+
+    def _compute_total_steps(self, **kwargs) -> int:
+        use_cache = kwargs.get("use_cache", self.use_cache)
+        force_recalculation = kwargs.get("force_recalculation", self.force_recalculation)
+        save_output = kwargs.get("save_output", self.save_output)
+        generate_visualization = kwargs.get("generate_visualization", self.generate_visualization)
+
+        steps = 0
+
+        steps += 1  # Step 1: Preparation
+        steps += 1  # Step 2: Load data and validate input
+
+        if use_cache and not force_recalculation:
+            steps += 1  # Step 3: Try to load from cache
+
+        steps += 1  # Step 4: Process data
+        steps += 1  # Step 5: Collect metrics
+
+        if save_output:
+            steps += 1  # Step 6: Save output
+
+        if generate_visualization:
+            steps += 1  # Step 7: Generate visualizations
+
+        if use_cache:
+            steps += 1  # Step 8: Save cache
+
+        return steps
 
 
 def analyze_categorical_fields(
@@ -569,7 +1010,7 @@ def analyze_categorical_fields(
         Additional parameters for the operations:
         - top_n: int, number of top values to include in results (default: 15)
         - min_frequency: int, minimum frequency for inclusion in dictionary (default: 1)
-        - generate_plots: bool, whether to generate plots (default: True)
+        - generate_visualization: bool, whether to generate plots (default: True)
         - include_timestamp: bool, whether to include timestamps in filenames (default: True)
         - profile_type: str, type of profiling for organizing artifacts (default: 'categorical')
 
@@ -592,8 +1033,9 @@ def analyze_categorical_fields(
         error_message = "No valid DataFrame found in data source"
         if error_info is not None and isinstance(error_info, dict):
             error_message += f": {error_info.get('message', '')}"
-        reporter.add_operation("Categorical fields analysis", status="error",
-                               details={"error": error_message})
+        if reporter:
+            reporter.add_operation("Categorical fields analysis", status="error",
+                                   details={"error": error_message})
         return {}
 
     # Extract operation parameters from kwargs
@@ -614,27 +1056,29 @@ def analyze_categorical_fields(
                     elif pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() <= min(100, int(len(df) * 0.1)):
                         cat_fields.append(col)
                 except Exception as e:
-                    logger.warning(f"Error checking column {col}: {str(e)}")
+                    print(f"Error checking column {col}: {str(e)}")
         else:
-            logger.error("DataFrame does not have columns attribute")
-            reporter.add_operation("Categorical fields detection", status="error",
-                                   details={"error": "DataFrame doesn't have expected structure"})
+            print("DataFrame does not have columns attribute")
+            if reporter:
+                reporter.add_operation("Categorical fields detection", status="error",
+                                       details={"error": "DataFrame doesn't have expected structure"})
 
     # Report on fields to be analyzed
-    reporter.add_operation("Categorical fields analysis", details={
-        "fields_count": len(cat_fields),
-        "fields": cat_fields,
-        "top_n": top_n,
-        "min_frequency": min_frequency,
-        "parameters": {k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))}
-    })
+    if reporter:
+        reporter.add_operation("Categorical fields analysis", details={
+            "fields_count": len(cat_fields),
+            "fields": cat_fields,
+            "top_n": top_n,
+            "min_frequency": min_frequency,
+            "parameters": {k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))}
+        })
 
     # Track progress if enabled
     track_progress = kwargs.get('track_progress', True)
     overall_tracker = None
 
     if track_progress and cat_fields:
-        overall_tracker = ProgressTracker(
+        overall_tracker = HierarchicalProgressTracker(
             total=len(cat_fields),
             description=f"Analyzing {len(cat_fields)} categorical fields",
             unit="fields",
@@ -653,7 +1097,7 @@ def analyze_categorical_fields(
                 if overall_tracker:
                     overall_tracker.update(0, {"field": field, "progress": f"{i + 1}/{len(cat_fields)}"})
 
-                logger.info(f"Analyzing categorical field: {field}")
+                print(f"Analyzing categorical field: {field}")
 
                 # Create and execute operation
                 operation = CategoricalOperation(
@@ -675,10 +1119,10 @@ def analyze_categorical_fields(
                                                    "error": result.error_message})
 
             except Exception as e:
-                logger.error(f"Error analyzing categorical field {field}: {e}", exc_info=True)
-
-                reporter.add_operation(f"Analyzing {field} field", status="error",
-                                       details={"error": str(e)})
+                print(f"Error analyzing categorical field {field}: {e}", exc_info=True)
+                if reporter:
+                    reporter.add_operation(f"Analyzing {field} field", status="error",
+                                           details={"error": str(e)})
 
                 # Update overall tracker in case of error
                 if overall_tracker:
@@ -692,11 +1136,12 @@ def analyze_categorical_fields(
     success_count = sum(1 for r in results.values() if r.status == OperationStatus.SUCCESS)
     error_count = sum(1 for r in results.values() if r.status == OperationStatus.ERROR)
 
-    reporter.add_operation("Categorical fields analysis completed", details={
-        "fields_analyzed": len(results),
-        "successful": success_count,
-        "failed": error_count
-    })
+    if reporter:
+        reporter.add_operation("Categorical fields analysis completed", details={
+            "fields_analyzed": len(results),
+            "successful": success_count,
+            "failed": error_count
+        })
 
     return results
 

--- a/pamola_core/profiling/analyzers/currency.py
+++ b/pamola_core/profiling/analyzers/currency.py
@@ -14,13 +14,18 @@ The module supports:
 - Multiple artifact outputs: stats in JSON, visualizations (PNG), and samples (CSV)
 """
 
+from datetime import datetime
+import json
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+import time
+from typing import Dict, Any, List, Optional, Union
 
+from joblib import Parallel, delayed
 import numpy as np
 import pandas as pd
 
+from pamola_core.anonymization.commons.processing_utils import get_dataframe_chunks
 from pamola_core.profiling.commons.currency_utils import (
     is_currency_field, parse_currency_field, analyze_currency_stats,
     detect_currency_from_sample,
@@ -30,17 +35,19 @@ from pamola_core.profiling.commons.numeric_utils import (
     calculate_percentiles, calculate_histogram
 )
 from pamola_core.utils.io import (
-    load_data_operation, write_dataframe_to_csv, write_json, load_settings_operation
+    get_timestamped_filename, load_data_operation, write_dataframe_to_csv, write_json, load_settings_operation
 )
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register
-from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.ops.op_result import OperationArtifact, OperationResult, OperationStatus
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.visualization import (
     create_histogram, create_boxplot, create_correlation_pair
 )
 from pamola_core.common.constants import Constants
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
+from pamola_core.profiling.commons.helpers import filter_used_kwargs
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -63,7 +70,10 @@ class CurrencyAnalyzer:
                 test_normality: bool = True,
                 chunk_size: int = 10000,
                 use_dask: bool = False,
-                progress_tracker: Optional[ProgressTracker] = None,
+                use_vectorization: bool = False,
+                parallel_processes: int = 1,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                task_logger: Optional[logging.Logger] = None,
                 **kwargs) -> Dict[str, Any]:
         """
         Analyze a currency field in the given DataFrame.
@@ -86,8 +96,10 @@ class CurrencyAnalyzer:
             Size of chunks for processing large datasets
         use_dask : bool
             Whether to use Dask for large datasets
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
+        task_logger : Optional[logging.Logger]
+            Logger for tracking task progress and debugging.
         **kwargs : dict
             Additional parameters for the analysis
 
@@ -96,6 +108,9 @@ class CurrencyAnalyzer:
         Dict[str, Any]
             The results of the analysis
         """
+        if task_logger:
+            logger = task_logger
+
         logger.info(f"Analyzing currency field: {field_name}")
 
         # Validate input
@@ -143,7 +158,7 @@ class CurrencyAnalyzer:
                 logger.info(f"Using Dask for large dataset with {total_rows} rows")
                 return self._analyze_with_dask(df, field_name, locale, bins,
                                                detect_outliers, test_normality,
-                                               progress_tracker, **kwargs)
+                                               progress_tracker, logger, **kwargs)
             except ImportError:
                 logger.warning("Dask requested but not available. Falling back to chunked processing.")
                 if progress_tracker:
@@ -151,13 +166,19 @@ class CurrencyAnalyzer:
                         "step": "Dask fallback",
                         "warning": "Dask not available, using chunks"
                     })
-
+        
+        # Process in parallel
+        if use_vectorization and parallel_processes > 0:
+            return self._analyze_with_parallel(df, field_name, locale,
+                                               chunk_size, bins, detect_outliers, 
+                                               test_normality, parallel_processes,
+                                               progress_tracker, logger)
         # Process in chunks for large datasets
-        if is_large_df and not use_dask:
+        elif is_large_df and not use_dask:
             return self._analyze_in_chunks(df, field_name, locale, bins,
                                            detect_outliers, test_normality,
-                                           chunk_size, progress_tracker, **kwargs)
-
+                                           chunk_size, progress_tracker, logger, **kwargs)
+        
         # Standard processing for smaller datasets
         if progress_tracker:
             progress_tracker.update(1, {
@@ -170,8 +191,11 @@ class CurrencyAnalyzer:
             normalized_values, currency_counts = parse_currency_field(df, field_name, locale)
 
             # Count valid, null, and invalid values
-            valid_flags = getattr(normalized_values, 'valid_flags', [True] * len(normalized_values))
-            valid_count = sum(1 for flag in valid_flags if flag)
+            if hasattr(normalized_values, 'valid_flags'):
+                valid_flags = normalized_values.valid_flags
+                valid_count = sum(1 for flag, val in zip(valid_flags, normalized_values) if flag and pd.notna(val))
+            else:
+                valid_count = normalized_values.notna().sum()
             null_count = normalized_values.isna().sum()
             invalid_count = total_rows - valid_count - null_count
 
@@ -316,18 +340,51 @@ class CurrencyAnalyzer:
                            bins: int,
                            detect_outliers: bool,
                            test_normality: bool,
-                           progress_tracker: Optional[ProgressTracker] = None,
+                           progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                           task_logger: Optional[logging.Logger] = None,
                            **kwargs) -> Dict[str, Any]:
         """
         Analyze a currency field using Dask for large datasets.
 
-        Parameters match the main analyze method.
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            The DataFrame containing the data to analyze
+        field_name : str
+            The name of the field to analyze
+        locale : str
+            Locale to use for parsing (default: 'en_US')
+        bins : int
+            Number of bins for histogram analysis
+        detect_outliers : bool
+            Whether to detect outliers
+        test_normality : bool
+            Whether to perform normality testing
+        progress_tracker : HierarchicalProgressTracker, optional
+            Progress tracker for the operation
+        task_logger : Optional[logging.Logger]
+            Logger for tracking task progress and debugging.
+        **kwargs : dict
+            Additional parameters for the analysis (e.g., npartitions for Dask)
+
+        Returns:
+        --------
+        Dict[str, Any]
+            The results of the analysis
         """
         try:
-            import dask.dataframe as dd
+            if task_logger:
+                logger = task_logger
+            npartitions=kwargs.get('npartitions', None)
 
+            logger.info("Parallel Enabled")
+            logger.info("Parallel Engine: Dask")
+            logger.info("Parallel Workers: {npartitions}")
+            
+            import dask.dataframe as dd
+            
             # Convert to Dask DataFrame
-            ddf = dd.from_pandas(df, npartitions=kwargs.get('npartitions', None))
+            ddf = dd.from_pandas(df, npartitions)
 
             if progress_tracker:
                 progress_tracker.update(1, {
@@ -423,13 +480,43 @@ class CurrencyAnalyzer:
                            detect_outliers: bool,
                            test_normality: bool,
                            chunk_size: int,
-                           progress_tracker: Optional[ProgressTracker] = None,
+                           progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                           task_logger: Optional[logging.Logger] = None,
                            **kwargs) -> Dict[str, Any]:
         """
         Analyze a currency field in chunks for large datasets.
 
-        Parameters match the main analyze method, with chunk_size determining the size of each chunk.
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            The DataFrame containing the data to analyze
+        field_name : str
+            The name of the field to analyze
+        locale : str
+            Locale to use for parsing (default: 'en_US')
+        bins : int
+            Number of bins for histogram analysis
+        detect_outliers : bool
+            Whether to detect outliers
+        test_normality : bool
+            Whether to perform normality testing
+        chunk_size : int
+            Size of chunks for processing large datasets
+        progress_tracker : HierarchicalProgressTracker, optional
+            Progress tracker for the operation
+        task_logger : Optional[logging.Logger]
+            Logger for tracking task progress and debugging.
+        **kwargs : dict
+            Additional parameters for the analysis
+
+        Returns:
+        --------
+        Dict[str, Any]
+            The results of the analysis
         """
+        if task_logger:
+            logger = task_logger
+
         total_rows = len(df)
         total_chunks = (total_rows + chunk_size - 1) // chunk_size
 
@@ -456,8 +543,7 @@ class CurrencyAnalyzer:
             normalized_values, currency_counts = parse_currency_field(chunk, field_name, locale)
 
             # Count nulls and invalids
-            valid_flags = getattr(normalized_values, 'valid_flags', [True] * len(normalized_values))
-            chunk_valid_count = sum(1 for flag in valid_flags if flag)
+            chunk_valid_count = normalized_values.notna().sum()
             chunk_null_count = normalized_values.isna().sum()
             chunk_invalid_count = len(chunk) - chunk_valid_count - chunk_null_count
 
@@ -481,8 +567,15 @@ class CurrencyAnalyzer:
         # Combine values from all chunks
         if all_values:
             combined_values = pd.concat(all_values)
+            if isinstance(combined_values, pd.DataFrame):
+                if combined_values.shape[1] == 1:
+                    combined_values = combined_values.iloc[:, 0]
+                else:
+                    combined_values = combined_values.squeeze()
+            if not isinstance(combined_values, pd.Series):
+                combined_values = pd.Series([combined_values])
         else:
-            combined_values = pd.Series()
+            combined_values = pd.Series(dtype='float64')
 
         valid_count = len(combined_values)
 
@@ -571,6 +664,251 @@ class CurrencyAnalyzer:
 
         return result
 
+    def _analyze_with_parallel(self,
+                           df: pd.DataFrame,
+                           field_name: str,
+                           locale: str,
+                           chunk_size: int,
+                           bins: int,
+                           detect_outliers: bool,
+                           test_normality: bool,
+                           parallel_processes: int = -1,
+                           progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                           task_logger: Optional[logging.Logger] = None,
+                           **kwargs) -> Dict[str, Any]:
+        """
+        Analyze a currency field using parallel processing for large datasets.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            The DataFrame containing the data to analyze
+        field_name : str
+            The name of the field to analyze
+        locale : str
+            Locale to use for parsing
+        chunk_size : int
+            Size of chunks for processing
+        bins : int
+            Number of bins for histogram analysis
+        detect_outliers : bool
+            Whether to detect outliers
+        test_normality : bool
+            Whether to perform normality testing
+        n_jobs : int
+            Number of parallel jobs to run (-1 for all cores)
+        parallel_processes : int, optional
+            Number of parallel processes to use (default: None, uses all available cores)
+        progress_tracker : HierarchicalProgressTracker, optional
+            Progress tracker for the operation
+        **kwargs : dict
+            Additional parameters
+
+        Returns:
+        --------
+        Dict[str, Any]
+            The results of the analysis
+        """
+        try:
+            if task_logger:
+                logger = task_logger
+
+            logger.info(f"Starting parallel analysis for field: {field_name}")
+            total_rows = len(df)
+            chunks = list(get_dataframe_chunks(df, chunk_size=chunk_size))
+            total_chunks = len(chunks)
+
+            if progress_tracker:
+                progress_tracker.total = total_chunks
+                progress_tracker.update(0, {
+                    "step": "Parallel processing setup",
+                    "total_chunks": total_chunks,
+                    "chunk_size": chunk_size
+                })
+
+            logger.info(f"Processing {total_rows} rows in {total_chunks} chunks with {parallel_processes} workers")
+            start_time = time.time()
+
+            def process_chunk(chunk_idx, chunk_df):
+                """Process a single chunk of data"""
+                logger.debug(f"Processing chunk {chunk_idx+1}/{total_chunks} (rows {chunk_df.index[0]}-{chunk_df.index[-1]})")
+                normalized_values, currency_counts = parse_currency_field(chunk_df, field_name, locale)
+                valid_values = normalized_values.dropna()
+
+                logger.debug(f"Chunk {chunk_idx+1}: valid={len(valid_values)}, null={normalized_values.isna().sum()}, invalid={len(chunk_df) - len(valid_values) - normalized_values.isna().sum()}")
+                return {
+                    'chunk_idx': chunk_idx,
+                    'valid_values': valid_values,
+                    'currency_counts': currency_counts,
+                    'valid_count': len(valid_values),
+                    'null_count': normalized_values.isna().sum(),
+                    'invalid_count': len(chunk_df) - len(valid_values) - normalized_values.isna().sum(),
+                    'chunk_size': len(chunk_df)
+                }
+
+            logger.info("Launching parallel processing of chunks...")
+            processed_chunks = Parallel(n_jobs=parallel_processes)(
+                delayed(process_chunk)(i, chunk) for i, chunk in enumerate(chunks)
+            )
+            logger.info("Parallel processing of chunks complete.")
+
+            if progress_tracker:
+                progress_tracker.update(total_chunks, {
+                    "step": "Parallel processing complete",
+                    "chunks_processed": len(processed_chunks)
+                })
+
+            all_values = []
+            all_currencies = {}
+            total_valid_count = 0
+            total_null_count = 0
+            total_invalid_count = 0
+
+            for i, chunk in enumerate(processed_chunks):
+                if chunk is None:
+                    logger.warning(f"Chunk {i} is None. Skipping.")
+                    continue
+                if not chunk.get('valid_values', pd.Series(dtype='float64')).empty:
+                    all_values.append(chunk['valid_values'])
+
+                for currency, count in chunk.get('currency_counts', {}).items():
+                    all_currencies[currency] = all_currencies.get(currency, 0) + count
+
+                total_valid_count += chunk.get('valid_count', 0)
+                total_null_count += chunk.get('null_count', 0)
+                total_invalid_count += chunk.get('invalid_count', 0)
+
+            logger.info(f"Aggregated results: valid={total_valid_count}, null={total_null_count}, invalid={total_invalid_count}, currencies={all_currencies}")
+
+            combined_values = pd.concat(all_values, ignore_index=True) if all_values else pd.Series(dtype='float64')
+            if isinstance(combined_values, pd.DataFrame):
+                combined_values = combined_values.squeeze()
+            if not isinstance(combined_values, pd.Series):
+                combined_values = pd.Series([combined_values])
+
+            sample_df = df.sample(n=min(1000, total_rows)) if total_rows > 0 else df
+            detected_currency = detect_currency_from_sample(sample_df, field_name)
+
+            if progress_tracker:
+                progress_tracker.update(1, {
+                    "step": "Sample analysis",
+                    "detected_currency": detected_currency
+                })
+
+            result = {
+                'field_name': field_name,
+                'total_rows': total_rows,
+                'valid_count': total_valid_count,
+                'null_count': total_null_count,
+                'invalid_count': total_invalid_count,
+                'null_percentage': (total_null_count / total_rows * 100) if total_rows else 0.0,
+                'invalid_percentage': (total_invalid_count / total_rows * 100) if total_rows else 0.0,
+                'currency_counts': all_currencies,
+                'multi_currency': len(all_currencies) > 1,
+                'is_detected_currency': is_currency_field(field_name),
+                'locale_used': locale,
+                'detected_currency': detected_currency
+            }
+
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Aggregating results",
+                    "valid_total": total_valid_count,
+                    "currencies_detected": len(all_currencies)
+                })
+
+            if combined_values.empty:
+                logger.warning("No valid currency values found after parallel processing.")
+                result['stats'] = create_empty_currency_stats()
+                result['note'] = "Analysis completed with parallel processing. No valid currency values found."
+                return result
+
+            logger.info("Calculating statistics on combined values...")
+            stats = analyze_currency_stats(combined_values, all_currencies)
+            stats['percentiles'] = calculate_percentiles(combined_values)
+            stats['histogram'] = calculate_histogram(combined_values, bins)
+
+            # Outlier Detection
+            if detect_outliers and len(combined_values) >= 5:
+                try:
+                    from pamola_core.profiling.commons.numeric_utils import detect_outliers as detect_outliers_func
+                    stats['outliers'] = detect_outliers_func(combined_values)
+                    logger.info(f"Outlier detection complete. Outliers found: {stats['outliers'].get('count', 0)}")
+                    if progress_tracker:
+                        progress_tracker.update(0, {
+                            "step": "Outlier detection complete",
+                            "outliers_found": stats['outliers'].get('count', 0)
+                        })
+                except Exception as e:
+                    logger.warning(f"Error in outlier detection for {field_name}: {e}")
+                    stats['outliers'] = {'count': 0, 'percentage': 0.0, 'error': str(e)}
+            else:
+                stats['outliers'] = {'count': 0, 'percentage': 0.0, 'message': 'Skipped or insufficient data'}
+
+            # Normality Test
+            if test_normality and len(combined_values) >= 8:
+                try:
+                    from pamola_core.profiling.commons.numeric_utils import test_normality as test_normality_func
+                    stats['normality'] = test_normality_func(combined_values)
+                    logger.info(f"Normality testing complete. Is normal: {stats['normality'].get('is_normal', False)}")
+                    if progress_tracker:
+                        progress_tracker.update(0, {
+                            "step": "Normality testing complete",
+                            "is_normal": stats['normality'].get('is_normal', False)
+                        })
+                except Exception as e:
+                    logger.warning(f"Error in normality testing for {field_name}: {e}")
+                    stats['normality'] = {'is_normal': False, 'error': str(e)}
+            else:
+                stats['normality'] = {
+                    'is_normal': False,
+                    'message': 'Insufficient data for normality testing' if len(combined_values) < 8 else 'Skipped'
+                }
+
+            stats['samples'] = generate_currency_samples(stats)
+
+            # Semantic Notes
+            semantic_notes = []
+            if stats.get('negative_count', 0) > 0:
+                semantic_notes.append(f"Field contains {stats['negative_count']} negative values.")
+            if stats.get('zero_count', 0) > 0:
+                semantic_notes.append(f"Field contains {stats['zero_count']} zero values.")
+            if stats.get('max', 0) > stats.get('mean', 0) * 100:
+                semantic_notes.append("Field contains extremely large values that may be data entry errors.")
+            if semantic_notes:
+                stats['semantic_notes'] = semantic_notes
+
+            processing_time = round(time.time() - start_time, 2)
+            stats['processing_metadata'] = {
+                'method': 'parallel',
+                'chunks_processed': total_chunks,
+                'n_jobs': parallel_processes,
+                'chunk_size': chunk_size,
+                'processing_time_seconds': processing_time
+            }
+
+            logger.info(f"Parallel analysis completed in {processing_time:.2f} seconds")
+            result['stats'] = stats
+            result['note'] = f"Analysis performed using parallel processing with {total_chunks} chunks and {parallel_processes} workers."
+            result['processing_time'] = processing_time
+
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Parallel analysis complete",
+                    "field": field_name,
+                    "processing_time": processing_time
+                })
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Error in parallel analysis for {field_name}: {e}", exc_info=True)
+            return {
+                'error': f"Error in parallel analysis: {str(e)}",
+                'field_name': field_name,
+                'processing_method': 'parallel'
+            }
+
 
 @register(version="1.0.0")
 class CurrencyOperation(FieldOperation):
@@ -588,12 +926,21 @@ class CurrencyOperation(FieldOperation):
                  detect_outliers: bool = True,
                  test_normality: bool = True,
                  description: str = "",
-                 chunk_size: int = 10000,
-                 use_dask: bool = False,
                  generate_plots: bool = True,
                  include_timestamp: bool = True,
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
+                 use_dask: bool = False,
+                 use_cache: bool = True,
+                 use_vectorization: bool = False,
+                 chunk_size: int = 10000,
+                 parallel_processes: int = 1,
+                 npartitions: int = 1,
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
+                 encryption_mode: Optional[str] = None,
                  **kwargs):
         """
         Initialize a currency field operation.
@@ -612,6 +959,34 @@ class CurrencyOperation(FieldOperation):
             Whether to perform normality testing
         description : str
             Description of the operation (optional)
+        generate_plots : bool
+            Whether to generate visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
+        use_encryption : bool
+            Whether to encrypt output files
+        encryption_key : Optional[Union[str, Path]]
+            Key or path to key file used for encryption
+        use_dask : bool
+            Whether to use Dask for large datasets
+        use_cache : bool
+            Whether to use operation caching
+        use_vectorization : bool
+            Whether to use vectorized (parallel) processing
+        chunk_size : int
+            Size of chunks for processing large datasets
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1)
+        npartitions : int, optional
+            Number of partitions for Dask processing (default: None)
+        visualization_theme : str, optional
+            Theme for visualizations (default: None, uses PAMOLA default)
+        visualization_backend : str, optional
+            Backend for visualizations (default: None, uses PAMOLA default)
+        visualization_strict : bool, optional
+            Whether to enforce strict visualization rules (default: False)
+        visualization_timeout : int, optional
+            Timeout for visualization generation in seconds (default: 120)
         **kwargs : dict
             Additional parameters passed to the base class
         """
@@ -619,23 +994,34 @@ class CurrencyOperation(FieldOperation):
             field_name=field_name,
             description=description or f"Analysis of currency field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
         )
         self.locale = locale
         self.bins = bins
         self.detect_outliers = detect_outliers
         self.test_normality = test_normality
-        self.analyzer = CurrencyAnalyzer()
-        self.chunk_size = chunk_size
-        self.use_dask = use_dask
         self.generate_plots = generate_plots
         self.include_timestamp = include_timestamp
+        self.use_dask = use_dask
+        self.use_cache = use_cache
+        self.use_vectorization = use_vectorization
+        self.chunk_size = chunk_size
+        self.parallel_processes = parallel_processes
+        self.npartitions = npartitions
+
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
+
+        self.analyzer = CurrencyAnalyzer()
 
     def execute(self,
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the currency field analysis operation.
@@ -648,28 +1034,46 @@ class CurrencyOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
             - locale: str, locale to use for parsing
-            - chunk_size: int, size of chunks for processing
-            - use_dask: bool, whether to use Dask for large datasets
             - generate_plots: bool, whether to generate visualizations
             - include_timestamp: bool, whether to include timestamps in filenames
+            - chunk_size: int, size of chunks for processing
+            - use_dask: bool, whether to use Dask for large datasets
+            - npartitions: Number of partitions for Dask
+            - force_recalculation: bool - Skip cache check
+            - parallel_processes: int - Number of parallel processes
+            - dataset_name : str - The name of the dataset to load.
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
+        if kwargs.get('logger'):
+            self.logger = kwargs['logger']
+
         # Extract parameters from kwargs with defaults
         locale = kwargs.get('locale', self.locale)
         generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        chunk_size = kwargs.get('chunk_size', self.chunk_size)
-        use_dask = kwargs.get('use_dask', self.use_dask)
         encryption_key = kwargs.get('encryption_key', None)
+        self.use_dask = kwargs.get('use_dask', self.use_dask)
+        self.chunk_size = kwargs.get('chunk_size', self.chunk_size)
+        self.use_vectorization = kwargs.get('use_vectorization', self.use_vectorization)
+        self.include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
+        force_recalculation = kwargs.get("force_recalculation", False)
+        parallel_processes = kwargs.get("parallel_processes", self.parallel_processes)
+        npartitions = kwargs.get('npartitions', self.npartitions)
+        dataset_name = kwargs.get('dataset_name', "main")
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+        self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+        self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+        self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
 
         # Set up directories
         dirs = self._prepare_directories(task_dir)
@@ -680,9 +1084,47 @@ class CurrencyOperation(FieldOperation):
         # Create the main result object with initial status
         result = OperationResult(status=OperationStatus.SUCCESS)
 
+        # Set up progress tracking
+        # Preparation, Cache Check, Data Loading, Analysis, Visualizations, Finalization
+        total_steps = 5 + (1 if self.use_cache and not force_recalculation else 0)
+        current_steps = 0
+
+        # Step 1: Preparation
+        if progress_tracker:
+            progress_tracker.update(current_steps, {"step": "Preparation", "operation": self.name})
+            progress_tracker.total = total_steps  # Define total steps for tracking
+
+        # Step 2: Check Cache (if enabled and not forced to recalculate)
+        if self.use_cache and not force_recalculation:
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Checking Cache"})
+
+            logger.info("Checking operation cache...")
+            cache_result = self._check_cache(data_source, dataset_name, **kwargs)
+
+            if cache_result:
+                self.logger.info("Cache hit! Using cached results.")
+
+                # Update progress
+                if progress_tracker:
+                    progress_tracker.update(total_steps,{"step": "Complete (cached)"})
+
+                # Report cache hit to reporter
+                if reporter:
+                    reporter.add_operation(
+                        f"Clean invalid values (from cache)",
+                        details={"cached": True}
+                    )
+                return cache_result
+        
+        # Step 3: Data Loading
+        if progress_tracker:
+            current_steps += 1
+            progress_tracker.update(current_steps, {"step": "Data Loading"}) 
+            
         try:
             # Get DataFrame from data source
-            dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
             df = load_data_operation(data_source, dataset_name, **settings_operation)
             if df is None:
@@ -699,16 +1141,23 @@ class CurrencyOperation(FieldOperation):
                 )
 
             # Add operation to reporter
-            reporter.add_operation(f"Analyzing currency field: {self.field_name}", details={
-                "field_name": self.field_name,
-                "locale": locale,
-                "bins": self.bins,
-                "detect_outliers": self.detect_outliers,
-                "test_normality": self.test_normality,
-                "operation_type": "currency_analysis"
-            })
+            if reporter:
+                reporter.add_operation(f"Analyzing currency field: {self.field_name}", details={
+                    "field_name": self.field_name,
+                    "locale": locale,
+                    "bins": self.bins,
+                    "detect_outliers": self.detect_outliers,
+                    "test_normality": self.test_normality,
+                    "operation_type": "currency_analysis"
+                })
+
+            # Step 4: Analysis
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "K-Anonymity Analysis"}) 
 
             # Execute the analyzer
+            safe_kwargs = filter_used_kwargs(kwargs, CurrencyAnalyzer.analyze)
             analysis_results = self.analyzer.analyze(
                 df=df,
                 field_name=self.field_name,
@@ -716,10 +1165,13 @@ class CurrencyOperation(FieldOperation):
                 bins=self.bins,
                 detect_outliers=self.detect_outliers,
                 test_normality=self.test_normality,
-                chunk_size=chunk_size,
-                use_dask=use_dask,
+                chunk_size=self.chunk_size,
+                use_dask=self.use_dask,
+                use_vectorization=self.use_vectorization,
+                parallel_processes=parallel_processes,
                 progress_tracker=progress_tracker,
-                **kwargs
+                task_logger=self.logger,
+                **safe_kwargs
             )
 
             # Check for errors
@@ -733,24 +1185,38 @@ class CurrencyOperation(FieldOperation):
             stats_filename = f"{self.field_name}_stats.json"
             stats_path = output_dir / stats_filename
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
+            encryption_mode = get_encryption_mode(analysis_results, **kwargs)
+            write_json(analysis_results, stats_path, encryption_key=encryption_key, encryption_mode=encryption_mode)
             result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
 
             # Add to reporter
             reporter.add_artifact("json", str(stats_path), f"{self.field_name} currency analysis")
-
+            
             # Generate visualizations if requested
             if generate_plots:
+
+                # Step 5: Creating Visualizations
+                if progress_tracker:
+                    current_steps += 1
+                    progress_tracker.update(current_steps, {"step": "Creating Visualizations"})
+                    
                 kwargs_encryption = {
                     "use_encryption": kwargs.get('use_encryption', False),
                     "encryption_key": encryption_key
                 }
-                self._generate_visualizations(
-                    df,
-                    analysis_results,
-                    visualizations_dir,
-                    result,
-                    reporter,
+
+                self._handle_visualizations(
+                    df = df,
+                    analysis_results = analysis_results,
+                    vis_dir = visualizations_dir,
+                    include_timestamp = self.include_timestamp,
+                    result = result,
+                    reporter = reporter,
+                    vis_theme = self.visualization_theme,
+                    vis_backend = self.visualization_backend,
+                    vis_strict = self.visualization_strict,
+                    vis_timeout = self.visualization_timeout,
+                    progress_tracker = progress_tracker,
                     **kwargs_encryption
                 )
 
@@ -767,6 +1233,12 @@ class CurrencyOperation(FieldOperation):
             # Add metrics to the result
             self._add_metrics_to_result(analysis_results, result)
 
+            # Step 6: Finalization
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Operation complete", "status": "success"})
+
+
             # Add final operation status to reporter
             reporter.add_operation(f"Analysis of currency field {self.field_name} completed", details={
                 "valid_values": analysis_results.get('valid_count', 0),
@@ -774,11 +1246,24 @@ class CurrencyOperation(FieldOperation):
                 "multi_currency": analysis_results.get('multi_currency', False),
                 "currencies_detected": len(analysis_results.get('currency_counts', {}))
             })
+            
+            # Cache the result if caching is enabled
+            if self.use_cache:
+                try:
+                    self._save_to_cache(
+                        artifacts=result.artifacts,
+                        original_df=df,
+                        metrics=result.metrics,
+                        task_dir=task_dir
+                    )
+                except Exception as e:
+                    # Failure to cache is non-critical
+                    self.logger.warning(f"Failed to cache results: {str(e)}")
 
             return result
 
         except Exception as e:
-            logger.exception(f"Error in currency operation for {self.field_name}: {e}")
+            self.logger.exception(f"Error in currency operation for {self.field_name}: {e}")
 
             # Add error to reporter
             reporter.add_operation(f"Error analyzing currency field {self.field_name}",
@@ -794,8 +1279,12 @@ class CurrencyOperation(FieldOperation):
                                  df: pd.DataFrame,
                                  analysis_results: Dict[str, Any],
                                  vis_dir: Path,
+                                 include_timestamp: bool,
                                  result: OperationResult,
                                  reporter: Any,
+                                 vis_theme: Optional[str] = None,
+                                 vis_backend: Optional[str] = None,
+                                 vis_strict: bool = False,
                                  **kwargs):
         """
         Generate visualizations for the currency field analysis.
@@ -808,10 +1297,18 @@ class CurrencyOperation(FieldOperation):
             Results of the analysis
         vis_dir : Path
             Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
         result : OperationResult
             Operation result to add artifacts to
         reporter : Any
             Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
         """
         stats_dict = analysis_results.get('stats', {})
 
@@ -820,13 +1317,13 @@ class CurrencyOperation(FieldOperation):
         valid_values = normalized_values.dropna()
 
         if len(valid_values) == 0:
-            logger.warning(f"No valid currency values for visualization in {self.field_name}")
+            self.logger.warning(f"No valid currency values for visualization in {self.field_name}")
             return
 
         # Generate distribution histogram
         if 'histogram' in stats_dict:
             try:
-                hist_filename = f"{self.field_name}_distribution.png"
+                hist_filename = get_timestamped_filename(f"{self.field_name}_distribution", "png", include_timestamp) 
                 hist_path = vis_dir / hist_filename
 
                 # Create histogram using the visualization module
@@ -852,6 +1349,9 @@ class CurrencyOperation(FieldOperation):
                     x_label=f"{self.field_name} Value",
                     y_label="Frequency",
                     bins=self.bins,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
                     **kwargs
                 )
 
@@ -859,12 +1359,12 @@ class CurrencyOperation(FieldOperation):
                     result.add_artifact("png", hist_path, f"{self.field_name} distribution histogram", category=Constants.Artifact_Category_Visualization)
                     reporter.add_artifact("png", str(hist_path), f"{self.field_name} distribution histogram")
             except Exception as e:
-                logger.warning(f"Error creating histogram for {self.field_name}: {e}")
+                self.logger.warning(f"Error creating histogram for {self.field_name}: {e}")
 
         # Generate boxplot
         if len(valid_values) >= 5:
             try:
-                boxplot_filename = f"{self.field_name}_boxplot.png"
+                boxplot_filename = get_timestamped_filename(f"{self.field_name}_boxplot", "png", include_timestamp)
                 boxplot_path = vis_dir / boxplot_filename
 
                 # Create boxplot using the visualization module
@@ -874,6 +1374,9 @@ class CurrencyOperation(FieldOperation):
                     title=f"Boxplot of {self.field_name}",
                     y_label=self.field_name,
                     show_points=True,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
                     **kwargs
                 )
 
@@ -881,12 +1384,12 @@ class CurrencyOperation(FieldOperation):
                     result.add_artifact("png", boxplot_path, f"{self.field_name} boxplot", category=Constants.Artifact_Category_Visualization)
                     reporter.add_artifact("png", str(boxplot_path), f"{self.field_name} boxplot")
             except Exception as e:
-                logger.warning(f"Error creating boxplot for {self.field_name}: {e}")
+                self.logger.warning(f"Error creating boxplot for {self.field_name}: {e}")
 
         # Generate Q-Q plot for normality if requested
         if self.test_normality and 'normality' in stats_dict and len(valid_values) >= 10:
             try:
-                qq_filename = f"{self.field_name}_qq_plot.png"
+                qq_filename = get_timestamped_filename(f"{self.field_name}_qq_plot", "png", include_timestamp)
                 qq_path = vis_dir / qq_filename
 
                 # Generate synthetic normal data for comparison
@@ -916,6 +1419,9 @@ class CurrencyOperation(FieldOperation):
                     x_label="Theoretical Quantiles",
                     y_label="Sample Quantiles",
                     add_trendline=True,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
                     **kwargs
                 )
 
@@ -923,7 +1429,7 @@ class CurrencyOperation(FieldOperation):
                     result.add_artifact("png", qq_path, f"{self.field_name} Q-Q plot (normality test)", category=Constants.Artifact_Category_Visualization)
                     reporter.add_artifact("png", str(qq_path), f"{self.field_name} Q-Q plot")
             except Exception as e:
-                logger.warning(f"Error creating Q-Q plot for {self.field_name}: {e}")
+                self.logger.warning(f"Error creating Q-Q plot for {self.field_name}: {e}")
 
     def _save_sample_records(self,
                              df: pd.DataFrame,
@@ -1037,7 +1543,7 @@ class CurrencyOperation(FieldOperation):
             reporter.add_artifact("csv", str(sample_path), f"{self.field_name} sample records")
 
         except Exception as e:
-            logger.warning(f"Error saving sample records for {self.field_name}: {e}")
+            self.logger.warning(f"Error saving sample records for {self.field_name}: {e}")
 
     def _add_metrics_to_result(self, analysis_results: Dict[str, Any], result: OperationResult):
         """
@@ -1103,3 +1609,441 @@ class CurrencyOperation(FieldOperation):
         if currency_counts:
             for currency, count in currency_counts.items():
                 result.add_nested_metric("currencies", currency, count)
+
+    def _check_cache(
+            self,
+            data_source: DataSource,
+            dataset_name: str = "main",
+            **kwargs
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        data_source : DataSource
+            Data source for the operation
+        task_dir : Path
+            Task directory
+        dataset_name: str
+            Dataset name
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Get DataFrame from data source
+            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+            df = load_data_operation(data_source, dataset_name, **settings_operation)
+            if df is None:
+                self.logger.warning("No valid DataFrame found in data source")
+                return None
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                self.logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Add cached metrics to result
+                metrics = cached_data.get("metrics", {})
+                if isinstance(metrics, dict):
+                    for key, value in metrics.items():
+                        cached_result.add_metric(key, value)
+
+                # Add cached artifacts to result
+                artifacts = cached_data.get("artifacts", [])
+                if isinstance(artifacts, list):
+                    for artifact in artifacts:
+                        artifact_type = artifact.get("artifact_type", "")
+                        artifact_path = artifact.get("path", "")
+                        artifact_name = artifact.get("description", "")
+                        artifact_category = artifact.get("category", "output")
+                        cached_result.add_artifact(artifact_type, artifact_path, artifact_name, artifact_category) 
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+
+                return cached_result
+
+            self.logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+        
+    def _save_to_cache(
+            self,
+            original_df: pd.DataFrame,
+            artifacts: List[OperationArtifact],
+            metrics: Dict[str, Any],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame
+            Original input data
+        processed_df : pd.DataFrame
+            Processed DataFrame
+        metrics : dict
+            The metrics of operation
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache or (not artifacts and not metrics):
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            artifacts_for_cache = [artifact.to_dict() for artifact in artifacts]
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "artifacts": artifacts_for_cache,
+                "metrics": metrics,
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                self.logger.info(f"Successfully saved results to cache")
+            else:
+                self.logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+        
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "locale": self.locale,
+            "bins": self.bins,
+            "detect_outliers": self.detect_outliers,
+            "test_normality": self.test_normality,
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+    
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+        
+    
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type         
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+    
+    def _handle_visualizations(
+            self,
+            df: pd.DataFrame,
+            analysis_results: Dict[str, Any],
+            vis_dir: Path,
+            include_timestamp: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str] = None,
+            vis_backend: Optional[str] = None,
+            vis_strict: bool = False,
+            vis_timeout: int = 120,
+            progress_tracker: Optional[HierarchicalProgressTracker] = None,
+            **kwargs
+    ) -> Dict[str, Path]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            DataFrame containing the data
+        analysis_results : Dict[str, Any]
+            Results of the analysis
+        vis_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
+        result : OperationResult
+            Operation result to add artifacts to
+        reporter : Any
+            Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    self._generate_visualizations(
+                        df,
+                        analysis_results,
+                        vis_dir,
+                        include_timestamp,
+                        result,
+                        reporter,
+                        vis_theme,
+                        vis_backend,
+                        vis_strict,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths

--- a/pamola_core/profiling/analyzers/date.py
+++ b/pamola_core/profiling/analyzers/date.py
@@ -6,9 +6,11 @@ new operation architecture. It includes validation, distribution analysis,
 anomaly detection, and visualization capabilities.
 """
 
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
+import time
 from typing import Dict, List, Any, Optional, Union
 
 import pandas as pd
@@ -21,13 +23,14 @@ from pamola_core.utils.io import write_json, get_timestamped_filename, load_data
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register
-from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.ops.op_result import OperationArtifact, OperationResult, OperationStatus
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.visualization import (
     plot_date_distribution,
     plot_value_distribution
 )
 from pamola_core.common.constants import Constants
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -45,6 +48,13 @@ class DateAnalyzer:
                 field_name: str,
                 min_year: int = 1940,
                 max_year: int = 2005,
+                chunk_size: int = 10000,
+                is_birth_date: bool = False,
+                use_dask: bool = False,
+                use_vectorization: bool = False,
+                parallel_processes: Optional[int] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                task_logger: Optional[logging.Logger] = None,
                 **kwargs) -> Dict[str, Any]:
         """
         Analyze a date field in the given DataFrame.
@@ -82,11 +92,17 @@ class DateAnalyzer:
             max_year=max_year,
             id_column=id_column,
             uid_column=uid_column,
+            chunk_size=chunk_size,
+            use_dask=use_dask,
+            use_vectorization = use_vectorization,
+            parallel_processes=parallel_processes,
+            progress_tracker=progress_tracker,
+            task_logger=task_logger,
             **new_kwargs
         )
 
         # For birth dates, calculate age distribution
-        if kwargs.get('is_birth_date', False) and not results.get('error'):
+        if is_birth_date and not results.get('error'):
             results.update(self._calculate_age_distribution(df, field_name))
 
         return results
@@ -210,11 +226,21 @@ class DateOperation(FieldOperation):
                  uid_column: Optional[str] = None,
                  description: str = "",
                  generate_plots: bool = True,
-                 include_timestamp: bool = True,
                  profile_type: str = "date",
                  is_birth_date: Optional[bool] = None,
                  use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+                 encryption_key: Optional[Union[str, Path]] = None,
+                 use_dask: bool = False,
+                 use_cache: bool = True,
+                 use_vectorization: bool = False,
+                 chunk_size: int = 10000,
+                 npartitions: Optional[int] = None,
+                 parallel_processes: Optional[int] = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize the date operation.
 
@@ -240,12 +266,33 @@ class DateOperation(FieldOperation):
             Type of profiling for organizing artifacts
         is_birth_date : bool, optional
             Whether the field is a birth date field
+        use_dask : bool
+            Whether to use Dask for processing (default: False)
+        use_cache : bool
+            Whether to use operation caching (default: True)
+        use_vectorization : bool, optional
+            Whether to use vectorized (parallel) processing (default: False)
+        chunk_size : int
+            Batch size for processing large datasets (default: 10000)
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1)
+        npartitions : int, optional
+            Number of partitions for Dask processing (default: None)
+        visualization_theme : str, optional
+            Theme for visualizations (default: None, uses PAMOLA default)
+        visualization_backend : str, optional
+            Backend for visualizations (default: None, uses PAMOLA default)
+        visualization_strict : bool, optional
+            Whether to enforce strict visualization rules (default: False)
+        visualization_timeout : int, optional
+            Timeout for visualization generation in seconds (default: 120)
         """
         super().__init__(
             field_name=field_name,
             description=description or f"Analysis of date field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
             )
         
         self.min_year = min_year
@@ -253,8 +300,18 @@ class DateOperation(FieldOperation):
         self.id_column = id_column
         self.uid_column = uid_column
         self.generate_plots = generate_plots
-        self.include_timestamp = include_timestamp
         self.profile_type = profile_type
+        
+        self.use_dask = use_dask
+        self.use_cache = use_cache
+        self.use_vectorization = use_vectorization
+        self.chunk_size = chunk_size
+        self.npartitions = npartitions
+        self.parallel_processes = parallel_processes
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
         
         # Set is_birth_date based on the provided value or field name
         if is_birth_date is None:
@@ -268,7 +325,7 @@ class DateOperation(FieldOperation):
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the date analysis operation.
@@ -281,7 +338,7 @@ class DateOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
@@ -289,18 +346,33 @@ class DateOperation(FieldOperation):
             - include_timestamp: bool, whether to include timestamps in filenames
             - profile_type: str, type of profiling for organizing artifacts
             - is_birth_date: bool, whether the field is a birth date field
+            - force_recalculation: bool - Skip cache check
+            - npartitions: Number of partitions for Dask
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
+        if kwargs.get('logger'):
+            self.logger = kwargs['logger']
+            
         # Extract parameters from kwargs, defaulting to instance variables
         generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
+        include_timestamp = kwargs.get('include_timestamp', True)
         profile_type = kwargs.get('profile_type', self.profile_type)
-        is_birth_date = kwargs.get('is_birth_date', self.is_birth_date)
+        self.is_birth_date = kwargs.get('is_birth_date', self.is_birth_date)
         encryption_key = kwargs.get('encryption_key', None)
+
+        self.use_vectorization = kwargs.get('use_vectorization', self.use_vectorization)
+        force_recalculation = kwargs.get("force_recalculation", False)
+        dataset_name = kwargs.get("dataset_name", "main")
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+        self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+        self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+        self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
 
         # Set up directories
         dirs = self._prepare_directories(task_dir)
@@ -311,13 +383,48 @@ class DateOperation(FieldOperation):
         # Create the main result object with initial status
         result = OperationResult(status=OperationStatus.SUCCESS)
 
+        # Set up progress tracking
+        # Preparation, Cache Check, Data Loading, Analysis, Saving results, Visualizations, Finalization
+        total_steps = 6 + (1 if self.use_cache and not force_recalculation else 0) + (1 if generate_plots else 0)
+        current_steps = 0
+
         # Update progress if tracker provided
+        # Step 1: Preparation
         if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+            current_steps += 1
+            progress_tracker.update(current_steps, {"step": "Preparation", "field": self.field_name})
+
+        # Step 2: Check Cache (if enabled and not forced to recalculate)
+        if self.use_cache and not force_recalculation:
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Checking Cache"})
+
+            logger.info("Checking operation cache...")
+            cache_result = self._check_cache(data_source, dataset_name, **kwargs)
+
+            if cache_result:
+                self.logger.info("Cache hit! Using cached results.")
+
+                # Update progress
+                if progress_tracker:
+                    progress_tracker.update(total_steps,{"step": "Complete (cached)"})
+
+                # Report cache hit to reporter
+                if reporter:
+                    reporter.add_operation(
+                        f"Clean invalid values (from cache)",
+                        details={"cached": True}
+                    )
+                return cache_result
+            
+        # Step 3: Data Loading
+        if progress_tracker:
+            current_steps += 1
+            progress_tracker.update(current_steps, {"step": "Data Loading"}) 
 
         try:
             # Get DataFrame from data source
-            dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
             df = load_data_operation(data_source, dataset_name, **settings_operation)
             if df is None:
@@ -340,18 +447,15 @@ class DateOperation(FieldOperation):
                 "max_year": self.max_year,
                 "id_column": self.id_column,
                 "uid_column": self.uid_column,
-                "is_birth_date": is_birth_date,
+                "is_birth_date": self.is_birth_date,
                 "operation_type": "date_analysis"
             })
 
-            # Adjust progress tracker total steps if provided
-            total_steps = 5
-            if generate_plots:
-                total_steps += 3 if is_birth_date else 2
-
+            # Step 4: Analysis
             if progress_tracker:
                 progress_tracker.total = total_steps
-                progress_tracker.update(0, {"status": "Analyzing field"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"status": "Analyzing field"})
 
             # Execute the analyzer
             analysis_results = self.analyzer.analyze(
@@ -361,7 +465,13 @@ class DateOperation(FieldOperation):
                 max_year=self.max_year,
                 id_column=self.id_column,
                 uid_column=self.uid_column,
-                is_birth_date=is_birth_date
+                is_birth_date=self.is_birth_date,
+                chunk_size=self.chunk_size,
+                use_dask=self.use_dask,
+                use_vectorization=self.use_vectorization,
+                parallel_processes=self.parallel_processes,
+                progress_tracker=progress_tracker,
+                task_logger=self.logger
             )
 
             # Check for errors
@@ -373,44 +483,56 @@ class DateOperation(FieldOperation):
 
             # Update progress
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Analysis complete", "field": self.field_name})
+                progress_tracker.update(current_steps, {"step": "Analysis complete", "field": self.field_name})
 
             # Save analysis results to JSON in the task root directory
             stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
             stats_path = output_dir / stats_filename
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
+            encryption_mode = get_encryption_mode(analysis_results, **kwargs)
+            write_json(analysis_results, stats_path, encryption_key=encryption_key, encryption_mode=encryption_mode)
             result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
 
             # Add to reporter
             reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
 
+            #Step 5: Saving results
             # Update progress
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved analysis results"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Saved analysis results"})
 
             # Generate visualizations if requested
             if generate_plots:
                 # Update progress
+                # Step 6: Visualizations
                 if progress_tracker:
-                    progress_tracker.update(0, {"step": "Generating visualizations"})
+                    current_steps += 1
+                    progress_tracker.update(current_steps, {"step": "Generating visualizations"})
+
                 kwargs_encryption = {
                     "use_encryption": kwargs.get('use_encryption', False),
                     "encryption_key": encryption_key
                 }
-                self._generate_visualizations(
-                    analysis_results,
-                    visualizations_dir,
-                    include_timestamp,
-                    is_birth_date,
-                    result,
-                    reporter,
+
+                self._handle_visualizations(
+                    analysis_results=analysis_results,
+                    vis_dir=visualizations_dir,
+                    include_timestamp=include_timestamp,
+                    is_birth_date=self.is_birth_date,
+                    result=result,
+                    reporter=reporter,
+                    vis_theme=self.visualization_theme,
+                    vis_backend=self.visualization_backend,
+                    vis_strict=self.visualization_strict,
+                    vis_timeout=self.visualization_timeout,
+                    progress_tracker=progress_tracker,
                     **kwargs_encryption
                 )
-
+                
                 # Update progress
                 if progress_tracker:
-                    progress_tracker.update(1, {"step": "Visualizations complete"})
+                    progress_tracker.update(current_steps, {"step": "Visualizations complete"})
 
             # Save anomalies to CSV if any
             if 'anomalies' in analysis_results and sum(analysis_results['anomalies'].values()) > 0:
@@ -425,7 +547,7 @@ class DateOperation(FieldOperation):
 
                 # Update progress
                 if progress_tracker:
-                    progress_tracker.update(1, {"step": "Saved anomalies data"})
+                    progress_tracker.update(current_steps, {"step": "Saved anomalies data"})
 
             # Add metrics to the result
             result.add_metric("total_rows", analysis_results.get('total_records', 0))
@@ -445,7 +567,7 @@ class DateOperation(FieldOperation):
                 result.add_metric("anomalies_count", sum(analysis_results['anomalies'].values()))
 
             # Add age metrics if it's a birth date
-            if is_birth_date and 'age_statistics' in analysis_results:
+            if self.is_birth_date and 'age_statistics' in analysis_results:
                 age_stats = analysis_results['age_statistics']
                 result.add_metric("min_age", age_stats.get('min_age'))
                 result.add_metric("max_age", age_stats.get('max_age'))
@@ -453,8 +575,10 @@ class DateOperation(FieldOperation):
                 result.add_metric("median_age", age_stats.get('median_age'))
 
             # Update progress to completion
+            # Step 7: Finalization
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Operation complete", "status": "success"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Operation complete", "status": "success"})
 
             # Add final operation status to reporter
             reporter.add_operation(f"Analysis of {self.field_name} completed", details={
@@ -466,10 +590,22 @@ class DateOperation(FieldOperation):
                                                                                                  0) if 'date_changes_within_group' in analysis_results else 0
             })
 
+            if self.use_cache:
+                try:
+                    self._save_to_cache(
+                        artifacts=result.artifacts,
+                        original_df=df,
+                        metrics=result.metrics,
+                        task_dir=task_dir
+                    )
+                except Exception as e:
+                    # Failure to cache is non-critical
+                    self.logger.warning(f"Failed to cache results: {str(e)}")
+
             return result
 
         except Exception as e:
-            logger.exception(f"Error in date operation for {self.field_name}: {e}")
+            self.logger.exception(f"Error in date operation for {self.field_name}: {e}")
 
             # Update progress tracker on error
             if progress_tracker:
@@ -492,6 +628,9 @@ class DateOperation(FieldOperation):
                                  is_birth_date: bool,
                                  result: OperationResult,
                                  reporter: Any,
+                                 vis_theme: Optional[str] = None,
+                                 vis_backend: Optional[str] = None,
+                                 vis_strict: bool = False,
                                  **kwargs):
         """
         Generate visualizations for the date field analysis.
@@ -510,6 +649,12 @@ class DateOperation(FieldOperation):
             Operation result to add artifacts to
         reporter : Any
             Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
         """
         # Generate year distribution visualization if we have data
         if 'year_distribution' in analysis_results and analysis_results['year_distribution']:
@@ -526,6 +671,9 @@ class DateOperation(FieldOperation):
                 {'year_distribution': analysis_results['year_distribution']},
                 str(year_path),
                 title=title,
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
                 **kwargs
             )
 
@@ -547,6 +695,9 @@ class DateOperation(FieldOperation):
                 analysis_results['month_distribution'],
                 str(month_path),
                 title=title,
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
                 **kwargs
             )
 
@@ -568,6 +719,9 @@ class DateOperation(FieldOperation):
                 analysis_results['day_of_week_distribution'],
                 str(dow_path),
                 title=title,
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
                 **kwargs
             )
 
@@ -589,6 +743,9 @@ class DateOperation(FieldOperation):
                 title=title,
                 x_label="Age Group",
                 y_label="Count",
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
                 **kwargs
             )
 
@@ -653,10 +810,451 @@ class DateOperation(FieldOperation):
                 reporter.add_artifact("csv", str(anomalies_path), f"{self.field_name} anomalies")
 
         except Exception as e:
-            logger.warning(f"Error saving anomalies for {self.field_name}: {e}")
+            self.logger.warning(f"Error saving anomalies for {self.field_name}: {e}")
             reporter.add_operation(f"Saving anomalies for {self.field_name}", status="warning",
                                    details={"warning": str(e)})
 
+    def _check_cache(
+            self,
+            data_source: DataSource,
+            dataset_name: str = "main",
+            **kwargs
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        data_source : DataSource
+            Data source for the operation
+        task_dir : Path
+            Task directory
+        dataset_name: str
+            Dataset name
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Get DataFrame from data source
+            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+            df = load_data_operation(data_source, dataset_name, **settings_operation)
+            if df is None:
+                self.logger.warning("No valid DataFrame found in data source")
+                return None
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                self.logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Add cached metrics to result
+                metrics = cached_data.get("metrics", {})
+                if isinstance(metrics, dict):
+                    for key, value in metrics.items():
+                        cached_result.add_metric(key, value)
+
+                # Add cached artifacts to result
+                artifacts = cached_data.get("artifacts", [])
+                if isinstance(artifacts, list):
+                    for artifact in artifacts:
+                        artifact_type = artifact.get("artifact_type", "")
+                        artifact_path = artifact.get("path", "")
+                        artifact_name = artifact.get("description", "")
+                        artifact_category = artifact.get("category", "output")
+                        cached_result.add_artifact(artifact_type, artifact_path, artifact_name, artifact_category)
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+
+                return cached_result
+
+            self.logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+        
+    def _save_to_cache(
+            self,
+            original_df: pd.DataFrame,
+            artifacts: List[OperationArtifact],
+            metrics: Dict[str, Any],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame
+            Original input data
+        processed_df : pd.DataFrame
+            Processed DataFrame
+        metrics : dict
+            The metrics of operation
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache or (not artifacts and not metrics):
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            artifacts_for_cache = [artifact.to_dict() for artifact in artifacts]
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "artifacts": artifacts_for_cache,
+                "metrics": metrics,
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                self.logger.info(f"Successfully saved results to cache")
+            else:
+                self.logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+        
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "min_year": self.min_year,
+            "max_year": self.max_year,
+            "id_column": self.id_column,
+            "uid_column": self.uid_column,
+            "generate_plots": self.generate_plots,
+            "profile_type": self.profile_type,
+            "is_birth_date": self.is_birth_date,
+            "use_encryption": self.use_encryption
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+    
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+        
+    
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type         
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+    
+    def _handle_visualizations(
+            self,
+            analysis_results: Dict[str, Any],
+            vis_dir: Path,
+            include_timestamp: bool,
+            is_birth_date: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str] = None,
+            vis_backend: Optional[str] = None,
+            vis_strict: bool = False,
+            vis_timeout: int = 120,
+            progress_tracker: Optional[HierarchicalProgressTracker] = None,
+            **kwargs
+    ) -> Dict[str, Path]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            DataFrame containing the data
+        analysis_results : Dict[str, Any]
+            Results of the analysis
+        vis_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
+        result : OperationResult
+            Operation result to add artifacts to
+        reporter : Any
+            Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    self._generate_visualizations(
+                        analysis_results,
+                        vis_dir,
+                        include_timestamp,
+                        is_birth_date,
+                        result,
+                        reporter,
+                        vis_theme,
+                        vis_backend,
+                        vis_strict,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths
 
 def analyze_date_fields(data_source: DataSource,
                         task_dir: Path,
@@ -692,7 +1290,8 @@ def analyze_date_fields(data_source: DataSource,
     """
     # Get DataFrame from data source
     dataset_name = kwargs.get('dataset_name', "main")
-    df = load_data_operation(data_source, dataset_name)
+    settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+    df = load_data_operation(data_source, dataset_name, **settings_operation)
     if df is None:
         reporter.add_operation("Date fields analysis", status="error",
                                details={"error": "No valid DataFrame found in data source"})
@@ -723,7 +1322,7 @@ def analyze_date_fields(data_source: DataSource,
     overall_tracker = None
 
     if track_progress and date_fields:
-        overall_tracker = ProgressTracker(
+        overall_tracker = HierarchicalProgressTracker(
             total=len(date_fields),
             description=f"Analyzing {len(date_fields)} date fields",
             unit="fields",

--- a/pamola_core/profiling/analyzers/email.py
+++ b/pamola_core/profiling/analyzers/email.py
@@ -16,8 +16,11 @@ Operations:
 - analyze_email_fields: Function for analyzing multiple email fields
 """
 
+from datetime import datetime
+import json
 import logging
 from pathlib import Path
+import time
 from typing import Dict, List, Any, Optional, Union
 
 import pandas as pd
@@ -28,15 +31,17 @@ from pamola_core.profiling.commons.email_utils import (
     estimate_resources
 )
 from pamola_core.utils.io import write_json, ensure_directory, get_timestamped_filename, load_data_operation, write_dataframe_to_csv, load_settings_operation
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register
-from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
+from pamola_core.utils.ops.op_result import OperationArtifact, OperationResult, OperationStatus
 from pamola_core.common.constants import Constants
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
+from pamola_core.profiling.commons.helpers import filter_used_kwargs
+
 # Configure logger
 logger = logging.getLogger(__name__)
-
 
 class EmailAnalyzer:
     """
@@ -50,6 +55,13 @@ class EmailAnalyzer:
     def analyze(df: pd.DataFrame,
                 field_name: str,
                 top_n: int = 20,
+                use_dask: bool = False,
+                use_vectorization: bool = False,
+                chunk_size: int = 1000,
+                npartitions: int = 1,
+                parallel_processes: int = 1,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                task_logger: Optional[logging.Logger] = None,
                 **kwargs) -> Dict[str, Any]:
         """
         Analyze an email field in the given DataFrame.
@@ -74,6 +86,13 @@ class EmailAnalyzer:
             df=df,
             field_name=field_name,
             top_n=top_n,
+            use_dask=use_dask,
+            chunk_size=chunk_size,
+            use_vectorization=use_vectorization,
+            npartitions=npartitions,
+            parallel_processes=parallel_processes,
+            progress_tracker=progress_tracker,
+            task_logger=task_logger,
             **kwargs
         )
 
@@ -142,12 +161,22 @@ class EmailOperation(FieldOperation):
                  top_n: int = 20,
                  min_frequency: int = 1,
                  generate_plots: bool = True,
-                 include_timestamp: bool  = True,
                  profile_type: str  = 'email',
                  analyze_privacy_risk: bool = True,
                  description: str = "",
                  use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+                 chunk_size: int = 10000,
+                 use_dask: bool = False,
+                 use_cache: bool = True,
+                 use_vectorization: bool = False,
+                 npartitions: Optional[int] = 1,
+                 parallel_processes: Optional[int] = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
+                 encryption_key: Optional[Union[str, Path]] = None,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize the email operation.
 
@@ -166,21 +195,33 @@ class EmailOperation(FieldOperation):
             field_name=field_name,
             description=description or f"Analysis of email field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
             )
         
         self.top_n = top_n
         self.min_frequency = min_frequency
         self.generate_plots = generate_plots
-        self.include_timestamp = include_timestamp
         self.profile_type = profile_type
         self.analyze_privacy_risk = analyze_privacy_risk
+        self.use_dask = use_dask
+        self.use_cache = use_cache
+        self.use_vectorization = use_vectorization
+        self.chunk_size = chunk_size
+        self.npartitions = npartitions
+        self.parallel_processes = parallel_processes
+        self.use_encryption = use_encryption
+        self.encryption_key = encryption_key
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
 
     def execute(self,
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the email analysis operation.
@@ -193,26 +234,46 @@ class EmailOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
             - generate_plots: bool, whether to generate visualizations
-            - include_timestamp: bool, whether to include timestamps in filenames
+            - include_timestamp: bool, whether to include timestamps in filenames, default = True
             - profile_type: str, type of profiling for organizing artifacts
             - analyze_privacy_risk: bool, whether to analyze privacy risks
+            - chunk_size: int, size of chunks for processing
+            - use_dask: bool, whether to use Dask for large datasets
+            - force_recalculation: bool - Skip cache check
+            - parallel_processes: int - Number of parallel processes
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
+        if kwargs.get('logger'):
+            self.logger = kwargs['logger']
+            
         # Extract parameters from kwargs
         generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
+        include_timestamp = kwargs.get('include_timestamp', True)
         profile_type = kwargs.get('profile_type', self.profile_type)
         analyze_privacy_risk = kwargs.get('analyze_privacy_risk', self.analyze_privacy_risk)
         encryption_key = kwargs.get('encryption_key', None)
+
+        self.use_vectorization = kwargs.get('use_vectorization', self.use_vectorization)
+        self.npartitions = kwargs.get('npartitions', self.npartitions)
+        self.parallel_processes = kwargs.get('parallel_processes', self.parallel_processes)
+
+        force_recalculation = kwargs.get("force_recalculation", False)
+        dataset_name = kwargs.get("dataset_name", "main")
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+        self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+        self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+        self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
 
         # Set up directories
         dirs = self._prepare_directories(task_dir)
@@ -223,13 +284,47 @@ class EmailOperation(FieldOperation):
         # Create the main result object with initial status
         result = OperationResult(status=OperationStatus.SUCCESS)
 
+        # Set up progress tracking
+        # Preparation, Cache Check, Data Loading, Analysis, Saving results, Visualizations, Dictionary, Finalization
+        total_steps = 6 + (1 if self.use_cache and not force_recalculation else 0) + (1 if generate_plots else 0)
+        current_steps = 0
+
         # Update progress if tracker provided
         if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+            current_steps += 1
+            progress_tracker.update(current_steps, {"step": "Preparation", "field": self.field_name})
+
+        # Step 2: Check Cache (if enabled and not forced to recalculate)
+        if self.use_cache and not force_recalculation:
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Checking Cache"})
+
+            logger.info("Checking operation cache...")
+            cache_result = self._check_cache(data_source, dataset_name, **kwargs)
+
+            if cache_result:
+                self.logger.info("Cache hit! Using cached results.")
+
+                # Update progress
+                if progress_tracker:
+                    progress_tracker.update(total_steps,{"step": "Complete (cached)"})
+
+                # Report cache hit to reporter
+                if reporter:
+                    reporter.add_operation(
+                        f"Clean invalid values (from cache)",
+                        details={"cached": True}
+                    )
+                return cache_result
+        
+        # Step 3: Data Loading
+        if progress_tracker:
+            current_steps += 1
+            progress_tracker.update(current_steps, {"step": "Data Loading"}) 
 
         try:
             # Get DataFrame from data source
-            dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
             df = load_data_operation(data_source, dataset_name, **settings_operation)
             if df is None:
@@ -246,28 +341,34 @@ class EmailOperation(FieldOperation):
                 )
 
             # Add operation to reporter
-            reporter.add_operation(f"Analyzing email field: {self.field_name}", details={
-                "field_name": self.field_name,
-                "top_n": self.top_n,
-                "min_frequency": self.min_frequency,
-                "operation_type": "email_analysis"
-            })
+            if reporter:
+                reporter.add_operation(f"Analyzing email field: {self.field_name}", details={
+                    "field_name": self.field_name,
+                    "top_n": self.top_n,
+                    "min_frequency": self.min_frequency,
+                    "operation_type": "email_analysis"
+                })
 
-            # Adjust progress tracker total steps if provided
-            total_steps = 4  # Preparation, analysis, saving results, dictionary
-            if generate_plots:
-                total_steps += 1  # Add step for generating visualizations
-
+            # Step 4: Analysis
             if progress_tracker:
                 progress_tracker.total = total_steps
-                progress_tracker.update(0, {"status": "Analyzing field"})
-
+                current_steps += 1
+                progress_tracker.update(current_steps, {"status": "Analyzing field"})
+    
             # Execute the analyzer
+            safe_kwargs = filter_used_kwargs(kwargs, EmailAnalyzer.analyze)
             analysis_results = EmailAnalyzer.analyze(
                 df=df,
                 field_name=self.field_name,
                 top_n=self.top_n,
-                **kwargs
+                chunk_size=self.chunk_size,
+                npartitions=self.npartitions,
+                parallel_processes=self.parallel_processes,
+                use_dask=self.use_dask,
+                use_vectorization=self.use_vectorization,
+                progress_tracker=progress_tracker,
+                task_logger=self.logger,
+                **safe_kwargs
             )
 
             # Check for errors
@@ -279,57 +380,56 @@ class EmailOperation(FieldOperation):
 
             # Update progress
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Analysis complete", "field": self.field_name})
+                progress_tracker.update(total_steps, {"step": "Analysis complete", "field": self.field_name})
 
             # Save analysis results to JSON
             stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
             stats_path = output_dir / stats_filename
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
+            encryption_mode = get_encryption_mode(analysis_results, **kwargs)
+            write_json(analysis_results, stats_path, encryption_key=encryption_key, encryption_mode=encryption_mode)
             result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
 
             # Add to reporter
             reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
 
+            #Step 5: Saving results
             # Update progress
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved analysis results"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Saved analysis results"})
 
             # Generate visualization if requested
             if generate_plots and 'top_domains' in analysis_results and analysis_results['top_domains']:
+                # Step 6: Visualizations
                 # Update progress
                 if progress_tracker:
-                    progress_tracker.update(0, {"step": "Generating visualization"})
+                    current_steps += 1
+                    progress_tracker.update(current_steps, {"step": "Generating visualization"})
+                
+                kwargs_encryption = {
+                    "use_encryption": kwargs.get('use_encryption', False),
+                    "encryption_key": encryption_key
+                }
 
-                # Create visualization filename with extension "png"
-                viz_filename = get_timestamped_filename(
-                    base_name=f"{self.field_name}_domains_distribution",
-                    extension="png",
-                    include_timestamp=include_timestamp
+                self._handle_visualizations(
+                    analysis_results=analysis_results,
+                    vis_dir=visualizations_dir,
+                    include_timestamp=include_timestamp,
+                    result=result,
+                    reporter=reporter,
+                    visualization_theme=self.visualization_theme,
+                    visualization_backend=self.visualization_backend,
+                    visualization_strict=self.visualization_strict,
+                    visualization_timeout=self.visualization_timeout,
+                    progress_tracker=progress_tracker,
+                    **kwargs_encryption
                 )
-                viz_path = visualizations_dir / viz_filename
-
-                # Create visualization using the visualization module
-                from pamola_core.utils.visualization import plot_email_domains
-                title = f"Top Email Domains in {self.field_name}"
-
-                viz_result = plot_email_domains(
-                    domains=analysis_results['top_domains'],
-                    output_path=str(viz_path),
-                    title=title,
-                    **kwargs
-                )
-
-                if not viz_result.startswith("Error"):
-                    result.add_artifact("png", viz_path, f"{self.field_name} domains distribution", category=Constants.Artifact_Category_Visualization)
-                    reporter.add_artifact("png", str(viz_path), f"{self.field_name} domains distribution")
-                else:
-                    logger.warning(f"Error creating visualization: {viz_result}")
 
                 # Update progress
                 if progress_tracker:
-                    progress_tracker.update(1, {"step": "Created visualization"})
-
+                    progress_tracker.update(current_steps, {"step": "Created visualization"})
+                    
             # Create and save domain dictionary
             dict_result = EmailAnalyzer.create_domain_dictionary(
                 df=df,
@@ -352,7 +452,8 @@ class EmailOperation(FieldOperation):
                 json_dict_filename = get_timestamped_filename(f"{self.field_name}_domains_dictionary", "json",
                                                               include_timestamp)
                 json_dict_path = output_dir / json_dict_filename
-                write_json(dict_result, json_dict_path, encryption_key=encryption_key)
+                encryption_mode_dict_result = get_encryption_mode(dict_result, **kwargs)
+                write_json(dict_result, json_dict_path, encryption_key=encryption_key, encryption_mode=encryption_mode_dict_result)
 
                 result.add_artifact("csv", dict_path, f"{self.field_name} domains dictionary (CSV)", category=Constants.Artifact_Category_Dictionary)
                 result.add_artifact("json", json_dict_path, f"{self.field_name} domains dictionary (JSON)", category=Constants.Artifact_Category_Output)
@@ -361,8 +462,10 @@ class EmailOperation(FieldOperation):
                 reporter.add_artifact("json", str(json_dict_path), f"{self.field_name} domains dictionary (JSON)")
 
             # Update progress
+            # Step 7: Dictionary
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Created domain dictionary"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Created domain dictionary"})
 
             # Add privacy risk assessment if requested
             if analyze_privacy_risk:
@@ -374,7 +477,8 @@ class EmailOperation(FieldOperation):
                     privacy_filename = get_timestamped_filename(f"{self.field_name}_privacy_risk", "json",
                                                                 include_timestamp)
                     privacy_path = output_dir / privacy_filename
-                    write_json(privacy_risk, privacy_path, encryption_key=encryption_key)
+                    encryption_mode_privacy_risk = get_encryption_mode(privacy_risk, **kwargs)
+                    write_json(privacy_risk, privacy_path, encryption_key=encryption_key, encryption_mode=encryption_mode_privacy_risk)
 
                     result.add_artifact("json", privacy_path, f"{self.field_name} privacy risk assessment", category=Constants.Artifact_Category_Output)
                     reporter.add_artifact("json", str(privacy_path), f"{self.field_name} privacy risk assessment")
@@ -387,6 +491,11 @@ class EmailOperation(FieldOperation):
             result.add_metric("valid_percentage", analysis_results.get('valid_percentage', 0))
             result.add_metric("unique_domains", analysis_results.get('unique_domains', 0))
 
+            # Step 8: Finalization
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Operation complete", "status": "success"})
+
             # Add final operation status to reporter
             reporter.add_operation(f"Analysis of {self.field_name} completed", details={
                 "valid_emails": analysis_results.get('valid_count', 0),
@@ -395,10 +504,23 @@ class EmailOperation(FieldOperation):
                 "null_percentage": analysis_results.get('null_percentage', 0)
             })
 
+            # Cache the result if caching is enabled
+            if self.use_cache:
+                try:
+                    self._save_to_cache(
+                        artifacts=result.artifacts,
+                        original_df=df,
+                        metrics=result.metrics,
+                        task_dir=task_dir
+                    )
+                except Exception as e:
+                    # Failure to cache is non-critical
+                    self.logger.warning(f"Failed to cache results: {str(e)}")
+
             return result
 
         except Exception as e:
-            logger.exception(f"Error in email operation for {self.field_name}: {e}")
+            self.logger.exception(f"Error in email operation for {self.field_name}: {e}")
 
             # Update progress tracker on error
             if progress_tracker:
@@ -509,8 +631,521 @@ class EmailOperation(FieldOperation):
                 'most_frequent_examples': most_frequent
             }
         except Exception as e:
-            logger.error(f"Error in privacy risk assessment for {field_name}: {e}", exc_info=True)
+            self.logger.error(f"Error in privacy risk assessment for {field_name}: {e}", exc_info=True)
             return {}
+
+    def _create_visualizations(self,
+                               analysis_results: Dict[str, Dict[str, Any]],
+                               vis_dir: Path,
+                               include_timestamp: bool,
+                               result: OperationResult,
+                               reporter: Any,
+                               vis_theme: Optional[str] = None,
+                               vis_backend: Optional[str] = None,
+                               vis_strict: bool = False,
+                               **kwargs):
+        """
+        Create visualizations for k-anonymity metrics.
+
+        Parameters:
+        -----------
+        ka_metrics : Dict[str, Dict[str, Any]]
+            Dictionary mapping KA indices to their computed metrics.
+        field_uniqueness : Dict[str, Dict[str, Any]]
+            Dictionary with uniqueness statistics for each field.
+        vis_dir : Path
+            Directory where visualization files will be saved.
+        include_timestamp : bool
+            Whether to include a timestamp in output filenames.
+        result : OperationResult
+            The operation result object to which visualization artifacts will be added.
+        reporter : Any
+            Reporter object for logging and artifact registration.
+        vis_theme : Optional[str], default=None
+            Theme to use for visualizations.
+        vis_backend : Optional[str], default=None
+            Visualization backend to use (e.g., "matplotlib", "plotly").
+        vis_strict : bool, default=False
+            If True, enforce strict visualization rules and raise errors on failure.
+        **kwargs
+            Additional keyword arguments for visualization functions.
+        """
+        try:
+            
+            # Create visualization filename with extension "png"
+            viz_filename = get_timestamped_filename(
+                base_name=f"{self.field_name}_domains_distribution",
+                extension="png",
+                include_timestamp=include_timestamp
+            )
+            viz_path = vis_dir / viz_filename
+
+            # Create visualization using the visualization module
+            from pamola_core.utils.visualization import plot_email_domains
+            title = f"Top Email Domains in {self.field_name}"
+
+            viz_result = plot_email_domains(
+                domains=analysis_results['top_domains'],
+                output_path=str(viz_path),
+                title=title,
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
+                **kwargs
+            )
+
+            if not viz_result.startswith("Error"):
+                result.add_artifact("png", viz_path, f"{self.field_name} domains distribution", category=Constants.Artifact_Category_Visualization)
+                reporter.add_artifact("png", str(viz_path), f"{self.field_name} domains distribution")
+            else:
+                self.logger.warning(f"Error creating visualization: {viz_result}")
+
+        except Exception as e:
+            self.logger.error(f"Error creating visualizations: {e}", exc_info=True)
+            if reporter:
+                reporter.add_operation("Creating visualizations", status="warning",
+                                   details={"warning": f"Error creating some visualizations: {str(e)}"})
+                        
+
+    def _check_cache(
+            self,
+            data_source: DataSource,
+            dataset_name: str = "main",
+            **kwargs
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        data_source : DataSource
+            Data source for the operation
+        task_dir : Path
+            Task directory
+        dataset_name: str
+            Dataset name
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Get DataFrame from data source
+            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+            df = load_data_operation(data_source, dataset_name, **settings_operation)
+            if df is None:
+                self.logger.warning("No valid DataFrame found in data source")
+                return None
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                self.logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Add cached metrics to result
+                metrics = cached_data.get("metrics", {})
+                if isinstance(metrics, dict):
+                    for key, value in metrics.items():
+                        cached_result.add_metric(key, value)
+
+                # Add cached artifacts to result
+                artifacts = cached_data.get("artifacts", [])
+                if isinstance(artifacts, list):
+                    for artifact in artifacts:
+                        artifact_type = artifact.get("artifact_type", "")
+                        artifact_path = artifact.get("path", "")
+                        artifact_name = artifact.get("description", "")
+                        artifact_category = artifact.get("category", "output")
+                        cached_result.add_artifact(artifact_type, artifact_path, artifact_name, artifact_category) 
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+
+                return cached_result
+
+            self.logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+        
+    def _save_to_cache(
+            self,
+            original_df: pd.DataFrame,
+            artifacts: List[OperationArtifact],
+            metrics: Dict[str, Any],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame
+            Original input data
+        processed_df : pd.DataFrame
+            Processed DataFrame
+        metrics : dict
+            The metrics of operation
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache or (not artifacts and not metrics):
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            artifacts_for_cache = [artifact.to_dict() for artifact in artifacts]
+
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "artifacts": artifacts_for_cache,
+                "artifacts_test": artifacts,
+                "metrics": metrics,
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                self.logger.info(f"Successfully saved results to cache")
+            else:
+                self.logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+        
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "top_n": self.top_n,
+            "min_frequency": self.min_frequency,
+            "profile_type": self.profile_type,
+            "analyze_privacy_risk": self.analyze_privacy_risk,
+            "generate_plots": self.generate_plots,
+            "encryption_key": self.encryption_key,
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+    
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+        
+    
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type         
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+    def _handle_visualizations(
+            self,
+            analysis_results: Dict[str, Any],
+            vis_dir: Path,
+            include_timestamp: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str] = None,
+            vis_backend: Optional[str] = None,
+            vis_strict: bool = False,
+            vis_timeout: int = 120,
+            progress_tracker: Optional[HierarchicalProgressTracker] = None,
+            **kwargs
+    ) -> Dict[str, Path]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            DataFrame containing the data
+        analysis_results : Dict[str, Any]
+            Results of the analysis
+        vis_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
+        result : OperationResult
+            Operation result to add artifacts to
+        reporter : Any
+            Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        self.logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                self.logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        self.logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    self._create_visualizations(
+                        analysis_results,
+                        vis_dir,
+                        include_timestamp,
+                        result,
+                        reporter,
+                        vis_theme,
+                        vis_backend,
+                        vis_strict,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                self.logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                self.logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                self.logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            self.logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths
 
 
 def analyze_email_fields(
@@ -547,7 +1182,8 @@ def analyze_email_fields(
     """
     # Get DataFrame from data source
     dataset_name = kwargs.get('dataset_name', "main")
-    df = load_data_operation(data_source, dataset_name)
+    settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+    df = load_data_operation(data_source, dataset_name, **settings_operation)
     if df is None:
         reporter.add_operation("Email fields analysis", status="error",
                                details={"error": "No valid DataFrame found in data source"})
@@ -581,7 +1217,7 @@ def analyze_email_fields(
     overall_tracker = None
 
     if track_progress and email_fields:
-        overall_tracker = ProgressTracker(
+        overall_tracker = HierarchicalProgressTracker(
             total=len(email_fields),
             description=f"Analyzing {len(email_fields)} email fields",
             unit="fields",

--- a/pamola_core/profiling/analyzers/group.py
+++ b/pamola_core/profiling/analyzers/group.py
@@ -21,9 +21,12 @@ Key features:
 """
 
 import hashlib
+import json
 import logging
 from pathlib import Path
+import time
 from typing import Dict, List, Any, Optional, Union, Tuple, Set
+from datetime import datetime
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,15 +34,17 @@ import pandas as pd
 
 # Import only the essential base classes and utilities
 # Note: MinHash-related imports are moved to conditional imports inside methods
+from pamola_core.profiling.commons.group_utils import analyze_group, calculate_field_metrics
+from pamola_core.profiling.commons.helpers import filter_used_kwargs
 from pamola_core.utils.ops.op_base import BaseOperation
 from pamola_core.utils.ops.op_config import OperationConfig
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_data_writer import DataWriter
 from pamola_core.utils.ops.op_registry import register_operation
-from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.ops.op_result import OperationArtifact, OperationResult, OperationStatus
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.visualization import create_histogram, create_heatmap
-from pamola_core.utils.io import load_data_operation, load_settings_operation
+from pamola_core.utils.io import get_timestamped_filename, load_data_operation, load_settings_operation
 from pamola_core.common.constants import Constants
 
 # Configure module logger
@@ -69,6 +74,168 @@ class GroupAnalyzerConfig(OperationConfig):
     }
 
 
+class GroupAnalyzer:
+    def analyze(self,
+                df: pd.DataFrame,
+                field_name: str,
+                fields_config: Dict[str, int],
+                fields_to_analyze: List[str],
+                text_length_threshold: int = 100,
+                variance_threshold: float = 0.2,
+                large_group_threshold: int = 100,
+                large_group_variance_threshold: float = 0.05,
+                hash_algorithm: str = "md5",
+                minhash_similarity_threshold: float = 0.7,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                task_logger: Optional[logging.Logger] = None,
+                **kwargs) -> Dict[str, Any]:
+        """
+        Analyze grouped data to compute variance and duplication metrics for anonymization.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            The input DataFrame to analyze.
+        field_name : str
+            The column name to group data by.
+        fields_config : Dict[str, int]
+            Dictionary mapping field names to their weights for variance calculation.
+        fields_to_analyze : List[str]
+            List of field names to analyze within each group.
+        text_length_threshold : int, optional
+            Minimum length for text fields to be considered for hashing (default: 100).
+        variance_threshold : float, optional
+            Variance threshold for aggregation decision (default: 0.2).
+        large_group_threshold : int, optional
+            Threshold for considering a group as large (default: 100).
+        large_group_variance_threshold : float, optional
+            Variance threshold for large groups (default: 0.05).
+        hash_algorithm : str, optional
+            Algorithm for text comparison: "md5" or "minhash" (default: "md5").
+        minhash_similarity_threshold : float, optional
+            Similarity threshold for MinHash signatures (default: 0.7).
+        progress_tracker : Optional[HierarchicalProgressTracker], optional
+            Progress tracker for reporting progress (default: None).
+        task_logger : Optional[logging.Logger], optional
+            Logger for logging messages (default: None).
+        **kwargs
+            Additional keyword arguments passed to downstream utilities.
+
+        Returns:
+        --------
+        Dict[str, Any]
+        """
+        if task_logger:
+            logger = task_logger
+
+        # Step 2: Group data
+        if progress_tracker:
+            progress_tracker.update(1, {"step": "Grouping data"})
+
+        logger.info(f"Grouping data by field: {field_name}")
+
+        # Group data by field_name
+        grouped = df.groupby(field_name)
+        group_keys = list(grouped.groups.keys())
+
+        # Step 3: Analyze groups
+        if progress_tracker:
+            progress_tracker.update(1, {"step": "Analyzing groups"})
+
+        logger.info(f"Analyzing {len(group_keys)} groups")
+
+        # Initialize group analysis dictionary for storing metrics
+        group_metrics = {}
+
+        # Track variance distribution for visualization
+        variance_distribution = {
+            "below_0.1": 0,
+            "0.1_to_0.2": 0,
+            "0.2_to_0.5": 0,
+            "0.5_to_0.8": 0,
+            "above_0.8": 0
+        }
+
+        # Track field variances for visualization
+        field_variances = {field: [] for field in fields_to_analyze}
+
+        # Calculate metrics for each group
+        for i, group_key in enumerate(group_keys):
+            if progress_tracker and i % 100 == 0:
+                progress_tracker.update(0, {"step": "Analyzing groups", "processed": i, "total": len(group_keys)})
+
+            group_df = grouped.get_group(group_key)
+            group_metrics[str(group_key)] = analyze_group(
+                group_df=group_df,
+                fields=fields_to_analyze,
+                fields_config=fields_config,
+                text_length_threshold= text_length_threshold,
+                hash_algorithm=hash_algorithm,
+                use_minhash=(hash_algorithm == "minhash"),
+                minhash_similarity_threshold=minhash_similarity_threshold,
+                minhash_cache={},
+                large_group_threshold=large_group_threshold,
+                large_group_variance_threshold=large_group_variance_threshold,
+                variance_threshold=variance_threshold,
+            )
+
+            # Update variance distribution
+            weighted_variance = group_metrics[str(group_key)]["weighted_variance"]
+            if weighted_variance < 0.1:
+                variance_distribution["below_0.1"] += 1
+            elif weighted_variance < 0.2:
+                variance_distribution["0.1_to_0.2"] += 1
+            elif weighted_variance < 0.5:
+                variance_distribution["0.2_to_0.5"] += 1
+            elif weighted_variance < 0.8:
+                variance_distribution["0.5_to_0.8"] += 1
+            else:
+                variance_distribution["above_0.8"] += 1
+
+            # Update field variances
+            for field in fields_to_analyze:
+                field_variances[field].append(group_metrics[str(group_key)]["field_variances"].get(field, 0))
+
+        # Calculate overall metrics
+        field_metrics = calculate_field_metrics(group_metrics, fields_to_analyze)
+
+        # Calculate average variance across all fields and groups
+        all_variances = []
+        for metrics in group_metrics.values():
+            all_variances.append(metrics["weighted_variance"])
+
+        avg_variance = np.mean(all_variances) if all_variances else 0
+        max_variance = np.max(all_variances) if all_variances else 0
+
+        # Count groups that can be aggregated
+        groups_to_aggregate = 0
+        for metrics in group_metrics.values():
+            if metrics["should_aggregate"]:
+                groups_to_aggregate += 1
+
+        # Build metrics object
+        metrics = {
+            "field": field_name,
+            "total_groups": len(group_keys),
+            "total_records": len(df),
+            "avg_variance": float(avg_variance),
+            "max_variance": float(max_variance),
+            "groups_to_aggregate": groups_to_aggregate,
+            "field_metrics": field_metrics,
+            "group_metrics": group_metrics,
+            "threshold_metrics": variance_distribution,
+            "algorithm_info": {
+                "hash_algorithm_used": hash_algorithm,
+                "text_length_threshold": text_length_threshold,
+                "variance_threshold": variance_threshold,
+                "large_group_threshold": large_group_threshold,
+                "large_group_variance_threshold": large_group_variance_threshold,
+                "minhash_similarity_threshold": minhash_similarity_threshold
+            },
+            "fields_analyzed": fields_to_analyze
+        }
+        return metrics
+
 class GroupAnalyzerOperation(BaseOperation):
     """
     Operation for analyzing variability within groups of records.
@@ -90,6 +257,17 @@ class GroupAnalyzerOperation(BaseOperation):
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
                  name: str = "group_analyzer",
+                 encryption_mode: Optional[str] = None,
+                 chunk_size: int = 10000,
+                 use_dask: bool = False,
+                 use_cache: bool = True,
+                 use_vectorization: bool = False,
+                 npartitions: Optional[int] = 1,
+                 parallel_processes: Optional[int] = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
                  description: str = ""):
         """
         Initialize the group analyzer operation.
@@ -132,7 +310,8 @@ class GroupAnalyzerOperation(BaseOperation):
             hash_algorithm=hash_algorithm,
             minhash_similarity_threshold=minhash_similarity_threshold,
             use_encryption=use_encryption,
-            encryption_key=encryption_key,     
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode     
         )
 
         # Use a default description if none provided
@@ -144,7 +323,8 @@ class GroupAnalyzerOperation(BaseOperation):
             name=name,
             description=description,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
         )
 
         # Store parameters
@@ -156,7 +336,21 @@ class GroupAnalyzerOperation(BaseOperation):
         self.large_group_variance_threshold = large_group_variance_threshold
         self.hash_algorithm = hash_algorithm.lower()
         self.minhash_similarity_threshold = minhash_similarity_threshold
-        self.use_minhash = self.hash_algorithm == "minhash"     
+        self.use_minhash = self.hash_algorithm == "minhash"
+
+        self.use_dask = use_dask
+        self.use_cache = use_cache
+        self.use_vectorization = use_vectorization
+        self.chunk_size = chunk_size
+        self.npartitions = npartitions
+        self.parallel_processes = parallel_processes
+        self.encryption_key = encryption_key
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
+
+        self.analyzer = GroupAnalyzer()
 
         # Cache for MinHash signatures to avoid recomputation - only initialized if needed
         self.minhash_cache = {}
@@ -171,7 +365,7 @@ class GroupAnalyzerOperation(BaseOperation):
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the group analyzer operation.
@@ -184,16 +378,36 @@ class GroupAnalyzerOperation(BaseOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : Optional[ProgressTracker]
+        progress_tracker : Optional[HierarchicalProgressTracker]
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation
+            - include_timestamp: bool, whether to include timestamps in filenames, default = True
+            - force_recalculation: bool - Skip cache check
+            - parallel_processes: int - Number of parallel processes
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
+        self.use_vectorization = kwargs.get('use_vectorization', self.use_vectorization)
+        self.npartitions = kwargs.get('npartitions', self.npartitions)
+        self.parallel_processes = kwargs.get('parallel_processes', self.parallel_processes)
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+        self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+        self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+        self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+        force_recalculation = kwargs.get("force_recalculation", False)
+        include_timestamp = kwargs.get('include_timestamp', True)
+
+        # Use the subset name instead of "main" to get the correct dataframe
+        dataset_name = kwargs.get('dataset_name', 'main')
+
+
         self.logger.info(f"Starting group analysis for field: {self.field_name}")
 
         # Initialize result object
@@ -202,26 +416,58 @@ class GroupAnalyzerOperation(BaseOperation):
         # Create data writer
         writer = DataWriter(task_dir=task_dir, logger=self.logger, progress_tracker=progress_tracker)
 
-        # Set up progress tracking
-        total_steps = 5  # Data loading, grouping, analysis, visualization, saving
+        # Preparation, Cache Check, Data Loading, Grouping, Visualizations, Saving results
+        total_steps = 5 + (1 if self.use_cache and not force_recalculation else 0)
+        current_steps = 0
+
+        # Step 1: Preparation
         if progress_tracker:
             progress_tracker.total = total_steps
-            progress_tracker.update(0, {"step": "Starting group analysis", "field": self.field_name})
+            progress_tracker.update(current_steps, {"step": "Starting group analysis", "field": self.field_name})
 
+        # Step 2: Check Cache (if enabled and not forced to recalculate)
+        if self.use_cache and not force_recalculation:
+            if progress_tracker:
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Checking Cache"})
+
+            self.logger.info("Checking operation cache...")
+            cache_result = self._check_cache(data_source, dataset_name)
+
+            if cache_result:
+                self.logger.info("Cache hit! Using cached results.")
+
+                # Update progress
+                if progress_tracker:
+                    progress_tracker.update(total_steps,{"step": "Complete (cached)"})
+
+                # Report cache hit to reporter
+                if reporter:
+                    reporter.add_operation(
+                        f"Clean invalid values (from cache)",
+                        details={"cached": True}
+                    )
+                return cache_result
+            
         try:
             dirs = self._prepare_directories(task_dir)
             visualizations_dir = dirs['visualizations']
             output_dir = dirs['output']
 
-            # Step 1: Load data
+            # Step 3: Load data
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Loading data"})
+                current_steps += 1
+                progress_tracker.update(current_steps, {"step": "Loading data"})
 
             self.logger.info(f"Loading data for: {self.field_name}")
-            # Use the subset name instead of "main" to get the correct dataframe
-            dataset_name = kwargs.get('dataset_name', 'main')
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
             df = load_data_operation(data_source, dataset_name, **settings_operation)
+
+            if df is None:
+                return OperationResult(
+                    status=OperationStatus.ERROR,
+                    error_message="No valid DataFrame found in data source"
+                )
 
             # Save configuration
             self.save_config(task_dir)
@@ -241,118 +487,52 @@ class GroupAnalyzerOperation(BaseOperation):
                 self.logger.error(error_message)
                 return OperationResult(status=OperationStatus.ERROR, error_message=error_message)
 
-            # Step 2: Group data
+            # Step 4: Group data by the specified field
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Grouping data"})
+                current_steps+=1
+                progress_tracker.update(current_steps, {"step": "Grouping data"})
+            
+            safe_kwargs = filter_used_kwargs(kwargs, GroupAnalyzer.analyze)
+            metrics = self.analyzer.analyze(
+                df=df,
+                field_name=self.field_name,
+                fields_config=self.fields_config,
+                fields_to_analyze=fields_to_analyze,
+                hash_algorithm=self.hash_algorithm,
+                large_group_threshold=self.large_group_threshold,
+                large_group_variance_threshold=self.large_group_variance_threshold,
+                minhash_similarity_threshold=self.minhash_similarity_threshold,
+                text_length_threshold=self.text_length_threshold,
+                variance_threshold=self.variance_threshold,
+                progress_tracker=progress_tracker,
+                task_logger=self.logger,
+                **safe_kwargs
+            )
 
-            self.logger.info(f"Grouping data by field: {self.field_name}")
-
-            # Group data by field_name
-            grouped = df.groupby(self.field_name)
-            group_keys = list(grouped.groups.keys())
-
-            # Step 3: Analyze groups
+            # Step 5: Generate visualizations
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Analyzing groups"})
-
-            self.logger.info(f"Analyzing {len(group_keys)} groups")
-
-            # Initialize group analysis dictionary for storing metrics
-            group_metrics = {}
-
-            # Track variance distribution for visualization
-            variance_distribution = {
-                "below_0.1": 0,
-                "0.1_to_0.2": 0,
-                "0.2_to_0.5": 0,
-                "0.5_to_0.8": 0,
-                "above_0.8": 0
-            }
-
-            # Track field variances for visualization
-            field_variances = {field: [] for field in fields_to_analyze}
-
-            # Calculate metrics for each group
-            for i, group_key in enumerate(group_keys):
-                if progress_tracker and i % 100 == 0:
-                    progress_tracker.update(0, {"step": "Analyzing groups", "processed": i, "total": len(group_keys)})
-
-                group_df = grouped.get_group(group_key)
-                group_metrics[str(group_key)] = self._analyze_group(group_df, fields_to_analyze)
-
-                # Update variance distribution
-                weighted_variance = group_metrics[str(group_key)]["weighted_variance"]
-                if weighted_variance < 0.1:
-                    variance_distribution["below_0.1"] += 1
-                elif weighted_variance < 0.2:
-                    variance_distribution["0.1_to_0.2"] += 1
-                elif weighted_variance < 0.5:
-                    variance_distribution["0.2_to_0.5"] += 1
-                elif weighted_variance < 0.8:
-                    variance_distribution["0.5_to_0.8"] += 1
-                else:
-                    variance_distribution["above_0.8"] += 1
-
-                # Update field variances
-                for field in fields_to_analyze:
-                    field_variances[field].append(group_metrics[str(group_key)]["field_variances"].get(field, 0))
-
-            # Calculate overall metrics
-            field_metrics = self._calculate_field_metrics(group_metrics, fields_to_analyze)
-
-            # Calculate average variance across all fields and groups
-            all_variances = []
-            for metrics in group_metrics.values():
-                all_variances.append(metrics["weighted_variance"])
-
-            avg_variance = np.mean(all_variances) if all_variances else 0
-            max_variance = np.max(all_variances) if all_variances else 0
-
-            # Count groups that can be aggregated
-            groups_to_aggregate = 0
-            for metrics in group_metrics.values():
-                if metrics["should_aggregate"]:
-                    groups_to_aggregate += 1
-
-            # Build metrics object
-            metrics = {
-                "field": self.field_name,
-                "total_groups": len(group_keys),
-                "total_records": len(df),
-                "avg_variance": float(avg_variance),
-                "max_variance": float(max_variance),
-                "groups_to_aggregate": groups_to_aggregate,
-                "field_metrics": field_metrics,
-                "group_metrics": group_metrics,
-                "threshold_metrics": variance_distribution,
-                "algorithm_info": {
-                    "hash_algorithm_used": self.hash_algorithm,
-                    "text_length_threshold": self.text_length_threshold,
-                    "variance_threshold": self.variance_threshold,
-                    "large_group_threshold": self.large_group_threshold,
-                    "large_group_variance_threshold": self.large_group_variance_threshold,
-                    "minhash_similarity_threshold": self.minhash_similarity_threshold
-                },
-                "fields_analyzed": fields_to_analyze
-            }
-
-            # Step 4: Generate visualizations
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Generating visualizations"})
+                current_steps+=1
+                progress_tracker.update(current_steps, {"step": "Generating visualizations"})
 
             self.logger.info(f"Generating visualizations")
+            self._handle_visualizations(
+                threshold_metrics = metrics['threshold_metrics'],
+                field_metrics=metrics['field_metrics'],
+                vis_dir=visualizations_dir,
+                include_timestamp = include_timestamp,
+                result=result,
+                reporter=reporter,
+                vis_theme=self.visualization_theme,
+                vis_backend=self.visualization_backend,
+                vis_strict=self.visualization_strict,
+                vis_timeout=self.visualization_timeout,
+                progress_tracker=progress_tracker,
+            )
 
-            # Generate variance distribution histogram
-            variance_dist_path = visualizations_dir / f"{self.__class__.__name__}_{self.field_name}_variance_dist.png"
-            self._generate_variance_distribution(variance_distribution, variance_dist_path, **kwargs)
-
-            # Generate field variability heatmap
-            field_heatmap_path = visualizations_dir / f"{self.__class__.__name__}_{self.field_name}_field_heatmap.png"
-            self._generate_field_heatmap(field_metrics, field_heatmap_path, **kwargs)
-
-            # Step 5: Save results
+            # Step 6: Save results
             if progress_tracker:
-                progress_tracker.update(1, {"step": "Saving results"})
+                current_steps+=1
+                progress_tracker.update(current_steps, {"step": "Saving results"})
 
             self.logger.info(f"Saving metrics")
 
@@ -377,24 +557,14 @@ class GroupAnalyzerOperation(BaseOperation):
                 category=Constants.Artifact_Category_Metrics
             )
 
-            result.add_artifact(
-                artifact_type="png",
-                path=variance_dist_path,
-                description=f"{self.__class__.__name__} {self.field_name} variance distribution histogram",
-                category=Constants.Artifact_Category_Visualization
-            )
-
-            result.add_artifact(
-                artifact_type="png",
-                path=field_heatmap_path,
-                description=f"{self.__class__.__name__} {self.field_name} field variability heatmap",
-                category=Constants.Artifact_Category_Visualization
-            )
-
             # Set success status
             result.status = OperationStatus.SUCCESS
 
             self.logger.info(f"Group analysis for {self.field_name} completed successfully")
+
+            # Group data by field_name
+            grouped = df.groupby(self.field_name)
+            group_keys = list(grouped.groups.keys())
 
             # Report to reporter if available
             if reporter:
@@ -402,8 +572,8 @@ class GroupAnalyzerOperation(BaseOperation):
                     f"Group analysis for {self.field_name}",
                     details={
                         "total_groups": len(group_keys),
-                        "groups_to_aggregate": groups_to_aggregate,
-                        "avg_variance": avg_variance
+                        "groups_to_aggregate": metrics['groups_to_aggregate'],
+                        "avg_variance": metrics['avg_variance']
                     }
                 )
 
@@ -413,69 +583,12 @@ class GroupAnalyzerOperation(BaseOperation):
                     f"{self.__class__.__name__} {self.field_name} group analysis metrics"
                 )
 
-                reporter.add_artifact(
-                    "png",
-                    str(variance_dist_path),
-                    f"{self.__class__.__name__} {self.field_name} variance distribution histogram"
-                )
-
-                reporter.add_artifact(
-                    "png",
-                    str(field_heatmap_path),
-                    f"{self.__class__.__name__} {self.field_name} field variability heatmap"
-                )
-
             return result
 
         except Exception as e:
             error_message = f"Error executing group analysis: {str(e)}"
             self.logger.error(error_message, exc_info=True)
             return OperationResult(status=OperationStatus.ERROR, error_message=error_message)
-
-    def _analyze_group(self, group_df: pd.DataFrame, fields: List[str]) -> Dict[str, Any]:
-        """
-        Analyze a single group of records.
-
-        Parameters:
-        -----------
-        group_df : pd.DataFrame
-            DataFrame containing records for a single group
-        fields : List[str]
-            Fields to analyze
-
-        Returns:
-        --------
-        Dict[str, Any]
-            Dictionary with group metrics
-        """
-        # Initialize metrics
-        field_variances = {}
-        duplication_ratios = {}
-
-        # Calculate variance and duplication ratio for each field
-        for field in fields:
-            # Calculate variance for this field
-            variance, duplications = self._calculate_field_variance(group_df[field])
-            field_variances[field] = variance
-            duplication_ratios[field] = duplications
-
-        # Calculate weighted variance
-        weighted_variance = self._calculate_weighted_variance(field_variances)
-
-        # Determine if this group should be aggregated
-        should_aggregate = self._should_aggregate(weighted_variance, len(group_df))
-
-        # Get max field variance
-        max_field_variance = max(field_variances.values()) if field_variances else 0
-
-        return {
-            "weighted_variance": weighted_variance,
-            "max_field_variance": max_field_variance,
-            "total_records": len(group_df),
-            "field_variances": field_variances,
-            "duplication_ratios": duplication_ratios,
-            "should_aggregate": should_aggregate
-        }
 
     def _calculate_field_variance(self, field_series: pd.Series) -> Tuple[float, float]:
         """
@@ -703,105 +816,6 @@ class GroupAnalyzerOperation(BaseOperation):
 
         return intersection / union if union > 0 else 0.0
 
-    def _calculate_weighted_variance(self, field_variances: Dict[str, float]) -> float:
-        """
-        Calculate weighted variance across all fields.
-
-        Parameters:
-        -----------
-        field_variances : Dict[str, float]
-            Dictionary mapping field names to their variance values
-
-        Returns:
-        --------
-        float
-            Weighted variance across all fields
-        """
-        weighted_sum = 0
-        total_weight = 0
-
-        for field, variance in field_variances.items():
-            weight = self.fields_config.get(field, 1)
-            weighted_sum += variance * weight
-            total_weight += weight
-
-        return weighted_sum / total_weight if total_weight > 0 else 0
-
-    def _should_aggregate(self, weighted_variance: float, group_size: int) -> bool:
-        """
-        Determine if a group should be aggregated based on variance and size.
-
-        Parameters:
-        -----------
-        weighted_variance : float
-            Weighted variance of the group
-        group_size : int
-            Number of records in the group
-
-        Returns:
-        --------
-        bool
-            True if the group should be aggregated, False otherwise
-        """
-        # Apply different thresholds based on group size
-        if group_size > self.large_group_threshold:
-            return weighted_variance <= self.large_group_variance_threshold
-        else:
-            return weighted_variance <= self.variance_threshold
-
-    def _calculate_field_metrics(self, group_metrics: Dict[str, Dict[str, Any]], fields: List[str]) -> Dict[
-        str, Dict[str, float]]:
-        """
-        Calculate metrics for each field across all groups.
-
-        Parameters:
-        -----------
-        group_metrics : Dict[str, Dict[str, Any]]
-            Dictionary with metrics for each group
-        fields : List[str]
-            List of fields to analyze
-
-        Returns:
-        --------
-        Dict[str, Dict[str, float]]
-            Dictionary with metrics for each field
-        """
-        field_metrics = {}
-
-        for field in fields:
-            # Initialize metrics for this field
-            field_metrics[field] = {
-                "avg_variance": 0,
-                "max_variance": 0,
-                "avg_duplication_ratio": 0,
-                "unique_values_total": 0
-            }
-
-            # Collect variances and duplication ratios for this field
-            variances = []
-            duplication_ratios = []
-            unique_values_count = 0
-
-            for group_data in group_metrics.values():
-                if field in group_data["field_variances"]:
-                    variances.append(group_data["field_variances"][field])
-
-                if field in group_data["duplication_ratios"]:
-                    duplication_ratios.append(group_data["duplication_ratios"][field])
-
-                    # Estimate unique values from duplication ratio: total_records / duplication_ratio
-                    if group_data["duplication_ratios"][field] > 0:
-                        unique_values_count += group_data["total_records"] / group_data["duplication_ratios"][field]
-
-            # Calculate average and max values
-            field_metrics[field]["avg_variance"] = float(np.mean(variances)) if variances else 0
-            field_metrics[field]["max_variance"] = float(np.max(variances)) if variances else 0
-            field_metrics[field]["avg_duplication_ratio"] = float(
-                np.mean(duplication_ratios)) if duplication_ratios else 0
-            field_metrics[field]["unique_values_total"] = int(unique_values_count)
-
-        return field_metrics
-
     def _generate_variance_distribution(self, variance_distribution: Dict[str, int], output_path: Path, **kwargs):
         """
         Generate a histogram of variance distribution.
@@ -967,6 +981,447 @@ class GroupAnalyzerOperation(BaseOperation):
             except Exception as e2:
                 self.logger.error(f"Failed to generate fallback visualization: {str(e2)}")
 
+    def _check_cache(
+            self,
+            data_source: DataSource,
+            dataset_name: str = "main",
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        data_source : DataSource
+            Data source for the operation
+        task_dir : Path
+            Task directory
+        dataset_name: str
+            Dataset name
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Get DataFrame from data source
+            df = load_data_operation(data_source, dataset_name)
+            if df is None:
+                self.logger.warning("No valid DataFrame found in data source")
+                return None
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                self.logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Add cached metrics to result
+                metrics = cached_data.get("metrics", {})
+                if isinstance(metrics, dict):
+                    for key, value in metrics.items():
+                        cached_result.add_metric(key, value)
+
+                # Add cached artifacts to result
+                artifacts = cached_data.get("artifacts", [])
+                if isinstance(artifacts, list):
+                    for artifact in artifacts:
+                        artifact_type = artifact.get("artifact_type", "")
+                        artifact_path = artifact.get("path", "")
+                        artifact_name = artifact.get("description", "")
+                        artifact_category = artifact.get("category", "output")
+                        cached_result.add_artifact(artifact_type, artifact_path, artifact_name, artifact_category) 
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+
+                return cached_result
+
+            self.logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+        
+    def _save_to_cache(
+            self,
+            original_df: pd.DataFrame,
+            artifacts: List[OperationArtifact],
+            metrics: Dict[str, Any],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame
+            Original input data
+        processed_df : pd.DataFrame
+            Processed DataFrame
+        metrics : dict
+            The metrics of operation
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache or (not artifacts and not metrics):
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            artifacts_for_cache = [artifact.to_dict() for artifact in artifacts]
+
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "artifacts": artifacts_for_cache,
+                "artifacts_test": artifacts,
+                "metrics": metrics,
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                self.logger.info(f"Successfully saved results to cache")
+            else:
+                self.logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+        
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "field_name": self.field_name,
+            "fields_config": self.fields_config,
+            "text_length_threshold": self.text_length_threshold,
+            "variance_threshold": self.variance_threshold,
+            "large_group_threshold": self.large_group_threshold,
+            "large_group_variance_threshold": self.large_group_variance_threshold,
+            "hash_algorithm": self.hash_algorithm,
+            "minhash_similarity_threshold": self.minhash_similarity_threshold,
+            "encryption_key": self.encryption_key
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+    
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+        
+    
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type         
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+    
+    def _handle_visualizations(
+            self,
+            threshold_metrics: Dict[str, Any],
+            field_metrics: Dict[str, Any],
+            vis_dir: Path,
+            include_timestamp: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str] = None,
+            vis_backend: Optional[str] = None,
+            vis_strict: bool = False,
+            vis_timeout: int = 120,
+            progress_tracker: Optional[HierarchicalProgressTracker] = None,
+            **kwargs
+    ) -> Dict[str, Path]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        threshold_metrics : Dict[str, Any]
+            Dictionary containing variance distribution metrics (e.g., group counts by variance range).
+        field_metrics : Dict[str, Any]
+            Dictionary containing per-field metrics (e.g., avg/max variance, duplication ratios).
+        vis_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in output filenames
+        result : OperationResult
+            Operation result to add artifacts to
+        reporter : Any
+            Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        self.logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                self.logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        self.logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    # Generate variance distribution histogram
+                    variance_dist_filename = get_timestamped_filename(f"{self.__class__.__name__}_{self.field_name}_variance_dist", "png",
+                                                         include_timestamp)
+                    variance_dist_path = vis_dir / variance_dist_filename
+                    self._generate_variance_distribution(threshold_metrics, variance_dist_path, **kwargs)
+                    visualization_paths.update({"variance_dist_path": variance_dist_path})
+                    # Generate field variability heatmap
+                    field_heatmap_filename = get_timestamped_filename(f"{self.__class__.__name__}_{self.field_name}_field_heatmap", "png",
+                                                         include_timestamp)
+                    field_heatmap_path = vis_dir / field_heatmap_filename
+                    self._generate_field_heatmap(field_metrics, field_heatmap_path, **kwargs)
+                    visualization_paths.update({"field_heatmap_path": field_heatmap_path})
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                self.logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                self.logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                self.logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            self.logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths
 
 # Register the operation so it's discoverable
 register_operation(GroupAnalyzerOperation)

--- a/pamola_core/profiling/analyzers/identity.py
+++ b/pamola_core/profiling/analyzers/identity.py
@@ -12,28 +12,35 @@ It integrates with the utility modules:
 - logging.py: For operation logging
 """
 
+from datetime import datetime
 import logging
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Union
-
+import time
+from typing import Dict, List, Any, Optional, Tuple, Union
 import pandas as pd
 
 from pamola_core.profiling.commons.identity_utils import (
     analyze_identifier_distribution,
     analyze_identifier_consistency,
     find_cross_matches,
-    compute_identifier_stats
+    compute_identifier_stats,
+    generate_consistency_analysis_vis,
+    generate_cross_match_distribution_vis,
+    generate_field_distribution_vis,
+    generate_identifier_statistics_vis,
 )
-from pamola_core.utils.io import write_json, ensure_directory, get_timestamped_filename, load_data_operation, load_settings_operation
+from pamola_core.utils.io import (
+    load_data_operation,
+    load_settings_operation,
+)
 from pamola_core.utils.ops.op_base import FieldOperation
+from pamola_core.utils.ops.op_cache import OperationCache
+from pamola_core.utils.ops.op_config import OperationConfig
 from pamola_core.utils.ops.op_data_source import DataSource
+from pamola_core.utils.ops.op_data_writer import DataWriter
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
-from pamola_core.utils.progress import ProgressTracker
-from pamola_core.utils.visualization import (
-    plot_value_distribution,
-    create_bar_plot  # Using bar plot instead of pie chart
-)
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.common.constants import Constants
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -49,10 +56,12 @@ class IdentityAnalyzer:
     """
 
     @staticmethod
-    def analyze_identifier_distribution(df: pd.DataFrame,
-                                        id_field: str,
-                                        entity_field: Optional[str] = None,
-                                        top_n: int = 15) -> Dict[str, Any]:
+    def analyze_identifier_distribution(
+        df: pd.DataFrame,
+        id_field: str,
+        entity_field: Optional[str] = None,
+        top_n: int = 15,
+    ) -> Dict[str, Any]:
         """
         Analyze the distribution of entities per identifier.
 
@@ -75,9 +84,9 @@ class IdentityAnalyzer:
         return analyze_identifier_distribution(df, id_field, entity_field, top_n)
 
     @staticmethod
-    def analyze_identifier_consistency(df: pd.DataFrame,
-                                       id_field: str,
-                                       reference_fields: List[str]) -> Dict[str, Any]:
+    def analyze_identifier_consistency(
+        df: pd.DataFrame, id_field: str, reference_fields: List[str]
+    ) -> Dict[str, Any]:
         """
         Analyze consistency between an identifier and reference fields.
 
@@ -98,11 +107,13 @@ class IdentityAnalyzer:
         return analyze_identifier_consistency(df, id_field, reference_fields)
 
     @staticmethod
-    def find_cross_matches(df: pd.DataFrame,
-                           id_field: str,
-                           reference_fields: List[str],
-                           min_similarity: float = 0.8,
-                           fuzzy_matching: bool = False) -> Dict[str, Any]:
+    def find_cross_matches(
+        df: pd.DataFrame,
+        id_field: str,
+        reference_fields: List[str],
+        min_similarity: float = 0.8,
+        fuzzy_matching: bool = False,
+    ) -> Dict[str, Any]:
         """
         Find cases where reference fields match but identifiers differ.
 
@@ -124,12 +135,14 @@ class IdentityAnalyzer:
         Dict[str, Any]
             Cross-matching analysis results
         """
-        return find_cross_matches(df, id_field, reference_fields, min_similarity, fuzzy_matching)
+        return find_cross_matches(
+            df, id_field, reference_fields, min_similarity, fuzzy_matching
+        )
 
     @staticmethod
-    def compute_identifier_stats(df: pd.DataFrame,
-                                 id_field: str,
-                                 entity_field: Optional[str] = None) -> Dict[str, Any]:
+    def compute_identifier_stats(
+        df: pd.DataFrame, id_field: str, entity_field: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Compute basic statistics about an identifier field.
 
@@ -150,6 +163,47 @@ class IdentityAnalyzer:
         return compute_identifier_stats(df, id_field, entity_field)
 
 
+class IdentityAnalysisOperationConfig(OperationConfig):
+    """Configuration for IdentityAnalysisOperation."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "uid_field": {"type": "string"},
+            "reference_fields": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+            },
+            "id_field": {"type": ["string", "null"]},
+            "top_n": {"type": "integer", "minimum": 1, "default": 15},
+            "check_cross_matches": {"type": "boolean", "default": True},
+            "min_similarity": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.8,
+            },
+            "fuzzy_matching": {"type": "boolean", "default": False},
+            "use_cache": {"type": "boolean"},
+            "use_encryption": {"type": "boolean"},
+            "encryption_key": {"type": ["string", "null"]},
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {
+                "type": ["string", "null"],
+                "enum": ["plotly", "matplotlib", None],
+            },
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
+        },
+        "required": [
+            "uid_field",
+            "reference_fields",
+        ],
+    }
+
+
 @register(version="1.0.0")
 class IdentityAnalysisOperation(FieldOperation):
     """
@@ -161,18 +215,24 @@ class IdentityAnalysisOperation(FieldOperation):
     3. Cross-matching of identifiers
     """
 
-    def __init__(self,
-                 uid_field: str,
-                 reference_fields: List[str],
-                 id_field: Optional[str] = None,
-                 top_n: int = 15,
-                 check_cross_matches: bool = None,
-                 include_timestamp: bool = None,
-                 min_similarity: float = 0.8,
-                 fuzzy_matching: bool = None,
-                 description: str = "",
-                 use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+    def __init__(
+        self,
+        uid_field: str,
+        reference_fields: List[str],
+        id_field: Optional[str] = None,
+        top_n: int = 15,
+        check_cross_matches: bool = True,
+        min_similarity: float = 0.8,
+        fuzzy_matching: bool = False,
+        description: str = "",
+        use_encryption: bool = False,
+        encryption_key: Optional[Union[str, Path]] = None,
+        use_cache: bool = True,
+        visualization_theme: Optional[str] = None,
+        visualization_backend: Optional[str] = None,
+        visualization_strict: bool = False,
+        visualization_timeout: int = 120,
+    ):
         """
         Initialize the identity analysis operation.
 
@@ -184,29 +244,95 @@ class IdentityAnalysisOperation(FieldOperation):
             Fields that can be used to identify an entity (e.g., ['first_name', 'last_name', 'birth_day'])
         id_field : Optional[str]
             Entity identifier field (e.g., 'resume_id'), used to analyze entities per identifier
+        top_n : int
+            Number of top entries to include (default: 15)
+        check_cross_matches : bool
+            Whether to check for cross matches (default: True)
+        min_similarity : float
+            Minimum similarity for fuzzy matching (default: 0.8)
+        fuzzy_matching : bool
+            Whether to use fuzzy matching (default: False)
         description : str
             Description of the operation (optional)
+        use_encryption : bool
+            Whether to use encryption (default: False)
+        encryption_key : Optional[Union[str, Path]]
+            Encryption key to use for sensitive data (default: None)
+        use_cache : bool
+            Whether to use caching (default: True)
+        visualization_theme : Optional[str]
+            Theme to use for visualizations (default: None)
+        visualization_backend : Optional[str]
+            Backend to use for visualizations (default: None)
+        visualization_strict : bool
+            Whether to enforce strict visualization rules (default: False)
+        visualization_timeout : int
+            Timeout for visualizations in seconds (default: 120)
         """
+        # Use default description if not provided
+        if not description:
+            description = f"Analysis of identity field '{uid_field}'"
+
+        # Build config parameters, excluding None values for optional fields
+        config_params = {
+            "uid_field": uid_field,
+            "reference_fields": reference_fields or [],
+            "id_field": id_field,
+            "top_n": top_n,
+            "check_cross_matches": check_cross_matches,
+            "min_similarity": min_similarity,
+            "fuzzy_matching": fuzzy_matching,
+            "use_cache": use_cache,
+            "use_encryption": use_encryption,
+            "encryption_key": encryption_key,
+            "visualization_theme": visualization_theme,
+            "visualization_backend": visualization_backend,
+            "visualization_strict": visualization_strict,
+            "visualization_timeout": visualization_timeout,
+        }
+
+        # Create configuration and validate parameters
+        config = IdentityAnalysisOperationConfig(**config_params)
+
         super().__init__(
             field_name=uid_field,
-            description=description or f"Analysis of identity field '{uid_field}'",
+            description=description,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            config=config,
         )
-        self.reference_fields = reference_fields
-        self.id_field = id_field
-        self.top_n = top_n
-        self.check_cross_matches = check_cross_matches
-        self.include_timestamp = include_timestamp
-        self.min_similarity = min_similarity
-        self.fuzzy_matching = fuzzy_matching
 
-    def execute(self,
-                data_source: DataSource,
-                task_dir: Path,
-                reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
-                **kwargs) -> OperationResult:
+        # Assign instance properties from config
+        for key, value in config_params.items():
+            setattr(self, key, value)
+
+        # Optionally store the config
+        self.config = config
+
+        # Set up performance tracking variables
+        self.start_time = None
+        self.end_time = None
+        self.process_count = 0
+
+        # Set up common variables
+        self.force_recalculation = False  # Skip cache check
+        self.generate_visualization = True  # Create visualizations
+        self.encrypt_output = False  # Override encryption setting
+
+        # Updated version for fixes
+        self.version = "1.4.1"
+
+        # Temporary storage for cleanup
+        self.operation_cache = None
+
+    def execute(
+        self,
+        data_source: DataSource,
+        task_dir: Path,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        **kwargs,
+    ) -> OperationResult:
         """
         Execute the identity analysis operation.
 
@@ -218,338 +344,1490 @@ class IdentityAnalysisOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
-            Additional parameters for the operation:
-            - top_n : int, number of top entries to include (default: 15)
-            - check_cross_matches : bool, whether to analyze cross matches (default: True)
-            - include_timestamp : bool, whether to include timestamps (default: True)
-            - min_similarity : float, similarity threshold for fuzzy matching (default: 0.8)
-            - fuzzy_matching : bool, whether to use fuzzy matching (default: False)
+            Additional parameters for the operation including:
+            - force_recalculation: bool - Skip cache check
+            - generate_visualization: bool - Create visualizations
+            - encrypt_output: bool - Override encryption setting
+            - visualization_theme: str - Override theme for visualizations
+            - visualization_backend: str - Override backend for visualizations
+            - visualization_strict: bool - Override strict mode for visualizations
+            - visualization_timeout: int - Override timeout for visualizations
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
-        # Extract parameters from kwargs
-        global distribution_analysis, cross_match_analysis
-        top_n = kwargs.get('top_n', self.top_n)
-        check_cross_matches = kwargs.get('check_cross_matches', self.check_cross_matches)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        min_similarity = kwargs.get('min_similarity', self.min_similarity)
-        fuzzy_matching = kwargs.get('fuzzy_matching', self.fuzzy_matching)
-        encryption_key = kwargs.get('encryption_key', None)
+        # Initialize global analysis dictionaries
+        global identifier_stats, consistency_analysis, distribution_analysis, cross_match_analysis
+        identifier_stats = {}
+        consistency_analysis = {}
+        distribution_analysis = {}
+        cross_match_analysis = {}
+        # Initialize timing and result
+        self.start_time = time.time()
+        self.logger = kwargs.get("logger", self.logger)
+        self.logger.info(f"Starting {self.name} operation at {self.start_time}")
+        self.process_count = 0
+        df = None
+        result = OperationResult(status=OperationStatus.PENDING)
 
-        # Set up directories
-        dirs = self._prepare_directories(task_dir)
-        visualizations_dir = dirs['visualizations']
-        output_dir = dirs['output']
+        # Prepare directories for artifacts
+        directories = self._prepare_directories(task_dir)
 
-        # Create the main result object with initial status
-        result = OperationResult(status=OperationStatus.SUCCESS)
+        # Initialize operation cache
+        self.operation_cache = OperationCache(
+            cache_dir=task_dir / "cache",
+        )
 
-        # Update progress if tracker provided
-        if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+        # Create DataWriter for consistent file operations
+        writer = DataWriter(
+            task_dir=task_dir, logger=self.logger, progress_tracker=progress_tracker
+        )
+
+        # Save configuration to task directory
+        self.save_config(task_dir)
+
+        # Decompose kwargs and introduce variables for clarity
+        self.encrypt_output = kwargs.get("encrypt_output", False) or self.use_encryption
+        self.generate_visualization = kwargs.get("generate_visualization", True)
+        self.force_recalculation = kwargs.get("force_recalculation", False)
+        dataset_name = kwargs.get("dataset_name", "main")
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get(
+            "visualization_theme", self.visualization_theme
+        )
+        self.visualization_backend = kwargs.get(
+            "visualization_backend", self.visualization_backend
+        )
+        self.visualization_strict = kwargs.get(
+            "visualization_strict", self.visualization_strict
+        )
+        self.visualization_timeout = kwargs.get(
+            "visualization_timeout", self.visualization_timeout
+        )
+
+        self.logger.info(
+            f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+        )
 
         try:
+            # Set up progress tracking with proper steps
+            # Main steps: 1. Cache check, 2. Validation, 3. Data loading, 4. Processing, 5. Metrics, 6. Visualization, 7. Save output
+            TOTAL_MAIN_STEPS = 6 + (
+                1 if self.use_cache and not self.force_recalculation else 0
+            )
+            main_progress = progress_tracker
+            current_steps = 0
+            if main_progress:
+                self.logger.info(
+                    f"Setting up progress tracker with {TOTAL_MAIN_STEPS} main steps"
+                )
+                try:
+                    main_progress.total = TOTAL_MAIN_STEPS
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS,
+                        current_steps,
+                        {
+                            "step": "Starting identity analysis",
+                        },
+                        main_progress,
+                    )
+                except Exception as e:
+                    self.logger.warning(f"Could not update progress tracker: {e}")
+
             # Get DataFrame from data source
-            dataset_name = kwargs.get('dataset_name', "main")
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
-            df = load_data_operation(data_source, dataset_name, **settings_operation)
-            if df is None:
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message="No valid DataFrame found in data source"
+            settings_operation = load_settings_operation(
+                data_source, dataset_name, **kwargs
+            )
+
+            # Check Cache (if enabled and not forced to recalculate)
+            if self.use_cache and not self.force_recalculation:
+                # Step 1: Check if we have a cached result
+                if main_progress:
+                    current_steps += 1
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS, current_steps, "Checking cache", main_progress
+                    )
+
+                # Load left dataset for check cache
+                df = load_data_operation(
+                    data_source, dataset_name, **settings_operation
+                )
+                if df is None:
+                    return OperationResult(
+                        status=OperationStatus.ERROR,
+                        error_message="No valid DataFrame found in data source",
+                    )
+
+                self.logger.info(
+                    f"Field: '{self.field_name}' loaded with {len(df)} records."
                 )
 
-            # Check if required fields exist
-            if self.field_name not in df.columns:
+                self.logger.info("Checking operation cache...")
+                cache_result = self._check_cache(df=df, reporter=reporter)
+                if cache_result:
+                    self.logger.info("Cache hit! Using cached results.")
+
+                    # Update progress
+                    if main_progress:
+                        self._update_progress_tracker(
+                            TOTAL_MAIN_STEPS,
+                            current_steps,
+                            "Complete (cached)",
+                            main_progress,
+                        )
+
+                    return cache_result
+
+            # Step 2: Data Loading
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Data Loading", main_progress
+                )
+
+            try:
+                # Load DataFrame
+                if df is None:
+                    df = load_data_operation(
+                        data_source, dataset_name, **settings_operation
+                    )
+                    if df is None:
+                        return OperationResult(
+                            status=OperationStatus.ERROR,
+                            error_message="No valid DataFrame found in data source",
+                        )
+            except Exception as e:
+                error_message = f"Error loading data: {str(e)}"
+                self.logger.error(error_message)
+                return OperationResult(
+                    status=OperationStatus.ERROR, error_message=error_message
+                )
+
+            # Step 3: Validation
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Validation", main_progress
+                )
+
+            # Validate input parameters
+            # Validate main field
+            if not self._field_exists(df, self.field_name):
                 return OperationResult(
                     status=OperationStatus.ERROR,
-                    error_message=f"Field {self.field_name} not found in DataFrame"
+                    error_message=f"Field {self.field_name} not found in DataFrame",
                 )
 
             # Validate reference fields
-            valid_reference_fields = [field for field in self.reference_fields if field in df.columns]
-            if not valid_reference_fields:
+            valid_refs, missing_refs = self._validate_reference_fields(df)
+            if not valid_refs:
                 return OperationResult(
                     status=OperationStatus.ERROR,
-                    error_message=f"None of the reference fields {self.reference_fields} found in DataFrame"
+                    error_message=f"None of the reference fields {self.reference_fields} found in DataFrame",
+                )
+            if missing_refs:
+                self._log_and_report_missing(
+                    reporter,
+                    label="reference fields",
+                    field_list=missing_refs,
+                    context=f"Missing reference fields for {self.field_name}",
                 )
 
-            # Log missing reference fields
-            if len(valid_reference_fields) < len(self.reference_fields):
-                missing_fields = set(self.reference_fields) - set(valid_reference_fields)
-                logger.warning(f"Some reference fields are missing: {missing_fields}")
-                reporter.add_operation(
-                    f"Missing reference fields for {self.field_name}",
-                    status="warning",
-                    details={"missing_fields": list(missing_fields)}
+            # Validate ID field
+            if self.id_field and not self._field_exists(df, self.id_field):
+                self._log_and_report_missing(
+                    reporter,
+                    label="ID field",
+                    field_list=[self.id_field],
+                    context=f"Missing ID field {self.id_field}",
                 )
+                valid_id_field = None
+            else:
+                valid_id_field = self.id_field
 
-            # Check id_field existence
-            valid_id_field = self.id_field in df.columns if self.id_field else False
-            if self.id_field and not valid_id_field:
-                logger.warning(f"ID field {self.id_field} not found in DataFrame")
-                reporter.add_operation(
-                    f"Missing ID field {self.id_field}",
-                    status="warning",
-                    details={"missing_field": self.id_field}
-                )
-
-            # Add operation to reporter
-            reporter.add_operation(f"Analyzing identity field: {self.field_name}", details={
-                "field_name": self.field_name,
-                "reference_fields": valid_reference_fields,
-                "id_field": self.id_field if valid_id_field else None,
-                "operation_type": "identity_analysis"
-            })
-
-            # Adjust progress tracker total steps if provided
-            total_steps = 4  # Preparation, identifier stats, consistency, distribution
-            if check_cross_matches:
-                total_steps += 1  # Add step for cross-matching
-
-            if progress_tracker:
-                progress_tracker.total = total_steps
-                progress_tracker.update(0, {"status": "Analyzing field"})
-
-            # Step 1: Basic identifier statistics
-            identifier_stats = IdentityAnalyzer.compute_identifier_stats(
-                df,
-                self.field_name,
-                self.id_field if valid_id_field else None
+            # Log analysis metadata
+            reporter.add_operation(
+                f"Analyzing identity field: {self.field_name}",
+                details={
+                    "field_name": self.field_name,
+                    "reference_fields": valid_refs,
+                    "id_field": valid_id_field,
+                    "operation_type": "identity_analysis",
+                },
             )
 
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Basic identifier statistics complete"})
-
-            # Step 2: Analyze identifier consistency
-            consistency_analysis = IdentityAnalyzer.analyze_identifier_consistency(
-                df,
-                self.field_name,
-                valid_reference_fields
-            )
-
-            # Save consistency analysis results
-            consistency_filename = get_timestamped_filename(f"{self.field_name}_consistency", "json",
-                                                            include_timestamp)
-            consistency_path = output_dir / consistency_filename
-
-            write_json(consistency_analysis, consistency_path, encryption_key=encryption_key)
-            result.add_artifact("json", consistency_path, f"{self.field_name} consistency analysis", category=Constants.Artifact_Category_Output)
-            reporter.add_artifact("json", str(consistency_path), f"{self.field_name} consistency analysis")
-
-            # Create visualization for consistency analysis
-            if 'match_percentage' in consistency_analysis:
-                # Create data for visualization - consistency percentage
-                consistency_data = {
-                    'Consistent': consistency_analysis['match_percentage'],
-                    'Inconsistent': 100 - consistency_analysis['match_percentage']
-                }
-
-                viz_filename = get_timestamped_filename(f"{self.field_name}_consistency", "png", include_timestamp)
-                viz_path = visualizations_dir / viz_filename
-
-                # Use create_bar_plot instead of create_pie_chart
-                viz_result = create_bar_plot(
-                    data=consistency_data,
-                    output_path=str(viz_path),
-                    title=f"{self.field_name} Consistency Analysis",
-                    orientation="h",  # horizontal bars to better show the proportions
-                    **kwargs
+            # Step 4: Processing progress tracker
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Processing data", main_progress
                 )
 
-                if not viz_result.startswith("Error"):
-                    result.add_artifact("png", viz_path, f"{self.field_name} consistency visualization", category=Constants.Artifact_Category_Visualization)
-                    reporter.add_artifact("png", str(viz_path), f"{self.field_name} consistency visualization")
+            try:
+                self.logger.info(f"Processing with field_name: {self.field_name}")
+
+                # Create child progress tracker for chunk processing
+                data_tracker = None
+                if main_progress and hasattr(main_progress, "create_subtask"):
+                    try:
+                        data_tracker = main_progress.create_subtask(
+                            total=4,
+                            description="Identity analysis processing",
+                            unit="steps",
+                        )
+                    except Exception as e:
+                        self.logger.debug(
+                            f"Could not create child progress tracker: {e}"
+                        )
+
+                # Basic identifier statistics
+                # Update progress
+                if data_tracker:
+                    data_tracker.update(
+                        1, {"step": "Basic identifier statistics processing"}
+                    )
+                self.logger.info("Basic identifier statistics processing")
+
+                identifier_stats = IdentityAnalyzer.compute_identifier_stats(
+                    df, self.field_name, self.id_field if valid_id_field else None
+                )
+
+                self.logger.info("Basic identifier statistics processing complete")
+
+                # Analyze identifier consistency
+                # Update progress
+                if data_tracker:
+                    data_tracker.update(
+                        2, {"step": "Analyze identifier consistency processing"}
+                    )
+                self.logger.info("Analyze identifier consistency processing")
+
+                consistency_analysis = IdentityAnalyzer.analyze_identifier_consistency(
+                    df, self.field_name, valid_refs
+                )
+
+                self.logger.info("Analyze identifier consistency processing complete")
+
+                # Analyze identifier distribution
+                # Update progress
+                if data_tracker:
+                    data_tracker.update(
+                        3, {"step": "Analyze identifier distribution processing"}
+                    )
+                self.logger.info("Analyze identifier distribution processing")
+
+                if valid_id_field:
+                    distribution_analysis = (
+                        IdentityAnalyzer.analyze_identifier_distribution(
+                            df, self.field_name, self.id_field, self.top_n
+                        )
+                    )
+                    self.logger.info(
+                        "Analyze identifier distribution processing complete"
+                    )
                 else:
-                    logger.warning(f"Error creating consistency visualization: {viz_result}")
-
-            # Save examples of mismatches
-            if 'mismatch_examples' in consistency_analysis and consistency_analysis['mismatch_examples']:
-                mismatch_filename = get_timestamped_filename(f"{self.field_name}_mismatch_examples", "json",
-                                                             include_timestamp)
-                mismatch_path = output_dir / mismatch_filename
-
-                mismatch_examples = {
-                    'mismatch_examples': consistency_analysis['mismatch_examples'],
-                    'mismatch_count': consistency_analysis.get('mismatch_count', 0),
-                    'total_records': consistency_analysis.get('total_records', 0)
-                }
-
-                write_json(mismatch_examples, mismatch_path, encryption_key=encryption_key)
-                result.add_artifact("json", mismatch_path, f"{self.field_name} mismatch examples", category=Constants.Artifact_Category_Output)
-                reporter.add_artifact("json", str(mismatch_path), f"{self.field_name} mismatch examples")
-
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Identifier consistency analysis complete"})
-
-            # Step 3: Analyze distribution of records per identifier
-            if valid_id_field:
-                distribution_analysis = IdentityAnalyzer.analyze_identifier_distribution(
-                    df,
-                    self.field_name,
-                    self.id_field,
-                    top_n
-                )
-
-                # Save distribution analysis results
-                distribution_filename = get_timestamped_filename(f"{self.field_name}_distribution", "json",
-                                                                 include_timestamp)
-                distribution_path = output_dir / distribution_filename
-
-                write_json(distribution_analysis, distribution_path, encryption_key=encryption_key)
-                result.add_artifact("json", distribution_path, f"Records per {self.field_name} distribution analysis", category=Constants.Artifact_Category_Output)
-                reporter.add_artifact("json", str(distribution_path),
-                                      f"Records per {self.field_name} distribution analysis")
-
-                # Create visualization for distribution analysis
-                if 'distribution' in distribution_analysis:
-                    viz_filename = get_timestamped_filename(f"{self.field_name}_count_distribution", "png",
-                                                            include_timestamp)
-                    viz_path = visualizations_dir / viz_filename
-
-                    # Create visualization using the visualization module
-                    viz_result = plot_value_distribution(
-                        data=distribution_analysis['distribution'],
-                        output_path=str(viz_path),
-                        title=f"Records per {self.field_name} Distribution",
-                        max_items=top_n,
-                        **kwargs
+                    logger.warning(
+                        f"Skipping distribution analysis. ID field not found: {self.id_field}"
+                    )
+                    reporter.add_operation(
+                        f"Skipping distribution analysis for {self.field_name}",
+                        status="warning",
+                        details={"reason": f"ID field {self.id_field} not found"},
                     )
 
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", viz_path, f"Records per {self.field_name} distribution visualization", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(viz_path),
-                                              f"Records per {self.field_name} distribution visualization")
-                    else:
-                        logger.warning(f"Error creating distribution visualization: {viz_result}")
-            else:
-                logger.warning(f"Skipping distribution analysis. ID field not found: {self.id_field}")
-                reporter.add_operation(
-                    f"Skipping distribution analysis for {self.field_name}",
-                    status="warning",
-                    details={"reason": f"ID field {self.id_field} not found"}
+                # Cross-matching analysis
+                # Update progress
+                if data_tracker:
+                    data_tracker.update(
+                        4, {"step": "Analyze cross-matching processing"}
+                    )
+                self.logger.info("Analyze cross-matching processing")
+
+                if self.check_cross_matches and valid_refs:
+                    cross_match_analysis = IdentityAnalyzer.find_cross_matches(
+                        df,
+                        self.field_name,
+                        valid_refs,
+                        self.min_similarity,
+                        self.fuzzy_matching,
+                    )
+                    self.logger.info("Analyze cross-matching processing complete")
+                else:
+                    if not self.check_cross_matches:
+                        logger.warning(
+                            "Skipping cross-match analysis as per configuration"
+                        )
+                    elif not valid_refs:
+                        logger.warning(
+                            "Skipping cross-match analysis. No valid reference fields"
+                        )
+
+                # Close child progress tracker
+                if data_tracker:
+                    try:
+                        data_tracker.close()
+                    except:
+                        pass
+
+                self.logger.info(
+                    f"Processed data: {len(df)} records, dtype: {df.dtypes}"
                 )
 
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Record distribution analysis complete"})
-
-            # Step 4: Cross-matching analysis
-            if check_cross_matches and valid_reference_fields:
-                cross_match_analysis = IdentityAnalyzer.find_cross_matches(
-                    df,
-                    self.field_name,
-                    valid_reference_fields,
-                    min_similarity,
-                    fuzzy_matching
+                # Log sample of processed data
+                if len(df) > 0:
+                    self.logger.debug(
+                        f"Sample of processed data (first 5 rows): {df.head(5).to_dict(orient='records')}"
+                    )
+            except Exception as e:
+                error_message = f"Processing error: {str(e)}"
+                self.logger.error(error_message)
+                return OperationResult(
+                    status=OperationStatus.ERROR, error_message=error_message
                 )
+
+            # Step 5: Metrics Calculation
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Metrics Calculation",
+                    main_progress,
+                )
+
+            # Generate single timestamp for all artifacts
+            operation_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+            # Initialize metrics in scope
+            metrics = {}
+
+            try:
+                # Save identifier statistics
+                if identifier_stats and "error" not in identifier_stats:
+                    # Generate metrics file name
+                    identifier_filename = f"{self.field_name}_{self.name}_identifier_metrics_{operation_timestamp}"
+
+                    # Write metrics to persistent storage/artifact repository
+                    identifier_metrics_result = writer.write_metrics(
+                        metrics=identifier_stats,
+                        name=identifier_filename,
+                        timestamp_in_name=False,
+                        encryption_key=(
+                            self.encryption_key if self.encrypt_output else None
+                        ),
+                    )
+
+                    # Add simple metrics (int, float, str, bool) to the result object
+                    for key, value in identifier_stats.items():
+                        if isinstance(value, (int, float, str, bool)):
+                            result.add_metric(key, value)
+
+                    result.add_artifact(
+                        artifact_type="json",
+                        path=identifier_metrics_result.path,
+                        description=f"{self.name} profiling on {self.field_name} identifier metrics",
+                        category=Constants.Artifact_Category_Metrics,
+                    )
+
+                    # Add identifier stats to metrics dictionary
+                    metrics["identifier_stats"] = identifier_stats
+                    metrics["identifier_metrics_result_path"] = (
+                        identifier_metrics_result.path
+                    )
+
+                # Save consistency analysis results
+                if consistency_analysis and "error" not in consistency_analysis:
+                    # Generate metrics file name
+                    consistency_filename = f"{self.field_name}_{self.name}_consistency_metrics_{operation_timestamp}"
+
+                    consistency_metrics_result = writer.write_metrics(
+                        metrics=consistency_analysis,
+                        name=consistency_filename,
+                        timestamp_in_name=False,
+                        encryption_key=(
+                            self.encryption_key if self.encrypt_output else None
+                        ),
+                    )
+
+                    # Add simple metrics (int, float, str, bool) to the result object
+                    for key, value in consistency_analysis.items():
+                        if isinstance(value, (int, float, str, bool)):
+                            result.add_metric(key, value)
+
+                    result.add_artifact(
+                        artifact_type="json",
+                        path=consistency_metrics_result.path,
+                        description=f"{self.name} profiling on {self.field_name} consistency metrics",
+                        category=Constants.Artifact_Category_Metrics,
+                    )
+
+                    # Add consistency analysis to metrics dictionary
+                    metrics["consistency_analysis"] = consistency_analysis
+                    metrics["consistency_metrics_result_path"] = (
+                        consistency_metrics_result.path
+                    )
+
+                # Save distribution analysis results
+                if distribution_analysis and "error" not in distribution_analysis:
+                    # Generate file name for distribution metrics
+                    distribution_filename = f"{self.field_name}_{self.name}_distribution_metrics_{operation_timestamp}"
+
+                    # Write metrics to persistent storage/artifact repository
+                    distribution_metrics_result = writer.write_metrics(
+                        metrics=distribution_analysis,
+                        name=distribution_filename,
+                        timestamp_in_name=False,
+                        encryption_key=(
+                            self.encryption_key if self.encrypt_output else None
+                        ),
+                    )
+
+                    # Add simple metrics (int, float, str, bool) to the result object
+                    for key, value in distribution_analysis.items():
+                        if isinstance(value, (int, float, str, bool)):
+                            result.add_metric(key, value)
+
+                    result.add_artifact(
+                        artifact_type="json",
+                        path=distribution_metrics_result.path,
+                        description=f"{self.name} profiling on {self.field_name} distribution metrics",
+                        category=Constants.Artifact_Category_Metrics,
+                    )
+
+                    # Add distribution analysis to metrics dictionary
+                    metrics["distribution_analysis"] = distribution_analysis
+                    metrics["distribution_metrics_result_path"] = (
+                        distribution_metrics_result.path
+                    )
 
                 # Save cross-match analysis results
-                cross_match_filename = get_timestamped_filename(f"{self.field_name}_cross_match", "json",
-                                                                include_timestamp)
-                cross_match_path = output_dir / cross_match_filename
+                if cross_match_analysis and "error" not in cross_match_analysis:
+                    # Generate file name for cross-match metrics
+                    cross_match_filename = f"{self.field_name}_{self.name}_cross_match_metrics_{operation_timestamp}"
 
-                write_json(cross_match_analysis, cross_match_path, encryption_key=encryption_key)
-                result.add_artifact("json", cross_match_path, f"{self.field_name} cross-match analysis", category=Constants.Artifact_Category_Output)
-                reporter.add_artifact("json", str(cross_match_path), f"{self.field_name} cross-match analysis")
+                    # Write metrics to persistent storage/artifact repository
+                    cross_match_metrics_result = writer.write_metrics(
+                        metrics=cross_match_analysis,
+                        name=cross_match_filename,
+                        timestamp_in_name=False,
+                        encryption_key=(
+                            self.encryption_key if self.encrypt_output else None
+                        ),
+                    )
 
-                # Update progress
-                if progress_tracker:
-                    progress_tracker.update(1, {"step": "Cross-match analysis complete"})
+                    # Add simple metrics (int, float, str, bool) to the result object
+                    for key, value in cross_match_analysis.items():
+                        if isinstance(value, (int, float, str, bool)):
+                            result.add_metric(key, value)
+
+                    result.add_artifact(
+                        artifact_type="json",
+                        path=cross_match_metrics_result.path,
+                        description=f"{self.name} profiling on {self.field_name} cross-match metrics",
+                        category=Constants.Artifact_Category_Metrics,
+                    )
+
+                    # Add cross-match analysis to metrics dictionary
+                    metrics["cross_match_analysis"] = cross_match_analysis
+                    metrics["cross_match_metrics_result_path"] = (
+                        cross_match_metrics_result.path
+                    )
+
+                # Report the metrics artifact to the reporter if available
+                if reporter:
+                    # Add final operation status to reporter
+                    reporter.add_operation(
+                        f"Analysis of {self.field_name} completed",
+                        details={
+                            "unique_identifiers": identifier_stats.get(
+                                "unique_identifiers", 0
+                            ),
+                            "consistency_percentage": consistency_analysis.get(
+                                "match_percentage", 0
+                            ),
+                            "reference_fields_used": valid_refs,
+                            "cross_matches_found": cross_match_analysis.get(
+                                "total_cross_matches", 0
+                            ),
+                        },
+                    )
+            except Exception as e:
+                error_message = f"Error calculating metrics: {str(e)}"
+                self.logger.warning(error_message)
+                # Continue execution - metrics failure is not critical
+
+            # Step 6: Visualizations
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Generating Visualizations",
+                    main_progress,
+                )
+            # Generate visualizations if required
+            # Initialize visualization paths dictionary
+            visualization_paths = {}
+            if self.generate_visualization and self.visualization_backend is not None:
+                try:
+                    kwargs_encryption = {
+                        "use_encryption": self.encrypt_output,
+                        "encryption_key": self.encryption_key,
+                    }
+                    visualization_paths = self._handle_visualizations(
+                        identifier_stats=identifier_stats,
+                        consistency_analysis=consistency_analysis,
+                        distribution_analysis=distribution_analysis,
+                        cross_match_analysis=cross_match_analysis,
+                        task_dir=task_dir,
+                        result=result,
+                        reporter=reporter,
+                        progress_tracker=main_progress,
+                        vis_theme=self.visualization_theme,
+                        vis_backend=self.visualization_backend,
+                        vis_strict=self.visualization_strict,
+                        vis_timeout=self.visualization_timeout,
+                        operation_timestamp=operation_timestamp,
+                        **kwargs_encryption,
+                    )
+                except Exception as e:
+                    error_message = f"Error generating visualizations: {str(e)}"
+                    self.logger.warning(error_message)
+                    # Continue execution - visualization failure is not critical
             else:
-                if not check_cross_matches:
-                    logger.info("Skipping cross-match analysis as per configuration")
-                elif not valid_reference_fields:
-                    logger.warning("Skipping cross-match analysis. No valid reference fields")
+                self.logger.info(
+                    "Skipping visualizations as generate_visualization is False or backend is not set"
+                )
 
-            # Add metrics to the result
-            result.add_metric("total_records", identifier_stats.get('total_records', 0))
-            result.add_metric("unique_identifiers", identifier_stats.get('unique_identifiers', 0))
-            result.add_metric("identifier_coverage", identifier_stats.get('coverage_percentage', 0))
+            # Cache the result if caching is enabled
+            if self.use_cache:
+                try:
+                    self._save_to_cache(
+                        original_data=df,
+                        metrics=metrics,
+                        visualization_paths=visualization_paths,
+                        task_dir=task_dir,
+                    )
+                except Exception as e:
+                    # Failure to cache is non-critical
+                    self.logger.warning(f"Failed to cache results: {str(e)}")
 
-            if consistency_analysis:
-                result.add_metric("consistent_percentage", consistency_analysis.get('match_percentage', 0))
-                result.add_metric("inconsistent_count", consistency_analysis.get('mismatch_count', 0))
+            # Cleanup memory
+            self._cleanup_memory(df)
 
-            if valid_id_field and 'distribution_analysis' in locals():
-                result.add_metric("max_records_per_identifier", distribution_analysis.get('max_count', 0))
-                result.add_metric("avg_records_per_identifier", distribution_analysis.get('avg_count', 0))
+            # Record end time
+            self.end_time = time.time()
 
-            if check_cross_matches and 'cross_match_analysis' in locals():
-                result.add_metric("cross_match_count", cross_match_analysis.get('total_cross_matches', 0))
+            # Report completion
+            if reporter:
+                # Create the details dictionary with checks for all values
+                details = {
+                    "records_processed": self.process_count,
+                    "execution_time": (
+                        self.end_time - self.start_time
+                        if self.end_time and self.start_time
+                        else None
+                    ),
+                }
 
-            # Add final operation status to reporter
-            reporter.add_operation(f"Analysis of {self.field_name} completed", details={
-                "unique_identifiers": identifier_stats.get('unique_identifiers', 0),
-                "consistency_percentage": consistency_analysis.get('match_percentage', 0),
-                "reference_fields_used": valid_reference_fields,
-                "cross_matches_found": cross_match_analysis.get('total_cross_matches',
-                                                                0) if 'cross_match_analysis' in locals() else None
-            })
+                # Add the operation to the reporter
+                reporter.add_operation(
+                    f"Analyzing identity of {self.name} completed",
+                    details=details,
+                )
 
+            self.logger.info(
+                f"Processing completed {self.name} operation in {self.end_time - self.start_time:.2f} seconds"
+            )
+
+            # Set success status
+            result.status = OperationStatus.SUCCESS
             return result
 
         except Exception as e:
-            logger.exception(f"Error in identity analysis operation for {self.field_name}: {e}")
-
-            # Update progress tracker on error
-            if progress_tracker:
-                progress_tracker.update(0, {"step": "Error", "error": str(e)})
-
-            # Add error to reporter
-            reporter.add_operation(f"Error analyzing {self.field_name}",
-                                   status="error",
-                                   details={"error": str(e)})
-
+            # Handle any unexpected errors
+            error_message = f"Error in analyzing identity operation: {str(e)}"
+            self.logger.exception(error_message)
             return OperationResult(
                 status=OperationStatus.ERROR,
-                error_message=f"Error analyzing identity field {self.field_name}: {str(e)}"
+                error_message=f"Error analyzing identity field {self.field_name}: {str(e)}",
             )
+
+    def _generate_cache_key(self, data: pd.DataFrame) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        data : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+         # Get basic operation parameters
+        parameters = self._get_basic_parameters()
+
+        # Add operation-specific parameters (could be overridden by subclasses)
+        parameters.update(self._get_cache_parameters())
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(data)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return self.operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash,
+        )
+    
+    def _get_basic_parameters(self) -> Dict[str, str]:
+        """Get the basic parameters for the cache key generation."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+        }
+
+    def _get_cache_parameters(self) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        This method should be overridden by subclasses to provide
+        operation-specific parameters for caching.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Base implementation returns minimal parameters
+        params = {
+            "uid_field": self.uid_field,
+            "reference_fields": self.reference_fields or [],
+            "id_field": self.id_field,
+            "top_n": self.top_n,
+            "check_cross_matches": self.check_cross_matches,
+            "min_similarity": self.min_similarity,
+            "fuzzy_matching": self.fuzzy_matching,
+            "use_cache": self.use_cache,
+            "use_encryption": self.use_encryption,
+            "encryption_key": self.encryption_key,
+            "visualization_theme": self.visualization_theme,
+            "visualization_backend": self.visualization_backend,
+            "visualization_strict": self.visualization_strict,
+            "visualization_timeout": self.visualization_timeout,
+            "force_recalculation": self.force_recalculation,
+            "generate_visualization": self.generate_visualization,
+            "encrypt_output": self.encrypt_output,
+        }
+
+        return params
+
+    def _generate_data_hash(self, df: pd.DataFrame) -> str:
+        """
+        Generate a hash representing the key characteristics of the DataFrame.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns
+        -------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+        import json
+
+        try:
+            # Generate summary statistics for all columns (numeric and non-numeric)
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string with consistent formatting (ISO for dates)
+            json_str = characteristics.to_json(date_format="iso")
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback: use length and column data types
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+    def _save_to_cache(
+        self,
+        original_data: pd.DataFrame,
+        metrics: Dict[str, Any],
+        visualization_paths: Dict[str, Path],
+        task_dir: Path,
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_data : pd.DataFrame
+            Original input data
+        metrics : Dict[str, Any]
+            Metrics collected during the operation
+        visualization_paths : Dict[str, Path]
+            Paths to generated visualizations
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache:
+            return False
+
+        try:
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_data[self.field_name])
+
+            # Prepare metadata for cache
+            operation_params = self._get_basic_parameters()
+            operation_params.update(self._get_cache_parameters())
+
+            self.logger.debug(f"Operation parameters for cache: {operation_params}")
+
+            # Prepare cache data
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "metrics": metrics,
+                "parameters": operation_params,
+                "data_info": {
+                    "original_length": len(original_data),
+                    "original_null_count": int(original_data.isna().sum().sum()),
+                },
+                "visualizations": {
+                    k: str(v) for k, v in visualization_paths.items()
+                },  # Paths to visualizations
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+
+            success = self.operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)},
+            )
+
+            if success:
+                self.logger.info(
+                    f"Successfully saved {self.field_name} profiling results to cache"
+                )
+            else:
+                self.logger.warning(
+                    f"Failed to save {self.field_name} profiling results to cache"
+                )
+
+            return success
+
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+
+    def _check_cache(
+        self, df: pd.DataFrame, reporter: Any
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for this operation.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame for the operation
+        reporter : Any
+            Reporter object for tracking progress and artifacts
+
+        Returns
+        -------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            if self.field_name not in df.columns:
+                self.logger.warning(
+                    f"Field '{self.field_name}' not found in DataFrame."
+                )
+                return None
+
+            cache_key = self._generate_cache_key(df[self.field_name])
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+
+            cached_result = self.operation_cache.get_cache(
+                cache_key=cache_key, operation_type=self.__class__.__name__
+            )
+
+            if not cached_result:
+                self.logger.info("No cached result found, proceeding with operation")
+                return None
+
+            self.logger.info(
+                f"Using cached result for {self.field_name} of {self.name} profiling"
+            )
+
+            result = OperationResult(status=OperationStatus.SUCCESS)
+            # Restore cached data
+            self._add_cached_metrics(result, cached_result)
+            artifacts_restored = self._restore_cached_artifacts(
+                result, cached_result, reporter
+            )
+
+            # Add cache metadata
+            result.add_metric("cached", True)
+            result.add_metric("cache_key", cache_key)
+            result.add_metric(
+                "cache_timestamp", cached_result.get("timestamp", "unknown")
+            )
+            result.add_metric("artifacts_restored", artifacts_restored)
+
+            if reporter:
+                reporter.add_operation(
+                    f"{self.name} profiling of {self.field_name} (cached)",
+                    details={
+                        "field_name": self.field_name,
+                        "cached": True,
+                        "artifacts_restored": artifacts_restored,
+                    },
+                )
+
+            self.logger.info(
+                f"Cache hit successful: restored {artifacts_restored} artifacts"
+            )
+            return result
+
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+
+    def _add_cached_metrics(self, result: OperationResult, cached: dict):
+        """
+        Add cached scalar metrics (int, float, str, bool) to the OperationResult.
+
+        Parameters
+        ----------
+        result : OperationResult
+            The result object to update.
+        cached : dict
+            Cached result dictionary from cache manager.
+        """
+        for key, value in cached.get("metrics", {}).items():
+            if isinstance(value, (int, float, str, bool)):
+                result.add_metric(key, value)
+
+    def _restore_cached_artifacts(
+        self, result: OperationResult, cached: dict, reporter: Optional[Any]
+    ) -> int:
+        """
+        Restore artifacts (output, metrics, visualizations) from cached result if files exist.
+
+        Parameters
+        ----------
+        result : OperationResult
+            OperationResult object to update with restored artifacts.
+        cached : dict
+            Cached result dictionary from cache manager.
+        reporter : Optional[Any]
+            Optional reporter object for tracking operation-level artifacts.
+
+        Returns
+        -------
+        int
+            Number of artifacts successfully restored.
+        """
+        artifacts_restored = 0
+
+        def restore_file_artifact(
+            path: Union[str, Path], artifact_type: str, desc_suffix: str, category: str
+        ):
+            """
+            Restore a single artifact from a file path if it exists.
+
+            Parameters
+            ----------
+            path : Union[str, Path]
+                Path to the artifact file.
+            artifact_type : str
+                Type of the artifact (e.g., 'json', 'csv', 'png').
+            desc_suffix : str
+                Description suffix (e.g., 'visualization', 'metrics').
+            category : str
+                Artifact category (e.g., output, metrics, visualization).
+            """
+            nonlocal artifacts_restored
+            if not path:
+                return
+
+            artifact_path = Path(path)
+            if artifact_path.exists():
+                result.add_artifact(
+                    artifact_type=artifact_type,
+                    path=artifact_path,
+                    description=f"{self.field_name} {desc_suffix} (cached)",
+                    category=category,
+                )
+                artifacts_restored += 1
+
+                if reporter:
+                    reporter.add_operation(
+                        f"{self.field_name} {desc_suffix} (cached)",
+                        details={
+                            "artifact_type": artifact_type,
+                            "path": str(artifact_path),
+                        },
+                    )
+            else:
+                self.logger.warning(f"Cached file not found: {artifact_path}")
+
+        # Restore visualizations
+        for viz_type, path_str in cached.get("visualizations", {}).items():
+            restore_file_artifact(
+                path_str,
+                "png",
+                f"{viz_type} visualization",
+                Constants.Artifact_Category_Visualization,
+            )
+
+        return artifacts_restored
+
+    def _handle_visualizations(
+        self,
+        identifier_stats: Dict[str, Any],
+        consistency_analysis: Dict[str, Any],
+        distribution_analysis: Dict[str, Any],
+        cross_match_analysis: Dict[str, Any],
+        task_dir: Path,
+        result: OperationResult,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        vis_timeout: int = 120,
+        operation_timestamp: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Generate and save visualizations with thread-safe context support.
+
+        Parameters:
+        -----------
+        identifier_stats : Dict[str, Any]
+            Statistics related to the identifier
+        consistency_analysis : Dict[str, Any]
+            Analysis results for consistency
+        distribution_analysis : Dict[str, Any]
+            Analysis results for distribution
+        cross_match_analysis : Dict[str, Any]
+            Analysis results for cross-matching
+        task_dir : Path
+            The task directory
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        operation_timestamp : str, optional
+            Timestamp for the operation (default: current time)
+        **kwargs: Any
+            Additional keyword arguments for visualization functions.
+        """
+        self.logger.info(
+            f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s"
+        )
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(
+                    f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}"
+                )
+                self.logger.info(
+                    f"[DIAG] Field: {self.field_name}, Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+                )
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(
+                            f"[DIAG] Context vars count: {len(list(current_context))}"
+                        )
+                    except Exception as ctx_e:
+                        self.logger.warning(
+                            f"[DIAG] Could not inspect context: {ctx_e}"
+                        )
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(
+                                f"Could not create child progress tracker: {e}"
+                            )
+
+                    # Generate visualizations with context parameters
+                    visualization_paths = self._generate_visualizations(
+                        identifier_stats=identifier_stats,
+                        consistency_analysis=consistency_analysis,
+                        distribution_analysis=distribution_analysis,
+                        cross_match_analysis=cross_match_analysis,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend or "plotly",
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        timestamp=operation_timestamp,  # Pass the same timestamp
+                        **kwargs,
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(
+                        f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}"
+                    )
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-{self.field_name}",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(
+                f"[DIAG] Starting visualization thread with timeout={vis_timeout}s"
+            )
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(
+                        f"[DIAG] Visualization thread still running after {elapsed:.1f}s..."
+                    )
+
+            if viz_thread.is_alive():
+                self.logger.error(
+                    f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout"
+                )
+                self.logger.error(
+                    f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}"
+                )
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(
+                    f"[DIAG] Visualization failed with error: {visualization_error}"
+                )
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(
+                    f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s"
+                )
+                self.logger.info(
+                    f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}"
+                )
+
+        except Exception as e:
+            self.logger.error(
+                f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}"
+            )
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{self.field_name} {viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization,
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_operation(
+                    f"{self.field_name} {viz_type} visualization",
+                    details={"artifact_type": "png", "path": str(path)},
+                )
+
+        return visualization_paths
+
+    def _generate_visualizations(
+        self,
+        identifier_stats: Dict[str, Any],
+        consistency_analysis: Dict[str, Any],
+        distribution_analysis: Dict[str, Any],
+        cross_match_analysis: Dict[str, Any],
+        task_dir: Path,
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        timestamp: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Generate required visualizations for the merge operation using visualization utilities.
+
+        Parameters
+        ----------
+        identifier_stats : Dict[str, Any]
+            Statistics related to the identifier.
+        consistency_analysis : Dict[str, Any]
+            Analysis results for consistency.
+        distribution_analysis : Dict[str, Any]
+            Analysis results for distribution.
+        cross_match_analysis : Dict[str, Any]
+            Analysis results for cross-matching.
+        task_dir : Path
+            The base directory where all task-related outputs (including visualizations) will be saved.
+        vis_theme : Optional[str]
+            The theme to use for visualizations.
+        vis_backend : Optional[str]
+            The backend to use for rendering visualizations.
+        vis_strict : bool
+            Whether to enforce strict visualization rules.
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Tracker for monitoring progress of the visualization generation.
+        timestamp : Optional[str]
+            Timestamp to include in visualization filenames.
+        **kwargs : Any
+            Additional keyword arguments for visualization functions.
+
+        Returns
+        -------
+        dict
+            A dictionary mapping visualization types to their corresponding file paths.
+        """
+        viz_dir = task_dir / "visualizations"
+        viz_dir.mkdir(parents=True, exist_ok=True)
+        visualization_paths = {}
+
+        # Use provided timestamp or generate new one
+        if timestamp is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(
+                f"Skipping visualization for {self.field_name} (backend=None)"
+            )
+            return visualization_paths
+
+        self.logger.info(
+            f"[VIZ] Starting visualization generation for {self.field_name}"
+        )
+        self.logger.debug(
+            f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+        )
+
+        try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
+            self.logger.debug(
+                f"[VIZ] Data prepared for visualization: "
+                f"identifier_stats: {len(identifier_stats)}, "
+                f"consistency_analysis: {len(consistency_analysis)}, "
+                f"distribution_analysis: {len(distribution_analysis)}, "
+                f"cross_match_analysis: {len(cross_match_analysis)}"
+            )
+
+            # Step 2: Create visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Creating visualization"})
+
+            # 1. Identifier Statistics (bar chart)
+            if identifier_stats and "error" not in identifier_stats:
+                visualization_paths.update(
+                    generate_identifier_statistics_vis(
+                        identifier_stats,
+                        field_label=self.field_name,
+                        operation_name=self.name,
+                        task_dir=viz_dir,
+                        timestamp=timestamp,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=visualization_paths,
+                        **kwargs,
+                    )
+                )
+
+            # 2. Consistency analysis (bar chart)
+            if consistency_analysis and "error" not in consistency_analysis:
+                visualization_paths.update(
+                    generate_consistency_analysis_vis(
+                        consistency_analysis,
+                        field_label=self.field_name,
+                        operation_name=self.name,
+                        task_dir=viz_dir,
+                        timestamp=timestamp,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=visualization_paths,
+                        **kwargs,
+                    )
+                )
+
+            # 3. Distribution analysis (bar chart)
+            if distribution_analysis and "error" not in distribution_analysis:
+                visualization_paths.update(
+                    generate_field_distribution_vis(
+                        distribution_analysis,
+                        field_label=self.field_name,
+                        operation_name=self.name,
+                        task_dir=viz_dir,
+                        timestamp=timestamp,
+                        top_n=self.top_n,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=visualization_paths,
+                        **kwargs,
+                    )
+                )
+
+            # 4. Cross-match distribution (bar chart)
+            if cross_match_analysis and "error" not in cross_match_analysis:
+                visualization_paths.update(
+                    generate_cross_match_distribution_vis(
+                        cross_match_analysis,
+                        field_label=self.field_name,
+                        operation_name=self.name,
+                        task_dir=viz_dir,
+                        timestamp=timestamp,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=visualization_paths,
+                        **kwargs,
+                    )
+                )
+
+            # Step 3: Finalize visualizations
+            if progress_tracker:
+                progress_tracker.update(3, {"step": "Finalizing visualizations"})
+
+        except Exception as e:
+            self.logger.warning(f"Error creating visualizations: {e}")
+
+        return visualization_paths
+
+    def _update_progress_tracker(
+        self,
+        TOTAL_MAIN_STEPS: int,
+        n: int,
+        step_name: str,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+    ) -> None:
+        """
+        Helper to update progress tracker for the step.
+        """
+        if progress_tracker:
+            progress_tracker.total = TOTAL_MAIN_STEPS  # Ensure total steps is set
+            progress_tracker.update(
+                n,
+                {
+                    "step": step_name,
+                    "operation": f"{self.name}",
+                    "uid_field": f"{self.uid_field}",
+                    "reference_fields": f"{self.reference_fields}",
+                },
+            )
+
+    def _field_exists(self, df: pd.DataFrame, field: str) -> bool:
+        """
+        Check if a given field exists in the DataFrame.
+
+        Parameters:
+        - df (pd.DataFrame): The DataFrame to check.
+        - field (str): The field/column name.
+
+        Returns:
+        - bool: True if field exists, False otherwise.
+        """
+        return field in df.columns
+
+    def _validate_reference_fields(
+        self, df: pd.DataFrame
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Validate which reference fields exist in the DataFrame.
+
+        Parameters:
+        - df (pd.DataFrame): The input DataFrame.
+
+        Returns:
+        - Tuple[List[str], List[str]]: A tuple containing the list of valid and missing reference fields.
+        """
+        valid = [f for f in self.reference_fields if f in df.columns]
+        missing = list(set(self.reference_fields) - set(valid))
+        return valid, missing
+
+    def _log_and_report_missing(
+        self, reporter, label: str, field_list: List[str], context: str
+    ):
+        """
+        Log a warning and report missing fields.
+
+        Parameters:
+        - reporter: Reporter object to log and track operations.
+        - label (str): A human-readable label for the type of fields (e.g. "reference fields", "ID field").
+        - field_list (List[str]): List of missing fields.
+        - context (str): Contextual message for the reporter log.
+        """
+        logger.warning(f"{label.capitalize()} are missing: {field_list}")
+        reporter.add_operation(
+            context, status="warning", details={"missing_fields": field_list}
+        )
+
+    def _cleanup_memory(
+        self,
+        original_df: Optional[pd.DataFrame] = None,
+    ) -> None:
+        """
+        Clean up memory after operation completes.
+
+        For large datasets, explicitly free memory by deleting
+        references and optionally calling garbage collection.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame, optional
+            Original DataFrame to clear from memory
+        """
+        # Delete references
+        if original_df is not None:
+            del original_df
+
+        # Clear operation cache
+        if hasattr(self, "operation_cache"):
+            self.operation_cache = None
+
+        # Additional cleanup for any temporary attributes
+        for attr_name in list(vars(self).keys()):
+            if attr_name.startswith("_temp_"):
+                delattr(self, attr_name)
+
+        # Optional: Force garbage collection for large datasets
+        # Uncomment if memory pressure is an issue
+        # import gc
+        # gc.collect()
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
-        Prepare required directories for artifacts.
+        Prepare directories for artifacts following PAMOLA.CORE conventions.
 
         Parameters:
         -----------
         task_dir : Path
-            Base directory for the task
+            Root task directory
 
         Returns:
         --------
         Dict[str, Path]
-            Dictionary of directory paths
+            Dictionary with prepared directories
         """
-        # Create required directories
-        output_dir = task_dir / 'output'
-        visualizations_dir = task_dir / 'visualizations'
-        dictionaries_dir = task_dir / 'dictionaries'
+        directories = {}
 
-        ensure_directory(output_dir)
-        ensure_directory(visualizations_dir)
-        ensure_directory(dictionaries_dir)
+        # Create standard directories following PAMOLA.CORE conventions
+        directories["root"] = task_dir
+        directories["output"] = task_dir / "output"
+        directories["dictionaries"] = task_dir / "dictionaries"
+        directories["logs"] = task_dir / "logs"
+        directories["cache"] = task_dir / "cache"
 
-        return {
-            'output': output_dir,
-            'visualizations': visualizations_dir,
-            'dictionaries': dictionaries_dir
-        }
+        # Ensure all directories exist
+        for directory in directories.values():
+            directory.mkdir(parents=True, exist_ok=True)
+
+        return directories
 
 
 def analyze_identities(
-        data_source: DataSource,
-        task_dir: Path,
-        reporter: Any,
-        identity_fields: Dict[str, Dict[str, Any]] = None,
-        **kwargs) -> Dict[str, OperationResult]:
+    data_source: DataSource,
+    task_dir: Path,
+    reporter: Any,
+    identity_fields: Dict[str, Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, OperationResult]:
     """
     Analyze multiple identity fields in a dataset.
 
@@ -577,11 +1855,15 @@ def analyze_identities(
     """
     # Get DataFrame from data source
     dataset_name = kwargs.get('dataset_name', "main")
-    df = load_data_operation(data_source, dataset_name)
+    settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+    df = load_data_operation(data_source, dataset_name, **settings_operation)
     # Use get_dataframe safely
     if df is None:
-        reporter.add_operation("Identity fields analysis", status="error",
-                               details={"error": "No valid DataFrame found in data source"})
+        reporter.add_operation(
+            "Identity fields analysis",
+            status="error",
+            details={"error": "No valid DataFrame found in data source"},
+        )
         return {}
 
     # If no identity fields specified, try to detect them (this is a simplified approach)
@@ -589,15 +1871,21 @@ def analyze_identities(
         identity_fields = {}
 
         # Look for potential ID fields
-        potential_id_fields = [col for col in df.columns if
-                               'id' in col.lower() or 'uuid' in col.lower() or 'uid' in col.lower()]
+        potential_id_fields = [
+            col
+            for col in df.columns
+            if "id" in col.lower() or "uuid" in col.lower() or "uid" in col.lower()
+        ]
 
         # Look for potential reference fields (name fields, dates, etc.)
-        potential_reference_fields = [col for col in df.columns if
-                                      'name' in col.lower() or
-                                      'date' in col.lower() or
-                                      'birth' in col.lower() or
-                                      'gender' in col.lower()]
+        potential_reference_fields = [
+            col
+            for col in df.columns
+            if "name" in col.lower()
+            or "date" in col.lower()
+            or "birth" in col.lower()
+            or "gender" in col.lower()
+        ]
 
         # Create a simple configuration for detected ID fields
         for id_field in potential_id_fields:
@@ -609,27 +1897,34 @@ def analyze_identities(
                     break
 
             identity_fields[id_field] = {
-                'reference_fields': potential_reference_fields,
-                'id_field': entity_field
+                "reference_fields": potential_reference_fields,
+                "id_field": entity_field,
             }
 
     # Report on fields to be analyzed
-    reporter.add_operation("Identity fields analysis", details={
-        "fields_count": len(identity_fields),
-        "fields": list(identity_fields.keys()),
-        "parameters": {k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))}
-    })
+    reporter.add_operation(
+        "Identity fields analysis",
+        details={
+            "fields_count": len(identity_fields),
+            "fields": list(identity_fields.keys()),
+            "parameters": {
+                k: v
+                for k, v in kwargs.items()
+                if isinstance(v, (str, int, float, bool))
+            },
+        },
+    )
 
     # Track progress if enabled
-    track_progress = kwargs.get('track_progress', True)
+    track_progress = kwargs.get("track_progress", True)
     overall_tracker = None
 
     if track_progress and identity_fields:
-        overall_tracker = ProgressTracker(
+        overall_tracker = HierarchicalProgressTracker(
             total=len(identity_fields),
             description=f"Analyzing {len(identity_fields)} identity fields",
             unit="fields",
-            track_memory=True
+            track_memory=True,
         )
 
     # Initialize results dictionary
@@ -641,19 +1936,20 @@ def analyze_identities(
             try:
                 # Update overall progress tracker
                 if overall_tracker:
-                    overall_tracker.update(0, {"field": field, "progress": f"{i + 1}/{len(identity_fields)}"})
+                    overall_tracker.update(
+                        0,
+                        {"field": field, "progress": f"{i + 1}/{len(identity_fields)}"},
+                    )
 
                 logger.info(f"Analyzing identity field: {field}")
 
                 # Get configuration for this field
-                reference_fields = config.get('reference_fields', [])
-                id_field = config.get('id_field')
+                reference_fields = config.get("reference_fields", [])
+                id_field = config.get("id_field")
 
                 # Create and execute operation
                 operation = IdentityAnalysisOperation(
-                    field,
-                    reference_fields=reference_fields,
-                    id_field=id_field
+                    field, reference_fields=reference_fields, id_field=id_field
                 )
                 result = operation.execute(data_source, task_dir, reporter, **kwargs)
 
@@ -663,16 +1959,29 @@ def analyze_identities(
                 # Update overall tracker after successful analysis
                 if overall_tracker:
                     if result.status == OperationStatus.SUCCESS:
-                        overall_tracker.update(1, {"field": field, "status": "completed"})
+                        overall_tracker.update(
+                            1, {"field": field, "status": "completed"}
+                        )
                     else:
-                        overall_tracker.update(1, {"field": field, "status": "error",
-                                                   "error": result.error_message})
+                        overall_tracker.update(
+                            1,
+                            {
+                                "field": field,
+                                "status": "error",
+                                "error": result.error_message,
+                            },
+                        )
 
             except Exception as e:
-                logger.error(f"Error analyzing identity field {field}: {e}", exc_info=True)
+                logger.error(
+                    f"Error analyzing identity field {field}: {e}", exc_info=True
+                )
 
-                reporter.add_operation(f"Analyzing {field} field", status="error",
-                                       details={"error": str(e)})
+                reporter.add_operation(
+                    f"Analyzing {field} field",
+                    status="error",
+                    details={"error": str(e)},
+                )
 
                 # Update overall tracker in case of error
                 if overall_tracker:
@@ -683,13 +1992,18 @@ def analyze_identities(
         overall_tracker.close()
 
     # Report summary
-    success_count = sum(1 for r in results.values() if r.status == OperationStatus.SUCCESS)
+    success_count = sum(
+        1 for r in results.values() if r.status == OperationStatus.SUCCESS
+    )
     error_count = sum(1 for r in results.values() if r.status == OperationStatus.ERROR)
 
-    reporter.add_operation("Identity fields analysis completed", details={
-        "fields_analyzed": len(results),
-        "successful": success_count,
-        "failed": error_count
-    })
+    reporter.add_operation(
+        "Identity fields analysis completed",
+        details={
+            "fields_analyzed": len(results),
+            "successful": success_count,
+            "failed": error_count,
+        },
+    )
 
     return results

--- a/pamola_core/profiling/analyzers/mvf.py
+++ b/pamola_core/profiling/analyzers/mvf.py
@@ -17,31 +17,45 @@ MVF fields contain multiple values per record, typically stored as:
 - Comma-separated values: "Value1, Value2"
 """
 
+from datetime import datetime
 import logging
 from pathlib import Path
+import time
 from typing import Dict, List, Any, Optional, Union
 
 import pandas as pd
 
+from pamola_core.anonymization.commons.visualization_utils import (
+    generate_visualization_filename,
+)
+from pamola_core.common.constants import Constants
 from pamola_core.profiling.commons.mvf_utils import (
+    aggregate_mvf_analysis,
+    analyze_mvf_field_with_dask,
+    analyze_mvf_field_with_parallel,
+    analyze_mvf_in_chunks,
+    detect_mvf_format,
+    generate_analysis_distribution_vis,
     parse_mvf,
-    analyze_mvf_field,
     create_value_dictionary,
     create_combinations_dictionary,
     analyze_value_count_distribution,
-    estimate_resources
+    estimate_resources,
+    process_mvf_partition,
 )
-from pamola_core.utils.io import write_json, ensure_directory, get_timestamped_filename, load_data_operation, write_dataframe_to_csv, load_settings_operation
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.io import (
+    load_data_operation,
+    load_settings_operation,
+)
+from pamola_core.utils.ops.op_cache import OperationCache
+from pamola_core.utils.ops.op_config import OperationConfig
+from pamola_core.utils.ops.op_data_writer import DataWriter
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
-from pamola_core.utils.visualization import (
-    plot_value_distribution,
-    create_bar_plot
-)
-from pamola_core.common.constants import Constants
+
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -55,11 +69,19 @@ class MVFAnalyzer:
     """
 
     @staticmethod
-    def analyze(df: pd.DataFrame,
-                field_name: str,
-                top_n: int = 20,
-                min_frequency: int = 1,
-                **kwargs) -> Dict[str, Any]:
+    def analyze(
+        df: pd.DataFrame,
+        field_name: str,
+        top_n: int = 20,
+        parse_args: Dict[str, Any] = None,
+        chunk_size: int = 10000,
+        use_dask: bool = False,
+        npartitions: Optional[int] = None,
+        use_vectorization: bool = False,
+        parallel_processes: Optional[int] = None,
+        task_logger: Optional[logging.Logger] = None,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+    ) -> Dict[str, Any]:
         """
         Analyze a multi-valued field in the given DataFrame.
 
@@ -71,29 +93,159 @@ class MVFAnalyzer:
             The name of the field to analyze
         top_n : int
             Number of top values to include in the results
-        min_frequency : int
-            Minimum frequency for inclusion in the dictionary
-        **kwargs : dict
-            Additional parameters for the analysis
+        parse_args : Dict[str, Any] = {}
+            Additional arguments for parsing the MVF
+        chunk_size : int
+            Number of records to process in each chunk
+        use_dask : bool
+            Whether to use Dask for parallel processing
+        npartitions : int, optional
+            Number of Dask partitions to use
+        use_vectorization : bool
+            Whether to use vectorized operations
+        parallel_processes : int, optional
+            Number of parallel processes to use
+        task_logger : Optional[logging.Logger] = None,
+            Logger for task-specific logging
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+            Progress tracker for monitoring the analysis progress
 
         Returns:
         --------
         Dict[str, Any]
             The results of the analysis
         """
-        return analyze_mvf_field(
-            df=df,
-            field_name=field_name,
-            top_n=top_n,
-            min_frequency=min_frequency,
-            **kwargs
-        )
+        if task_logger:
+            logger = task_logger
+            logger.info(f"Analyzing MVF field: {field_name}")
+
+        results = None
+        flag_processed = False
+        logger.info("Process with config")
+
+        if use_dask:
+            try:
+                logger.info("Parallel Enabled")
+                logger.info("Parallel Engine: Dask")
+                logger.info(f"Parallel Workers: {npartitions}")
+                logger.info(f"Using dask processing with chunk size {chunk_size}")
+                if progress_tracker:
+                    progress_tracker.total = 3  # Setup, Processing, Finalization
+                    progress_tracker.update(0, {"step": "Setting up dask processing"})
+
+                logger.info("Process using Dask")
+
+                results = analyze_mvf_field_with_dask(
+                    df=df,
+                    field_name=field_name,
+                    top_n=top_n,
+                    parse_args=parse_args,
+                    chunk_size=chunk_size,
+                    npartitions=npartitions,
+                    progress_tracker=progress_tracker,
+                    task_logger=logger,
+                )
+
+                if results is not None:
+                    flag_processed = True
+                    logger.info("Completed using Dask")
+
+            except Exception as e:
+                logger.warning(
+                    f"Error in dask processing: {e}, falling back to chunk processing"
+                )
+
+        if not flag_processed and use_vectorization:
+            try:
+                logger.info("Parallel Enabled")
+                logger.info("Parallel Engine: Joblib")
+                logger.info(f"Parallel Workers: {parallel_processes}")
+                logger.info(f"Using vectorized processing with chunk size {chunk_size}")
+                if progress_tracker:
+                    progress_tracker.update(
+                        0, {"step": "Setting up vectorized processing"}
+                    )
+
+                logger.info("Process using Joblib")
+                results = analyze_mvf_field_with_parallel(
+                    df=df,
+                    field_name=field_name,
+                    top_n=top_n,
+                    parse_args=parse_args,
+                    chunk_size=chunk_size,
+                    n_jobs=parallel_processes,
+                    progress_tracker=progress_tracker,
+                    task_logger=logger,
+                )
+
+                if results is not None:
+                    flag_processed = True
+                    logger.info("Completed using Joblib")
+
+            except Exception as e:
+                logger.warning(
+                    f"Error in vectorized processing: {e}, falling back to chunk processing"
+                )
+
+        if not flag_processed and chunk_size > 1:
+            try:
+                # Regular chunk processing
+                logger.info(f"Processing in chunks with chunk size {chunk_size}")
+                total_chunks = (len(df) + chunk_size - 1) // chunk_size
+                logger.info(f"Total chunks to process: {total_chunks}")
+                if progress_tracker:
+                    progress_tracker.update(
+                        0,
+                        {
+                            "step": "Processing in chunks",
+                            "total_chunks": total_chunks,
+                        },
+                    )
+
+                logger.info("Process using chunk")
+
+                results = analyze_mvf_in_chunks(
+                    df=df,
+                    field_name=field_name,
+                    top_n=top_n,
+                    parse_args=parse_args,
+                    chunk_size=chunk_size,
+                    progress_tracker=progress_tracker,
+                    task_logger=logger,
+                )
+
+                if results is not None:
+                    flag_processed = True
+                    logger.info("Completed using chunk")
+
+            except Exception as e:
+                logger.warning(
+                    f"Error in chunk processing: {e}, falling back to chunk processing"
+                )
+
+        if not flag_processed:
+            logger.info("Fallback process as usual")
+            # Map partitions for processing
+            parsed_df = process_mvf_partition(
+                partition=df,
+                field_name=field_name,
+                parse_args=parse_args,
+            )
+            # Aggregate results
+            total_records = len(df)
+            null_count = df[field_name].isna().sum()
+            results = aggregate_mvf_analysis(
+                parsed_df, total_records, null_count, field_name, top_n=top_n
+            )
+            logger.info("Process using normal")
+            flag_processed = True
+
+        return results
 
     @staticmethod
-    def parse_field(df: pd.DataFrame,
-                    field_name: str,
-                    format_type: Optional[str] = None,
-                    **kwargs) -> pd.DataFrame:
+    def parse_field(
+        df: pd.DataFrame, field_name: str, format_type: Optional[str] = None, **kwargs
+    ) -> pd.DataFrame:
         """
         Parse an MVF field and add a new column with parsed values.
 
@@ -127,7 +279,7 @@ class MVFAnalyzer:
         logger.info(f"Parsing MVF field: {field_name}")
 
         parse_args = kwargs.copy()
-        parse_args['format_type'] = format_type
+        parse_args["format_type"] = format_type
 
         # Apply parsing to each value
         result_df[parsed_column] = result_df[field_name].apply(
@@ -137,10 +289,9 @@ class MVFAnalyzer:
         return result_df
 
     @staticmethod
-    def create_value_dictionary(df: pd.DataFrame,
-                                field_name: str,
-                                min_frequency: int = 1,
-                                **kwargs) -> pd.DataFrame:
+    def create_value_dictionary(
+        df: pd.DataFrame, field_name: str, min_frequency: int = 1, parse_args: Optional[Dict[str, Any]] = None
+    ) -> pd.DataFrame:
         """
         Create a dictionary of values with frequencies for an MVF field.
 
@@ -152,7 +303,7 @@ class MVFAnalyzer:
             The name of the field
         min_frequency : int
             Minimum frequency for inclusion in the dictionary
-        **kwargs : dict
+        parse_args : Any
             Additional parameters for parsing
 
         Returns:
@@ -161,17 +312,13 @@ class MVFAnalyzer:
             DataFrame with values and frequencies
         """
         return create_value_dictionary(
-            df=df,
-            field_name=field_name,
-            min_frequency=min_frequency,
-            parse_args=kwargs
+           df=df, field_name=field_name, min_frequency=min_frequency, parse_args=parse_args
         )
 
     @staticmethod
-    def create_combinations_dictionary(df: pd.DataFrame,
-                                       field_name: str,
-                                       min_frequency: int = 1,
-                                       **kwargs) -> pd.DataFrame:
+    def create_combinations_dictionary(
+        df: pd.DataFrame, field_name: str, min_frequency: int = 1, parse_args: Optional[Dict[str, Any]] = None
+    ) -> pd.DataFrame:
         """
         Create a dictionary of value combinations with frequencies for an MVF field.
 
@@ -183,7 +330,7 @@ class MVFAnalyzer:
             The name of the field
         min_frequency : int
             Minimum frequency for inclusion in the dictionary
-        **kwargs : dict
+        parse_args : dict
             Additional parameters for parsing
 
         Returns:
@@ -192,16 +339,13 @@ class MVFAnalyzer:
             DataFrame with combinations and frequencies
         """
         return create_combinations_dictionary(
-            df=df,
-            field_name=field_name,
-            min_frequency=min_frequency,
-            parse_args=kwargs
+            df=df, field_name=field_name, min_frequency=min_frequency, parse_args=parse_args
         )
 
     @staticmethod
-    def analyze_value_counts(df: pd.DataFrame,
-                             field_name: str,
-                             **kwargs) -> Dict[str, int]:
+    def analyze_value_counts(
+        df: pd.DataFrame, field_name: str, **kwargs
+    ) -> Dict[str, int]:
         """
         Analyze the distribution of value counts per record in an MVF field.
 
@@ -220,9 +364,7 @@ class MVFAnalyzer:
             Distribution of value counts
         """
         return analyze_value_count_distribution(
-            df=df,
-            field_name=field_name,
-            parse_args=kwargs
+            df=df, field_name=field_name, parse_args=kwargs
         )
 
     @staticmethod
@@ -245,6 +387,46 @@ class MVFAnalyzer:
         return estimate_resources(df, field_name)
 
 
+class MVFAnalysisOperationConfig(OperationConfig):
+    """Configuration for MVFOperation."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "field_name": {"type": "string"},
+            "top_n": {"type": "integer", "minimum": 1, "default": 20},
+            "min_frequency": {"type": "integer", "minimum": 1, "default": 1},
+            "format_type": {"type": "string", "default": None},
+            "parse_kwargs": {"type": "object", "default": {}},
+            "chunk_size": {"type": "integer", "minimum": 1},
+            "use_cache": {"type": "boolean"},
+            "use_dask": {"type": "boolean"},
+            "npartitions": {"type": ["integer", "null"]},
+            "use_vectorization": {"type": "boolean"},
+            "parallel_processes": {"type": ["integer", "null"]},
+            "use_encryption": {"type": "boolean"},
+            "encryption_key": {"type": ["string", "null"]},
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {
+                "type": ["string", "null"],
+                "enum": ["plotly", "matplotlib", None],
+            },
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
+            # Output format properties
+            "output_format": {
+                "type": "string",
+                "enum": ["csv", "parquet", "json"],
+                "default": "csv",
+            },
+        },
+        "required": [
+            "field_name",
+        ],
+    }
+
+
 @register(override=True)
 class MVFOperation(FieldOperation):
     """
@@ -254,18 +436,28 @@ class MVFOperation(FieldOperation):
     executing analysis, saving results, and generating artifacts.
     """
 
-    def __init__(self,
-                 field_name: str,
-                 top_n: int = 20,
-                 min_frequency: int = 1,
-                 generate_plots: bool = True,
-                 include_timestamp: bool = True,
-                 profile_type: str = 'mvf',
-                 format_type: Any = None,
-                 parse_kwargs: Any = {},
-                 description: str = "",
-                 use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+    def __init__(
+        self,
+        field_name: str,
+        top_n: int = 20,
+        min_frequency: int = 1,
+        format_type: Optional[str] = None,
+        parse_kwargs: Dict[str, Any] = {},
+        chunk_size: int = 10000,
+        use_dask: bool = False,
+        npartitions: Optional[int] = None,
+        use_vectorization: bool = False,
+        parallel_processes: Optional[int] = None,
+        use_cache: bool = True,
+        use_encryption: bool = False,
+        encryption_key: Optional[Union[str, Path]] = None,
+        visualization_theme: Optional[str] = None,
+        visualization_backend: Optional[str] = None,
+        visualization_strict: bool = False,
+        visualization_timeout: int = 120,
+        output_format: str = "csv",
+        description: str = "",
+    ):
         """
         Initialize the MVF operation.
 
@@ -277,33 +469,109 @@ class MVFOperation(FieldOperation):
             Number of top values to include in the results
         min_frequency : int
             Minimum frequency for inclusion in the dictionary
-        description : str
-            Description of the operation (optional)
+        format_type : str, optional
+            Format type hint for parsing (default: None)
+        parse_kwargs : dict, optional
+            Additional parameters for parsing (default: {})
+        chunk_size : int, optional
+            Chunk size for processing large datasets (default: 10000)
+        use_dask : bool, optional
+            Whether to use Dask for parallel processing (default: False)
+        npartitions : Optional[int], optional
+            Number of partitions to use with Dask (default: None)
+        use_vectorization : bool, optional
+            Whether to use vectorized operations (default: False)
+        parallel_processes : Optional[int], optional
+            Number of parallel processes to use (default: None)
+        use_cache : bool, optional
+            Whether to use operation caching (default: True)
+        use_encryption : bool, optional
+            Whether to encrypt output files (default: False)
+        encryption_key : Optional[Union[str, Path]], optional
+            Encryption key for securing outputs (default: None)
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
+        output_format : str, optional
+            Output file format: "csv", "parquet", or "json" (default: "csv")
+        description : str, optional
+            Operation description (default: "")
         """
+        # Use default description if not provided
+        if not description:
+            description = f"Analysis of MVF field '{field_name}'"
+
+        # Build config parameters, excluding None values for optional fields
+        config_params = {
+            "field_name": field_name,
+            "top_n": top_n,
+            "min_frequency": min_frequency,
+            "format_type": format_type,
+            "parse_kwargs": parse_kwargs,
+            "chunk_size": chunk_size,
+            "use_dask": use_dask,
+            "npartitions": npartitions,
+            "use_vectorization": use_vectorization,
+            "parallel_processes": parallel_processes,
+            "use_cache": use_cache,
+            "use_encryption": use_encryption,
+            "encryption_key": encryption_key,
+            "visualization_theme": visualization_theme,
+            "visualization_backend": visualization_backend,
+            "visualization_strict": visualization_strict,
+            "visualization_timeout": visualization_timeout,
+            "output_format": output_format,
+        }
+
+        # Create configuration and validate parameters
+        config = MVFAnalysisOperationConfig(**config_params)
+
         super().__init__(
             field_name=field_name,
-            description=description or f"Analysis of multi-valued field '{field_name}'",
+            description=description,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
-            )
-        
-        self.top_n = top_n
-        self.min_frequency = min_frequency
-        self.generate_plots = generate_plots
-        self.include_timestamp = include_timestamp
-        self.profile_type = profile_type
-        self.format_type = format_type
-        self.parse_kwargs = parse_kwargs
-        self.min_frequency = min_frequency
+            encryption_key=encryption_key,
+            config=config,
+        )
 
-    def execute(self,
-                data_source: DataSource,
-                task_dir: Path,
-                reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
-                **kwargs) -> OperationResult:
+        # Assign instance properties from config
+        for key, value in config_params.items():
+            setattr(self, key, value)
+
+        # Optionally store the config
+        self.config = config
+
+        # Set up performance tracking variables
+        self.start_time = None
+        self.end_time = None
+        self.process_count = 0
+
+        # Set up common variables
+        self.force_recalculation = False  # Skip cache check
+        self.generate_visualization = True  # Create visualizations
+        self.encrypt_output = False  # Override encryption setting
+
+        # Updated version for fixes
+        self.version = "1.4.1"
+
+        # Temporary storage for cleanup
+        self.operation_cache = None
+
+    def execute(
+        self,
+        data_source: DataSource,
+        task_dir: Path,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        **kwargs,
+    ) -> OperationResult:
         """
-        Execute the MVF analysis operation.
+        Execute the operation with timing and error handling.
 
         Parameters:
         -----------
@@ -313,316 +581,1351 @@ class MVFOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : Optional[ProgressTracker]
             Progress tracker for the operation
         **kwargs : dict
-            Additional parameters for the operation:
-            - generate_plots: bool, whether to generate visualizations
-            - include_timestamp: bool, whether to include timestamps in filenames
-            - profile_type: str, type of profiling for organizing artifacts
-            - format_type: str, format type hint for parsing
-            - parse_kwargs: dict, additional parameters for MVF parsing
+            Additional parameters for the operation including:
+            - force_recalculation: bool - Skip cache check
+            - generate_visualization: bool - Create visualizations
+            - encrypt_output: bool - Override encryption setting
+            - visualization_theme: str - Override theme for visualizations
+            - visualization_backend: str - Override backend for visualizations
+            - visualization_strict: bool - Override strict mode for visualizations
+            - visualization_timeout: int - Override timeout for visualizations
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
-        # Extract parameters from kwargs
-        generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        profile_type = kwargs.get('profile_type', self.profile_type)
-        format_type = kwargs.get('format_type', self.format_type)
-        parse_kwargs = kwargs.get('parse_kwargs', self.parse_kwargs)
-        encryption_key = kwargs.get('encryption_key', None)
+        # Initialize timing and result
+        self.start_time = time.time()
+        self.logger = kwargs.get("logger", self.logger)
+        self.logger.info(f"Starting {self.name} operation at {self.start_time}")
+        self.process_count = 0
+        df = None
+        result = OperationResult(status=OperationStatus.PENDING)
 
-        # Set up directories
-        dirs = self._prepare_directories(task_dir)
-        output_dir = dirs['output']
-        visualizations_dir = dirs['visualizations']
-        dictionaries_dir = dirs['dictionaries']
+        # Prepare directories for artifacts
+        directories = self._prepare_directories(task_dir)
 
-        # Create the main result object with initial status
-        result = OperationResult(status=OperationStatus.SUCCESS)
+        # Initialize operation cache
+        self.operation_cache = OperationCache(
+            cache_dir=task_dir / "cache",
+        )
 
-        # Update progress if tracker provided
-        if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+        # Save configuration to task directory
+        self.save_config(task_dir)
 
+        # Create DataWriter for consistent file operations
+        writer = DataWriter(
+            task_dir=task_dir, logger=self.logger, progress_tracker=progress_tracker
+        )
+
+        # Decompose kwargs and introduce variables for clarity
+        self.encrypt_output = kwargs.get("encrypt_output", False) or self.use_encryption
+        self.generate_visualization = kwargs.get("generate_visualization", True)
+        self.save_output = kwargs.get("save_output", True)
+        self.force_recalculation = kwargs.get("force_recalculation", False)
+        dataset_name = kwargs.get("dataset_name", "main")
+
+        # Extract visualization parameters
+        self.visualization_theme = kwargs.get(
+            "visualization_theme", self.visualization_theme
+        )
+        self.visualization_backend = kwargs.get(
+            "visualization_backend", self.visualization_backend
+        )
+        self.visualization_strict = kwargs.get(
+            "visualization_strict", self.visualization_strict
+        )
+        self.visualization_timeout = kwargs.get(
+            "visualization_timeout", self.visualization_timeout
+        )
+
+        self.logger.info(
+            f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+        )
         try:
+            # Set up progress tracking with proper steps
+            # Main steps: 1. Cache check, 2. Validation, 3. Data loading, 4. Processing, 5. Metrics, 6. Visualization, 7. Save output
+            TOTAL_MAIN_STEPS = 6 + (
+                1 if self.use_cache and not self.force_recalculation else 0
+            )
+            main_progress = progress_tracker
+            current_steps = 0
+            if main_progress:
+                self.logger.info(
+                    f"Setting up progress tracker with {TOTAL_MAIN_STEPS} main steps"
+                )
+                try:
+                    main_progress.total = TOTAL_MAIN_STEPS
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS,
+                        current_steps,
+                        {
+                            "step": "Starting MVF analysis",
+                        },
+                        main_progress,
+                    )
+                except Exception as e:
+                    self.logger.warning(f"Could not update progress tracker: {e}")
+
             # Get DataFrame from data source
-            dataset_name = kwargs.get('dataset_name', "main")
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
-            df = load_data_operation(data_source, dataset_name, **settings_operation)
-            if df is None:
+            settings_operation = load_settings_operation(
+                data_source, dataset_name, **kwargs
+            )
+
+            # Check Cache (if enabled and not forced to recalculate)
+            if self.use_cache and not self.force_recalculation:
+                # Step 1: Check if we have a cached result
+                if main_progress:
+                    current_steps += 1
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS, current_steps, "Checking cache", main_progress
+                    )
+
+                # Load left dataset for check cache
+                df = load_data_operation(
+                    data_source, dataset_name, **settings_operation
+                )
+                if df is None:
+                    return OperationResult(
+                        status=OperationStatus.ERROR,
+                        error_message="No valid DataFrame found in data source",
+                    )
+
+                self.logger.info(
+                    f"Field: '{self.field_name}' loaded with {len(df)} records."
+                )
+
+                self.logger.info("Checking operation cache...")
+                cache_result = self._check_cache(df=df, reporter=reporter)
+                if cache_result:
+                    self.logger.info("Cache hit! Using cached results.")
+
+                    # Update progress
+                    if main_progress:
+                        self._update_progress_tracker(
+                            TOTAL_MAIN_STEPS,
+                            current_steps,
+                            "Complete (cached)",
+                            main_progress,
+                        )
+
+                    return cache_result
+
+            # Step 2: Data Loading
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Data Loading", main_progress
+                )
+
+            try:
+                # Load DataFrame
+                if df is None:
+                    df = load_data_operation(
+                        data_source, dataset_name, **settings_operation
+                    )
+                    if df is None:
+                        return OperationResult(
+                            status=OperationStatus.ERROR,
+                            error_message="No valid DataFrame found in data source",
+                        )
+            except Exception as e:
+                error_message = f"Error loading data: {str(e)}"
+                self.logger.error(error_message)
                 return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message="No valid DataFrame found in data source"
+                    status=OperationStatus.ERROR, error_message=error_message
+                )
+
+            # Step 3: Validation
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Validation", main_progress
                 )
 
             # Check if field exists
             if self.field_name not in df.columns:
                 return OperationResult(
                     status=OperationStatus.ERROR,
-                    error_message=f"Field {self.field_name} not found in DataFrame"
+                    error_message=f"Field {self.field_name} not found in DataFrame",
                 )
 
             # Add operation to reporter
-            reporter.add_operation(f"Analyzing multi-valued field: {self.field_name}", details={
-                "field_name": self.field_name,
-                "top_n": self.top_n,
-                "min_frequency": self.min_frequency,
-                "operation_type": "mvf_analysis"
-            })
-
-            # Adjust progress tracker total steps if provided
-            total_steps = 5  # Preparation, analysis, saving results, dictionaries, visualization
-            if progress_tracker:
-                progress_tracker.total = total_steps
-                progress_tracker.update(0, {"status": "Analyzing field"})
-
-            # Execute the analyzer
-            analysis_results = MVFAnalyzer.analyze(
-                df=df,
-                field_name=self.field_name,
-                top_n=self.top_n,
-                min_frequency=self.min_frequency,
-                format_type=format_type,
-                **parse_kwargs
+            reporter.add_operation(
+                f"Analyzing multi-valued field: {self.field_name}",
+                details={
+                    "field_name": self.field_name,
+                    "top_n": self.top_n,
+                    "min_frequency": self.min_frequency,
+                    "operation_type": "mvf_analysis",
+                },
             )
 
-            # Check for errors
-            if 'error' in analysis_results:
-                return OperationResult(
-                    status=OperationStatus.ERROR,
-                    error_message=analysis_results['error']
+            # Step 4: Processing progress tracker
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Processing data", main_progress
                 )
 
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Analysis complete", "field": self.field_name})
+            # Detect format type if not set
+            if self.format_type is None:
+                self.format_type = detect_mvf_format(df[self.field_name])
 
-            # Save analysis results to JSON
-            stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
-            stats_path = output_dir / stats_filename
+            try:
+                self.logger.info(f"Processing with field_name: {self.field_name}")
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
-            result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
+                # Create child progress tracker for chunk processing
+                data_tracker = None
+                if main_progress and hasattr(main_progress, "create_subtask"):
+                    try:
+                        data_tracker = main_progress.create_subtask(
+                            total=3,
+                            description="MVF analysis processing",
+                            unit="steps",
+                        )
+                    except Exception as e:
+                        self.logger.debug(
+                            f"Could not create child progress tracker: {e}"
+                        )
 
-            # Add to reporter
-            reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
+                # Combine parsing arguments
+                parse_args = {**self.parse_kwargs, "format_type": self.format_type}
 
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved analysis results"})
+                # Execute the analyzer
+                self.logger.info("Executing MVF analysis")
+                analysis_results = MVFAnalyzer.analyze(
+                    df=df,
+                    field_name=self.field_name,
+                    top_n=self.top_n,
+                    parse_args=parse_args,
+                    chunk_size=self.chunk_size,
+                    use_dask=self.use_dask,
+                    npartitions=self.npartitions,
+                    use_vectorization=self.use_vectorization,
+                    parallel_processes=self.parallel_processes,
+                    task_logger=self.logger,
+                    progress_tracker=data_tracker,
+                )
 
-            # Create and save value dictionary
-            values_dict = MVFAnalyzer.create_value_dictionary(
-                df=df,
-                field_name=self.field_name,
-                min_frequency=self.min_frequency,
-                format_type=format_type,
-                **parse_kwargs
+                # Check for errors
+                if "error" in analysis_results:
+                    self.logger.error(analysis_results["error"])
+                    return OperationResult(
+                        status=OperationStatus.ERROR,
+                        error_message=analysis_results["error"],
+                    )
+
+                # Create and save value dictionary
+                self.logger.info("Creating value dictionary")
+                values_dict = MVFAnalyzer.create_value_dictionary(
+                    df=df,
+                    field_name=self.field_name,
+                    min_frequency=self.min_frequency,
+                    parse_args=parse_args,
+                )
+
+                # Create and save combinations dictionary
+                self.logger.info("Creating combinations dictionary")
+                combinations_dict = MVFAnalyzer.create_combinations_dictionary(
+                    df=df,
+                    field_name=self.field_name,
+                    min_frequency=self.min_frequency,
+                    parse_args=parse_args,
+                )
+
+                # Close child progress tracker
+                if data_tracker:
+                    try:
+                        data_tracker.close()
+                    except:
+                        pass
+
+                self.logger.info(
+                    f"Processed data: {len(df)} records, dtype: {df.dtypes}"
+                )
+
+                # Log sample of processed data
+                if len(df) > 0:
+                    self.logger.debug(
+                        f"Sample of processed data (first 5 rows): {df.head(5).to_dict(orient='records')}"
+                    )
+            except Exception as e:
+                error_message = f"Processing error: {str(e)}"
+                self.logger.error(error_message)
+                return OperationResult(
+                    status=OperationStatus.ERROR, error_message=error_message
+                )
+
+            # Step 5: Metrics Calculation
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Metrics Calculation",
+                    main_progress,
+                )
+
+            # Generate single timestamp for all artifacts
+            operation_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+            # Initialize metrics in scope
+            metrics = {}
+
+            try:
+                # Save identifier statistics
+                if analysis_results and "error" not in analysis_results:
+                    # Generate metrics file name
+                    statistics_filename = f"{self.field_name}_{self.name}_statistical_analysis_metrics_{operation_timestamp}"
+
+                    # Write metrics to persistent storage/artifact repository
+                    statistics_metrics_result = writer.write_metrics(
+                        metrics=analysis_results,
+                        name=statistics_filename,
+                        timestamp_in_name=False,
+                        encryption_key=(
+                            self.encryption_key if self.encrypt_output else None
+                        ),
+                    )
+
+                    # Add simple metrics (int, float, str, bool) to the result object
+                    for key, value in analysis_results.items():
+                        if isinstance(value, (int, float, str, bool)):
+                            result.add_metric(key, value)
+
+                    result.add_artifact(
+                        artifact_type="json",
+                        path=statistics_metrics_result.path,
+                        description=f"{self.name} profiling on {self.field_name} statistical analysis metrics",
+                        category=Constants.Artifact_Category_Metrics,
+                    )
+
+                    # Add identifier stats to metrics dictionary
+                    metrics["analysis_results"] = analysis_results
+                    metrics["statistics_metrics_result_path"] = (
+                        statistics_metrics_result.path
+                    )
+            except Exception as e:
+                error_message = f"Error calculating metrics: {str(e)}"
+                self.logger.warning(error_message)
+                # Continue execution - metrics failure is not critical
+
+            # Step 6: Visualizations
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Generating Visualizations",
+                    main_progress,
+                )
+            # Generate visualizations if required
+            # Initialize visualization paths dictionary
+            visualization_paths = {}
+            if self.generate_visualization and self.visualization_backend is not None:
+                try:
+                    kwargs_encryption = {
+                        "use_encryption": self.encrypt_output,
+                        "encryption_key": self.encryption_key,
+                    }
+                    visualization_paths = self._handle_visualizations(
+                        analysis_results=analysis_results,
+                        task_dir=task_dir,
+                        result=result,
+                        reporter=reporter,
+                        progress_tracker=main_progress,
+                        vis_theme=self.visualization_theme,
+                        vis_backend=self.visualization_backend,
+                        vis_strict=self.visualization_strict,
+                        vis_timeout=self.visualization_timeout,
+                        operation_timestamp=operation_timestamp,
+                        **kwargs_encryption,
+                    )
+                except Exception as e:
+                    error_message = f"Error generating visualizations: {str(e)}"
+                    self.logger.warning(error_message)
+                    # Continue execution - visualization failure is not critical
+            else:
+                self.logger.info(
+                    "Skipping visualizations as generate_visualization is False or backend is not set"
+                )
+
+            # Step 7: Save output data
+            self.logger.info("Step 7: Saving output data")
+            if main_progress:
+                current_steps += 1
+                main_progress.update(current_steps, {"step": "Saving output data"})
+
+            # Save output data if required
+            if self.save_output:
+                try:
+                    # Save values dictionary
+                    values_str_path = self._save_output_data(
+                        df=values_dict,
+                        suffix="values_dictionary",
+                        is_encryption_required=self.encrypt_output,
+                        writer=writer,
+                        result=result,
+                        reporter=reporter,
+                        progress_tracker=main_progress,
+                        timestamp=operation_timestamp,
+                        **kwargs,
+                    )
+
+                    # Save combinations dictionary
+                    combinations_str_path = self._save_output_data(
+                        df=combinations_dict,
+                        suffix="combinations_dictionary",
+                        is_encryption_required=self.encrypt_output,
+                        writer=writer,
+                        result=result,
+                        reporter=reporter,
+                        progress_tracker=main_progress,
+                        timestamp=operation_timestamp,
+                        **kwargs,
+                    )
+                except Exception as e:
+                    error_message = f"Error saving output data: {str(e)}"
+                    self.logger.error(error_message)
+                    return OperationResult(
+                        status=OperationStatus.ERROR, error_message=error_message
+                    )
+
+            # Cache the result if caching is enabled
+            if self.use_cache:
+                try:
+                    self._save_to_cache(
+                        original_data=df,
+                        metrics=metrics,
+                        visualization_paths=visualization_paths,
+                        task_dir=task_dir,
+                        values_str_path=values_str_path,
+                        combinations_str_path=combinations_str_path,
+                    )
+                except Exception as e:
+                    # Failure to cache is non-critical
+                    self.logger.warning(f"Failed to cache results: {str(e)}")
+
+            # Cleanup memory
+            self._cleanup_memory(df, values_dict, combinations_dict)
+
+            # Record end time
+            self.end_time = time.time()
+
+            # Report completion
+            if reporter:
+                # Create the details dictionary with checks for all values
+                details = {
+                    "records_processed": self.process_count,
+                    "execution_time": (
+                        self.end_time - self.start_time
+                        if self.end_time and self.start_time
+                        else None
+                    ),
+                }
+
+                # Add the operation to the reporter
+                reporter.add_operation(
+                    f"Analyzing MVF {self.field_name} completed",
+                    details={
+                        "unique_values": analysis_results.get("unique_values", 0),
+                        "unique_combinations": analysis_results.get(
+                            "unique_combinations", 0
+                        ),
+                        "avg_values_per_record": analysis_results.get(
+                            "avg_values_per_record", 0
+                        ),
+                        "null_percentage": analysis_results.get("null_percentage", 0),
+                    },
+                )
+
+            self.logger.info(
+                f"Processing completed {self.name} operation in {self.end_time - self.start_time:.2f} seconds"
             )
 
-            if not values_dict.empty:
-                values_dict_filename = get_timestamped_filename(f"{self.field_name}_values_dictionary", "csv",
-                                                                include_timestamp)
-                values_dict_path = dictionaries_dir / values_dict_filename
-                write_dataframe_to_csv(df=values_dict, file_path=values_dict_path, index=False, encoding='utf-8', encryption_key=encryption_key)
-
-                result.add_artifact("csv", values_dict_path, f"{self.field_name} values dictionary", category=Constants.Artifact_Category_Dictionary)
-                reporter.add_artifact("csv", str(values_dict_path), f"{self.field_name} values dictionary")
-
-            # Create and save combinations dictionary
-            combinations_dict = MVFAnalyzer.create_combinations_dictionary(
-                df=df,
-                field_name=self.field_name,
-                min_frequency=self.min_frequency,
-                format_type=format_type,
-                **parse_kwargs
-            )
-
-            if not combinations_dict.empty:
-                combinations_dict_filename = get_timestamped_filename(f"{self.field_name}_combinations_dictionary",
-                                                                      "csv", include_timestamp)
-                combinations_dict_path = dictionaries_dir / combinations_dict_filename
-                write_dataframe_to_csv(df=combinations_dict, file_path=combinations_dict_path, index=False, encoding='utf-8', encryption_key=encryption_key)
-
-                result.add_artifact("csv", combinations_dict_path, f"{self.field_name} combinations dictionary", category=Constants.Artifact_Category_Dictionary)
-                reporter.add_artifact("csv", str(combinations_dict_path), f"{self.field_name} combinations dictionary")
-
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Saved dictionaries"})
-
-            # Generate visualizations if requested
-            if generate_plots:
-                # Values distribution visualization
-                if 'values_analysis' in analysis_results and analysis_results['values_analysis']:
-                    values_viz_filename = get_timestamped_filename(f"{self.field_name}_values_distribution", "png",
-                                                                   include_timestamp)
-                    values_viz_path = visualizations_dir / values_viz_filename
-
-                    # Create visualization using the visualization module
-                    title = f"Distribution of values in {self.field_name}"
-                    viz_result = plot_value_distribution(
-                        data=analysis_results['values_analysis'],
-                        output_path=str(values_viz_path),
-                        title=title,
-                        max_items=self.top_n,
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", values_viz_path, f"{self.field_name} values distribution", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(values_viz_path), f"{self.field_name} values distribution")
-                    else:
-                        logger.warning(f"Error creating values visualization: {viz_result}")
-
-                # Combinations distribution visualization
-                if 'combinations_analysis' in analysis_results and analysis_results['combinations_analysis']:
-                    combos_viz_filename = get_timestamped_filename(f"{self.field_name}_combinations_distribution",
-                                                                   "png", include_timestamp)
-                    combos_viz_path = visualizations_dir / combos_viz_filename
-
-                    # Create visualization using the visualization module
-                    title = f"Distribution of combinations in {self.field_name}"
-                    viz_result = plot_value_distribution(
-                        data=analysis_results['combinations_analysis'],
-                        output_path=str(combos_viz_path),
-                        title=title,
-                        max_items=min(10, len(analysis_results['combinations_analysis'])),
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", combos_viz_path, f"{self.field_name} combinations distribution", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(combos_viz_path),
-                                              f"{self.field_name} combinations distribution")
-                    else:
-                        logger.warning(f"Error creating combinations visualization: {viz_result}")
-
-                # Value counts distribution visualization
-                if 'value_counts_distribution' in analysis_results and analysis_results['value_counts_distribution']:
-                    counts_viz_filename = get_timestamped_filename(f"{self.field_name}_value_counts_distribution",
-                                                                   "png", include_timestamp)
-                    counts_viz_path = visualizations_dir / counts_viz_filename
-
-                    # Create the data for bar plot - convert string keys to integers and then back to strings
-                    # to match the expected Dict[str, Any] type
-                    counts_data = {}
-                    for k, v in analysis_results['value_counts_distribution'].items():
-                        try:
-                            # Convert key to int, then back to string for visualization
-                            counts_data[str(int(k))] = v
-                        except ValueError:
-                            # If key can't be converted to int, keep as is
-                            counts_data[k] = v
-
-                    # Sort by numeric value of the key
-                    sorted_keys = sorted(counts_data.keys(), key=lambda x: int(x) if x.isdigit() else float('inf'))
-                    sorted_counts_data = {k: counts_data[k] for k in sorted_keys}
-
-                    # Create visualization using the visualization module
-                    title = f"Distribution of value counts in {self.field_name}"
-                    viz_result = create_bar_plot(
-                        data=sorted_counts_data,
-                        output_path=str(counts_viz_path),
-                        title=title,
-                        orientation="v",
-                        x_label="Number of values per record",
-                        y_label="Frequency",
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", counts_viz_path, f"{self.field_name} value counts distribution", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(counts_viz_path),
-                                              f"{self.field_name} value counts distribution")
-                    else:
-                        logger.warning(f"Error creating value counts visualization: {viz_result}")
-
-            # Update progress
-            if progress_tracker:
-                progress_tracker.update(1, {"step": "Created visualizations"})
-
-            # Add metrics to the result
-            result.add_metric("total_records", analysis_results.get('total_records', 0))
-            result.add_metric("null_count", analysis_results.get('null_count', 0))
-            result.add_metric("null_percentage", analysis_results.get('null_percentage', 0))
-            result.add_metric("empty_arrays_count", analysis_results.get('empty_arrays_count', 0))
-            result.add_metric("unique_values", analysis_results.get('unique_values', 0))
-            result.add_metric("unique_combinations", analysis_results.get('unique_combinations', 0))
-            result.add_metric("avg_values_per_record", analysis_results.get('avg_values_per_record', 0))
-
-            if 'error_count' in analysis_results:
-                result.add_metric("error_count", analysis_results.get('error_count', 0))
-                result.add_metric("error_percentage", analysis_results.get('error_percentage', 0))
-
-            # Add final operation status to reporter
-            reporter.add_operation(f"Analysis of {self.field_name} completed", details={
-                "unique_values": analysis_results.get('unique_values', 0),
-                "unique_combinations": analysis_results.get('unique_combinations', 0),
-                "avg_values_per_record": analysis_results.get('avg_values_per_record', 0),
-                "null_percentage": analysis_results.get('null_percentage', 0)
-            })
-
+            # Set success status
+            result.status = OperationStatus.SUCCESS
             return result
 
         except Exception as e:
-            logger.exception(f"Error in MVF operation for {self.field_name}: {e}")
-
-            # Update progress tracker on error
-            if progress_tracker:
-                progress_tracker.update(0, {"step": "Error", "error": str(e)})
-
-            # Add error to reporter
-            reporter.add_operation(f"Error analyzing {self.field_name}",
-                                   status="error",
-                                   details={"error": str(e)})
-
+            # Handle any unexpected errors
+            error_message = f"Error in analyzing MVF operation: {str(e)}"
+            self.logger.exception(error_message)
             return OperationResult(
                 status=OperationStatus.ERROR,
-                error_message=f"Error analyzing MVF field {self.field_name}: {str(e)}"
+                error_message=f"Error analyzing MVF field {self.field_name}: {str(e)}",
+            )
+
+    def _cleanup_memory(
+        self,
+        original_df: Optional[pd.DataFrame] = None,
+        values_dict: Optional[Dict[str, Any]] = None,
+        combinations_dict: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Clean up memory after operation completes.
+
+        For large datasets, explicitly free memory by deleting
+        references and optionally calling garbage collection.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame, optional
+            Original DataFrame to clear from memory
+        values_dict : dict, optional
+            Dictionary containing values to clear from memory
+        combinations_dict : dict, optional
+            Dictionary containing combinations to clear from memory
+        """
+        # Delete references
+        if original_df is not None:
+            del original_df
+        if values_dict is not None:
+            del values_dict
+        if combinations_dict is not None:
+            del combinations_dict
+
+        # Clear operation cache
+        if hasattr(self, "operation_cache"):
+            self.operation_cache = None
+
+        # Additional cleanup for any temporary attributes
+        for attr_name in list(vars(self).keys()):
+            if attr_name.startswith("_temp_"):
+                delattr(self, attr_name)
+
+        # Optional: Force garbage collection for large datasets
+        # Uncomment if memory pressure is an issue
+        # import gc
+        # gc.collect()
+
+    def _generate_cache_key(self, data: pd.DataFrame) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        data : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        # Get basic operation parameters
+        parameters = self._get_basic_parameters()
+
+        # Add operation-specific parameters (could be overridden by subclasses)
+        parameters.update(self._get_cache_parameters())
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(data)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return self.operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash,
+        )
+
+    def _get_basic_parameters(self) -> Dict[str, str]:
+        """Get the basic parameters for the cache key generation."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+        }
+
+    def _get_cache_parameters(self) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        This method should be overridden by subclasses to provide
+        operation-specific parameters for caching.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Base implementation returns minimal parameters
+        params = {
+            "field_name": self.field_name,
+            "top_n": self.top_n,
+            "min_frequency": self.min_frequency,
+            "format_type": self.format_type,
+            "parse_kwargs": self.parse_kwargs,
+            "chunk_size": self.chunk_size,
+            "use_dask": self.use_dask,
+            "npartitions": self.npartitions,
+            "use_vectorization": self.use_vectorization,
+            "parallel_processes": self.parallel_processes,
+            "use_cache": self.use_cache,
+            "use_encryption": self.use_encryption,
+            "encryption_key": self.encryption_key,
+            "visualization_theme": self.visualization_theme,
+            "visualization_backend": self.visualization_backend,
+            "visualization_strict": self.visualization_strict,
+            "visualization_timeout": self.visualization_timeout,
+            "force_recalculation": self.force_recalculation,
+            "generate_visualization": self.generate_visualization,
+            "encrypt_output": self.encrypt_output,
+            "output_format": self.output_format,
+        }
+
+        return params
+
+    def _generate_data_hash(self, df: pd.DataFrame) -> str:
+        """
+        Generate a hash representing the key characteristics of the DataFrame.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns
+        -------
+        str
+            Hash string representing the data
+        """
+        import hashlib
+        import json
+
+        try:
+            # Generate summary statistics for all columns (numeric and non-numeric)
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string with consistent formatting (ISO for dates)
+            json_str = characteristics.to_json(date_format="iso")
+        except Exception as e:
+            self.logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback: use length and column data types
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+    def _save_to_cache(
+        self,
+        original_data: pd.DataFrame,
+        metrics: Dict[str, Any],
+        visualization_paths: Dict[str, Path],
+        task_dir: Path,
+        values_str_path: Optional[str] = None,
+        combinations_str_path: Optional[str] = None,
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        original_data : pd.DataFrame
+            Original input data
+        metrics : Dict[str, Any]
+            Metrics collected during the operation
+        visualization_paths : Dict[str, Path]
+            Paths to generated visualizations
+        task_dir : Path
+            Task directory
+        values_str_path : Optional[str] = None
+        combinations_str_path : Optional[str] = None
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache:
+            return False
+
+        try:
+            # Generate cache key
+            cache_key = self._generate_cache_key(original_data[self.field_name])
+
+            # Prepare metadata for cache
+            operation_params = self._get_basic_parameters()
+            operation_params.update(self._get_cache_parameters())
+
+            self.logger.debug(f"Operation parameters for cache: {operation_params}")
+
+            # Prepare cache data
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "metrics": metrics,
+                "parameters": operation_params,
+                "data_info": {
+                    "original_length": len(original_data),
+                    "original_null_count": int(original_data.isna().sum().sum()),
+                },
+                "visualizations": {
+                    k: str(v) for k, v in visualization_paths.items()
+                },  # Paths to visualizations
+                "values_str_path": values_str_path,
+                "combinations_str_path": combinations_str_path,
+            }
+
+            # Save to cache
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
+
+            success = self.operation_cache.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)},
+            )
+
+            if success:
+                self.logger.info(
+                    f"Successfully saved {self.field_name} profiling results to cache"
+                )
+            else:
+                self.logger.warning(
+                    f"Failed to save {self.field_name} profiling results to cache"
+                )
+
+            return success
+
+        except Exception as e:
+            self.logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+
+    def _check_cache(
+        self, df: pd.DataFrame, reporter: Any
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for this operation.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame for the operation
+        reporter : Any
+            Reporter object for tracking progress and artifacts
+
+        Returns
+        -------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            if self.field_name not in df.columns:
+                self.logger.warning(
+                    f"Field '{self.field_name}' not found in DataFrame."
+                )
+                return None
+
+            cache_key = self._generate_cache_key(df[self.field_name])
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+
+            cached_result = self.operation_cache.get_cache(
+                cache_key=cache_key, operation_type=self.__class__.__name__
+            )
+
+            if not cached_result:
+                self.logger.info("No cached result found, proceeding with operation")
+                return None
+
+            self.logger.info(
+                f"Using cached result for {self.field_name} of {self.name} profiling"
+            )
+
+            result = OperationResult(status=OperationStatus.SUCCESS)
+            # Restore cached data
+            self._add_cached_metrics(result, cached_result)
+            artifacts_restored = self._restore_cached_artifacts(
+                result, cached_result, reporter
+            )
+
+            # Add cache metadata
+            result.add_metric("cached", True)
+            result.add_metric("cache_key", cache_key)
+            result.add_metric(
+                "cache_timestamp", cached_result.get("timestamp", "unknown")
+            )
+            result.add_metric("artifacts_restored", artifacts_restored)
+
+            if reporter:
+                reporter.add_operation(
+                    f"{self.name} profiling of {self.field_name} (cached)",
+                    details={
+                        "field_name": self.field_name,
+                        "cached": True,
+                        "artifacts_restored": artifacts_restored,
+                    },
+                )
+
+            self.logger.info(
+                f"Cache hit successful: restored {artifacts_restored} artifacts"
+            )
+            return result
+
+        except Exception as e:
+            self.logger.warning(f"Error checking cache: {str(e)}")
+            return None
+
+    def _add_cached_metrics(self, result: OperationResult, cached: dict):
+        """
+        Add cached scalar metrics (int, float, str, bool) to the OperationResult.
+
+        Parameters
+        ----------
+        result : OperationResult
+            The result object to update.
+        cached : dict
+            Cached result dictionary from cache manager.
+        """
+        for key, value in cached.get("metrics", {}).items():
+            if isinstance(value, (int, float, str, bool)):
+                result.add_metric(key, value)
+
+    def _restore_cached_artifacts(
+        self, result: OperationResult, cached: dict, reporter: Optional[Any]
+    ) -> int:
+        """
+        Restore artifacts (output, metrics, visualizations) from cached result if files exist.
+
+        Parameters
+        ----------
+        result : OperationResult
+            OperationResult object to update with restored artifacts.
+        cached : dict
+            Cached result dictionary from cache manager.
+        reporter : Optional[Any]
+            Optional reporter object for tracking operation-level artifacts.
+
+        Returns
+        -------
+        int
+            Number of artifacts successfully restored.
+        """
+        artifacts_restored = 0
+
+        def restore_file_artifact(
+            path: Union[str, Path], artifact_type: str, desc_suffix: str, category: str
+        ):
+            """
+            Restore a single artifact from a file path if it exists.
+
+            Parameters
+            ----------
+            path : Union[str, Path]
+                Path to the artifact file.
+            artifact_type : str
+                Type of the artifact (e.g., 'json', 'csv', 'png').
+            desc_suffix : str
+                Description suffix (e.g., 'visualization', 'metrics').
+            category : str
+                Artifact category (e.g., output, metrics, visualization).
+            """
+            nonlocal artifacts_restored
+            if not path:
+                return
+
+            artifact_path = Path(path)
+            if artifact_path.exists():
+                result.add_artifact(
+                    artifact_type=artifact_type,
+                    path=artifact_path,
+                    description=f"{self.field_name} {desc_suffix} (cached)",
+                    category=category,
+                )
+                artifacts_restored += 1
+
+                if reporter:
+                    reporter.add_operation(
+                        f"{self.field_name} {desc_suffix} (cached)",
+                        details={
+                            "artifact_type": artifact_type,
+                            "path": str(artifact_path),
+                        },
+                    )
+            else:
+                self.logger.warning(f"Cached file not found: {artifact_path}")
+
+        # Restore main output and metrics artifacts
+        restore_file_artifact(
+            cached.get("values_str_path"),
+            self.output_format,
+            "generalized data",
+            Constants.Artifact_Category_Output,
+        )
+
+        # Restore main output and metrics artifacts
+        restore_file_artifact(
+            cached.get("combinations_str_path"),
+            self.output_format,
+            "generalized data",
+            Constants.Artifact_Category_Output,
+        )
+
+        # Restore visualizations
+        for viz_type, path_str in cached.get("visualizations", {}).items():
+            restore_file_artifact(
+                path_str,
+                "png",
+                f"{viz_type} visualization",
+                Constants.Artifact_Category_Visualization,
+            )
+
+        return artifacts_restored
+
+    def _save_output_data(
+        self,
+        df: pd.DataFrame,
+        suffix: str,
+        is_encryption_required: bool,
+        writer: DataWriter,
+        result: OperationResult,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+        timestamp: Optional[str] = None,
+        **kwargs,
+    ) -> Optional[str]:
+        """
+        Save the processed output data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            The dataframe to save
+        suffix : str
+            The suffix to append to the output filename
+        is_encryption_required : bool
+            Whether to encrypt the output
+        writer : DataWriter
+            The writer to use for saving data
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+        timestamp : Optional[str]
+            Optional timestamp for the operation
+        **kwargs : dict
+            Additional parameters for the operation
+        """
+        if df.empty:
+            return None
+
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Saving output data"})
+
+        custom_kwargs = {k: v for k, v in kwargs.items() if k != "encryption_key"}
+
+        # Generate standardized output filename with timestamp
+        filename = generate_visualization_filename(
+            self.field_name,
+            f"{self.name}_{suffix}",
+            "output",
+            timestamp=timestamp,
+        )
+
+        # Use the DataWriter to save the DataFrame
+        output_result = writer.write_dataframe(
+            df=df,
+            name=filename,
+            format=self.output_format,
+            subdir="output",
+            timestamp_in_name=False,
+            encryption_key=self.encryption_key if is_encryption_required else None,
+            **custom_kwargs,
+        )
+
+        # Get the output path
+        path = output_result.path
+
+        # Register output artifact with the result
+        result.add_artifact(
+            artifact_type=self.output_format,
+            path=path,
+            description=f"{self.field_name} generalized data",
+            category=Constants.Artifact_Category_Output,
+        )
+
+        # Report to reporter
+        if reporter:
+            reporter.add_operation(
+                f"{self.field_name} generalized data",
+                details={"artifact_type": self.output_format, "path": str(path)},
+            )
+
+        return str(path)
+
+    def _handle_visualizations(
+        self,
+        analysis_results: Dict[str, Any],
+        task_dir: Path,
+        result: OperationResult,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        vis_timeout: int = 120,
+        operation_timestamp: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Generate and save visualizations with thread-safe context support.
+
+        Parameters:
+        -----------
+        analysis_results : Dict[str, Any]
+            A dictionary containing various analysis results.
+        task_dir : Path
+            The task directory
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        operation_timestamp : str, optional
+            Timestamp for the operation (default: current time)
+        **kwargs: Any
+            Additional keyword arguments for visualization functions.
+        """
+        self.logger.info(
+            f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s"
+        )
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(
+                    f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}"
+                )
+                self.logger.info(
+                    f"[DIAG] Field: {self.field_name}, Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+                )
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(
+                            f"[DIAG] Context vars count: {len(list(current_context))}"
+                        )
+                    except Exception as ctx_e:
+                        self.logger.warning(
+                            f"[DIAG] Could not inspect context: {ctx_e}"
+                        )
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(
+                                f"Could not create child progress tracker: {e}"
+                            )
+
+                    # Generate visualizations with context parameters
+                    visualization_paths = self._generate_visualizations(
+                        analysis_results=analysis_results,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend or "plotly",
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        timestamp=operation_timestamp,  # Pass the same timestamp
+                        **kwargs,
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(
+                        f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}"
+                    )
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-{self.field_name}",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(
+                f"[DIAG] Starting visualization thread with timeout={vis_timeout}s"
+            )
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(
+                        f"[DIAG] Visualization thread still running after {elapsed:.1f}s..."
+                    )
+
+            if viz_thread.is_alive():
+                self.logger.error(
+                    f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout"
+                )
+                self.logger.error(
+                    f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}"
+                )
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(
+                    f"[DIAG] Visualization failed with error: {visualization_error}"
+                )
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(
+                    f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s"
+                )
+                self.logger.info(
+                    f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}"
+                )
+
+        except Exception as e:
+            self.logger.error(
+                f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}"
+            )
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{self.field_name} {viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization,
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_operation(
+                    f"{self.field_name} {viz_type} visualization",
+                    details={"artifact_type": "png", "path": str(path)},
+                )
+
+        return visualization_paths
+
+    def _generate_visualizations(
+        self,
+        analysis_results: Dict[str, Any],
+        task_dir: Path,
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        timestamp: Optional[str] = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Generate required visualizations for the merge operation using visualization utilities.
+
+        Parameters
+        ----------
+        analysis_results : Dict[str, Any]
+            A dictionary containing various analysis results.
+        task_dir : Path
+            The base directory where all task-related outputs (including visualizations) will be saved.
+        vis_theme : Optional[str]
+            The theme to use for visualizations.
+        vis_backend : Optional[str]
+            The backend to use for rendering visualizations.
+        vis_strict : bool
+            Whether to enforce strict visualization rules.
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Tracker for monitoring progress of the visualization generation.
+        timestamp : Optional[str]
+            Timestamp to include in visualization filenames.
+        **kwargs : Any
+            Additional keyword arguments for visualization functions.
+
+        Returns
+        -------
+        dict
+            A dictionary mapping visualization types to their corresponding file paths.
+        """
+        viz_dir = task_dir / "visualizations"
+        viz_dir.mkdir(parents=True, exist_ok=True)
+        visualization_paths = {}
+
+        # Use provided timestamp or generate new one
+        if timestamp is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(
+                f"Skipping visualization for {self.field_name} (backend=None)"
+            )
+            return visualization_paths
+
+        self.logger.info(
+            f"[VIZ] Starting visualization generation for {self.field_name}"
+        )
+        self.logger.debug(
+            f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+        )
+
+        try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
+            self.logger.debug(
+                f"[VIZ] Data prepared for visualization:analysis_results: {len(analysis_results)}"
+            )
+
+            # Step 2: Create visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Creating visualization"})
+
+            # Generate analysis results visualization
+            if analysis_results and "error" not in analysis_results:
+                visualization_paths.update(
+                    generate_analysis_distribution_vis(
+                        analysis_results=analysis_results,
+                        field_label=self.field_name,
+                        operation_name=self.name,
+                        task_dir=viz_dir,
+                        timestamp=timestamp,
+                        top_n=self.top_n,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=visualization_paths,
+                        **kwargs,
+                    )
+                )
+
+            # Step 3: Finalize visualizations
+            if progress_tracker:
+                progress_tracker.update(3, {"step": "Finalizing visualizations"})
+
+        except Exception as e:
+            self.logger.warning(f"Error creating visualizations: {e}")
+
+        return visualization_paths
+
+    def _update_progress_tracker(
+        self,
+        TOTAL_MAIN_STEPS: int,
+        n: int,
+        step_name: str,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+    ) -> None:
+        """
+        Helper to update progress tracker for the step.
+        """
+        if progress_tracker:
+            progress_tracker.total = TOTAL_MAIN_STEPS  # Ensure total steps is set
+            progress_tracker.update(
+                n,
+                {
+                    "step": step_name,
+                    "operation": f"{self.name}",
+                    "field_name": f"{self.field_name}",
+                },
             )
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
-        Prepare required directories for artifacts.
+        Prepare directories for artifacts following PAMOLA.CORE conventions.
 
         Parameters:
         -----------
         task_dir : Path
-            Base directory for the task
+            Root task directory
 
         Returns:
         --------
         Dict[str, Path]
-            Dictionary of directory paths
+            Dictionary with prepared directories
         """
-        # Create required directories
-        output_dir = task_dir / 'output'
-        visualizations_dir = task_dir / 'visualizations'
-        dictionaries_dir = task_dir / 'dictionaries'
+        directories = {}
 
-        ensure_directory(output_dir)
-        ensure_directory(visualizations_dir)
-        ensure_directory(dictionaries_dir)
+        # Create standard directories following PAMOLA.CORE conventions
+        directories["root"] = task_dir
+        directories["output"] = task_dir / "output"
+        directories["dictionaries"] = task_dir / "dictionaries"
+        directories["logs"] = task_dir / "logs"
+        directories["cache"] = task_dir / "cache"
 
-        return {
-            'output': output_dir,
-            'visualizations': visualizations_dir,
-            'dictionaries': dictionaries_dir
-        }
+        # Ensure all directories exist
+        for directory in directories.values():
+            directory.mkdir(parents=True, exist_ok=True)
+
+        return directories
 
 
 def analyze_mvf_fields(
-        data_source: DataSource,
-        task_dir: Path,
-        reporter: Any,
-        mvf_fields: List[str],
-        **kwargs) -> Dict[str, OperationResult]:
+    data_source: DataSource,
+    task_dir: Path,
+    reporter: Any,
+    mvf_fields: List[str],
+    **kwargs,
+) -> Dict[str, OperationResult]:
     """
     Analyze multiple MVF fields in a dataset.
 
@@ -640,9 +1943,7 @@ def analyze_mvf_fields(
         Additional parameters for the operations:
         - top_n: int, number of top values to include in results (default: 20)
         - min_frequency: int, minimum frequency for inclusion in dictionary (default: 1)
-        - generate_plots: bool, whether to generate plots (default: True)
         - include_timestamp: bool, whether to include timestamps in filenames (default: True)
-        - profile_type: str, type of profiling for organizing artifacts (default: 'mvf')
         - format_type: str, format type hint for parsing (default: None)
         - parse_kwargs: dict, additional parameters for MVF parsing
 
@@ -652,39 +1953,50 @@ def analyze_mvf_fields(
         Dictionary mapping field names to their operation results
     """
     # Get DataFrame from data source
-    dataset_name = kwargs.get('dataset_name', "main")
+    dataset_name = kwargs.get("dataset_name", "main")
     df = load_data_operation(data_source, dataset_name)
     if df is None:
-        reporter.add_operation("MVF fields analysis", status="error",
-                               details={"error": "No valid DataFrame found in data source"})
+        reporter.add_operation(
+            "MVF fields analysis",
+            status="error",
+            details={"error": "No valid DataFrame found in data source"},
+        )
         return {}
 
     # Extract operation parameters from kwargs
-    top_n = kwargs.get('top_n', 20)
-    min_frequency = kwargs.get('min_frequency', 1)
-    format_type = kwargs.get('format_type', None)
-    parse_kwargs = kwargs.get('parse_kwargs', {})
+    top_n = kwargs.get("top_n", 20)
+    min_frequency = kwargs.get("min_frequency", 1)
+    format_type = kwargs.get("format_type", None)
+    parse_kwargs = kwargs.get("parse_kwargs", {})
 
     # Report on fields to be analyzed
-    reporter.add_operation("MVF fields analysis", details={
-        "fields_count": len(mvf_fields),
-        "fields": mvf_fields,
-        "top_n": top_n,
-        "min_frequency": min_frequency,
-        "parameters": {k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))}
-    })
+    reporter.add_operation(
+        "MVF fields analysis",
+        details={
+            "fields_count": len(mvf_fields),
+            "fields": mvf_fields,
+            "top_n": top_n,
+            "min_frequency": min_frequency,
+            "parameters": {
+                k: v
+                for k, v in kwargs.items()
+                if isinstance(v, (str, int, float, bool))
+            },
+        },
+    )
 
     # Track progress if enabled
-    track_progress = kwargs.get('track_progress', True)
+    track_progress = kwargs.get("track_progress", True)
     overall_tracker = None
 
     if track_progress and mvf_fields:
         from pamola_core.utils.progress import ProgressTracker
+
         overall_tracker = ProgressTracker(
             total=len(mvf_fields),
             description=f"Analyzing {len(mvf_fields)} MVF fields",
             unit="fields",
-            track_memory=True
+            track_memory=True,
         )
 
     # Initialize results dictionary
@@ -696,23 +2008,25 @@ def analyze_mvf_fields(
             try:
                 # Update overall progress tracker
                 if overall_tracker:
-                    overall_tracker.update(0, {"field": field, "progress": f"{i + 1}/{len(mvf_fields)}"})
+                    overall_tracker.update(
+                        0, {"field": field, "progress": f"{i + 1}/{len(mvf_fields)}"}
+                    )
 
                 logger.info(f"Analyzing MVF field: {field}")
 
                 # Create and execute operation
                 operation = MVFOperation(
-                    field,
-                    top_n=top_n,
-                    min_frequency=min_frequency
+                    field, top_n=top_n, min_frequency=min_frequency
                 )
 
                 # Create kwargs for this field
                 field_kwargs = kwargs.copy()
-                field_kwargs['format_type'] = format_type
-                field_kwargs['parse_kwargs'] = parse_kwargs
+                field_kwargs["format_type"] = format_type
+                field_kwargs["parse_kwargs"] = parse_kwargs
 
-                result = operation.execute(data_source, task_dir, reporter, **field_kwargs)
+                result = operation.execute(
+                    data_source, task_dir, reporter, **field_kwargs
+                )
 
                 # Store result
                 results[field] = result
@@ -720,16 +2034,27 @@ def analyze_mvf_fields(
                 # Update overall tracker after successful analysis
                 if overall_tracker:
                     if result.status == OperationStatus.SUCCESS:
-                        overall_tracker.update(1, {"field": field, "status": "completed"})
+                        overall_tracker.update(
+                            1, {"field": field, "status": "completed"}
+                        )
                     else:
-                        overall_tracker.update(1, {"field": field, "status": "error",
-                                                   "error": result.error_message})
+                        overall_tracker.update(
+                            1,
+                            {
+                                "field": field,
+                                "status": "error",
+                                "error": result.error_message,
+                            },
+                        )
 
             except Exception as e:
                 logger.error(f"Error analyzing MVF field {field}: {e}", exc_info=True)
 
-                reporter.add_operation(f"Analyzing {field} field", status="error",
-                                       details={"error": str(e)})
+                reporter.add_operation(
+                    f"Analyzing {field} field",
+                    status="error",
+                    details={"error": str(e)},
+                )
 
                 # Update overall tracker in case of error
                 if overall_tracker:
@@ -740,13 +2065,18 @@ def analyze_mvf_fields(
         overall_tracker.close()
 
     # Report summary
-    success_count = sum(1 for r in results.values() if r.status == OperationStatus.SUCCESS)
+    success_count = sum(
+        1 for r in results.values() if r.status == OperationStatus.SUCCESS
+    )
     error_count = sum(1 for r in results.values() if r.status == OperationStatus.ERROR)
 
-    reporter.add_operation("MVF fields analysis completed", details={
-        "fields_analyzed": len(results),
-        "successful": success_count,
-        "failed": error_count
-    })
+    reporter.add_operation(
+        "MVF fields analysis completed",
+        details={
+            "fields_analyzed": len(results),
+            "successful": success_count,
+            "failed": error_count,
+        },
+    )
 
     return results

--- a/pamola_core/profiling/analyzers/numeric.py
+++ b/pamola_core/profiling/analyzers/numeric.py
@@ -6,6 +6,8 @@ including statistical analysis, distribution analysis, outlier detection,
 and normality testing.
 """
 
+import time
+from datetime import datetime
 import logging
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Union
@@ -16,10 +18,11 @@ import pandas as pd
 from pamola_core.profiling.commons.numeric_utils import (
     prepare_numeric_data, handle_large_dataframe, analyze_numeric_chunk,
     calculate_extended_stats, calculate_percentiles, calculate_histogram,
-    detect_outliers, test_normality, create_empty_stats
+    detect_outliers, test_normality, create_empty_stats,
+    process_with_dask, process_with_joblib
 )
 from pamola_core.utils.io import write_json, get_timestamped_filename, load_data_operation, load_settings_operation
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
@@ -28,6 +31,7 @@ from pamola_core.utils.visualization import (
 )
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.common.constants import Constants
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,11 @@ class NumericAnalyzer:
                 bins: int = 10,
                 should_detect_outliers: bool = True,
                 should_test_normality: bool = True,
+                chunk_size: int = 10000,
+                use_dask: bool = False,
+                npartitions: int = 2,
+                use_vectorization: bool = False,
+                parallel_processes: int = 2,
                 **kwargs) -> Dict[str, Any]:
         """
         Analyze a numeric field in the given DataFrame.
@@ -62,6 +71,16 @@ class NumericAnalyzer:
             Whether to detect outliers
         should_test_normality : bool
             Whether to perform normality testing
+        chunk_size : int
+            Size of data chunks for processing large datasets
+        use_dask : bool, optional
+            Whether to use Dask for processing (default: False).
+        npartitions : int, optional
+            Number of partitions use with Dask (default: 1).
+        use_vectorization : bool, optional
+            Whether to use vectorized (parallel) processing (default: False).
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1).
         **kwargs : dict
             Additional parameters for the analysis:
             - near_zero_threshold: threshold for detecting "near zero" values (default: 1e-10)
@@ -82,7 +101,6 @@ class NumericAnalyzer:
         near_zero_threshold = kwargs.get('near_zero_threshold', 1e-10)
         track_progress = kwargs.get('track_progress', True)
         use_chunks = kwargs.get('use_chunks', True)
-        chunk_size = kwargs.get('chunk_size', 10000)  
         is_large_df = use_chunks and len(df) > chunk_size
         semantic_analysis = kwargs.get('semantic_analysis', True)
         normality_test_method = kwargs.get('normality_test_method', 'all')
@@ -91,7 +109,7 @@ class NumericAnalyzer:
         progress = None
         if track_progress:
             progress_steps = 6 if should_test_normality else 5  # Add step for normality testing
-            progress = ProgressTracker(
+            progress = HierarchicalProgressTracker(
                 total=progress_steps,
                 description=f"Analyzing numeric field: {field_name}",
                 unit="steps",
@@ -128,19 +146,82 @@ class NumericAnalyzer:
                 }
         else:
             # For large datasets, process in chunks
-            if is_large_df:
-                logger.info(f"Processing large field {field_name} with {valid_count} valid records using chunks")
+            stats_dict = create_empty_stats()
+            flag_processed = False
+            try:
+                if not flag_processed and use_dask and npartitions > 1:
+                    logger.info("Parallel Enabled")
+                    logger.info("Parallel Engine: Dask")
+                    logger.info(f"Parallel Workers: {npartitions}")
+                    logger.info(f"Using dask processing with chunk size {chunk_size}")
 
-                stats_dict = handle_large_dataframe(
-                    df,
-                    field_name,
-                    analyze_numeric_chunk,
-                    chunk_size,
-                    near_zero_threshold=near_zero_threshold
-                )
-            else:
-                # Standard processing for smaller datasets
-                stats_dict = calculate_extended_stats(valid_data, near_zero_threshold)
+                    stats_dict = process_with_dask(
+                        df,
+                        field_name,
+                        analyze_numeric_chunk,
+                        npartitions,
+                        chunk_size,
+                        near_zero_threshold=near_zero_threshold
+                    )
+
+                    flag_processed = True
+            except Exception as e:
+                logger.exception(f"Error in using dask processing: {e}")
+                flag_processed = False
+
+            try:
+                if not flag_processed and use_vectorization and parallel_processes > 1:
+                    logger.info("Parallel Enabled")
+                    logger.info("Parallel Engine: Joblib")
+                    logger.info(f"Parallel Workers: {parallel_processes}")
+                    logger.info(f"Using vectorized processing with chunk size {chunk_size}")
+
+                    stats_dict = process_with_joblib(
+                        df,
+                        field_name,
+                        analyze_numeric_chunk,
+                        parallel_processes,
+                        chunk_size,
+                        near_zero_threshold=near_zero_threshold
+                    )
+
+                    flag_processed = True
+            except Exception as e:
+                logger.exception(f"Error in using joblib processing: {e}")
+                flag_processed = False
+
+            try:
+                if not flag_processed and is_large_df:
+                    logger.info(f"Processing in chunks with chunk size {chunk_size}")
+                    total_chunks = (len(df) + chunk_size - 1) // chunk_size
+                    logger.info(f"Total chunks to process: {total_chunks}")
+
+                    stats_dict = handle_large_dataframe(
+                        df,
+                        field_name,
+                        analyze_numeric_chunk,
+                        chunk_size,
+                        near_zero_threshold=near_zero_threshold
+                    )
+
+                    flag_processed = True
+            except Exception as e:
+                logger.exception(f"Error in using chunks processing: {e}")
+                flag_processed = False
+
+            try:
+                if not flag_processed:
+                    logger.info("Fallback process as usual")
+
+                    stats_dict = calculate_extended_stats(valid_data, near_zero_threshold)
+
+                    flag_processed = True
+            except Exception as e:
+                logger.exception(f"Error in processing: {e}")
+                flag_processed = False
+
+            if not flag_processed:
+                logger.exception(f"Error in processing")
 
             if progress:
                 progress.update(1, {"step": "Descriptive statistics", "stats_calculated": True})
@@ -299,9 +380,20 @@ class NumericOperation(FieldOperation):
                  generate_plots: bool = True,
                  include_timestamp: bool = True,
                  profile_type: str = 'numeric',
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
+                 chunk_size: int = 10000,
+                 use_dask: bool = False,
+                 npartitions: int = 2,
+                 use_vectorization: bool = False,
+                 parallel_processes: int = 2,
+                 use_cache: bool = True,
                  description: str = "",
                  use_encryption: bool = False,
-                 encryption_key: Optional[Union[str, Path]] = None):
+                 encryption_key: Optional[Union[str, Path]] = None,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize a numeric field operation.
 
@@ -315,6 +407,26 @@ class NumericOperation(FieldOperation):
             Whether to detect outliers
         test_normality : bool
             Whether to perform normality testing
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
+        chunk_size : int
+            Size of data chunks for processing large datasets
+        use_dask : bool, optional
+            Whether to use Dask for processing (default: False).
+        npartitions : int, optional
+            Number of partitions use with Dask (default: 1).
+        use_vectorization : bool, optional
+            Whether to use vectorized (parallel) processing (default: False).
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1).
+        use_cache : bool
+            Whether to use caching for intermediate results
         description : str
             Description of the operation (optional)
         """
@@ -322,9 +434,10 @@ class NumericOperation(FieldOperation):
             field_name=field_name,
             description=description or f"Analysis of numeric field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
             )
-        
+
         self.bins = bins
         self.detect_outliers = detect_outliers
         self.test_normality = test_normality
@@ -333,12 +446,29 @@ class NumericOperation(FieldOperation):
         self.generate_plots = generate_plots
         self.include_timestamp = include_timestamp
         self.profile_type = profile_type
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
+        self.chunk_size = chunk_size
+        self.use_dask = use_dask
+        self.npartitions = npartitions
+        self.use_vectorization = use_vectorization
+        self.parallel_processes = parallel_processes
+        self.use_cache = use_cache
+
+        # Set up performance tracking variables
+        self.is_encryption_required = False
+        self.start_time = None
+        self.end_time = None
+        self.execution_time = 0
+        self.process_count = 0
 
     def execute(self,
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the numeric field analysis operation.
@@ -351,7 +481,7 @@ class NumericOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
@@ -359,32 +489,73 @@ class NumericOperation(FieldOperation):
             - generate_plots: bool, whether to generate visualizations
             - include_timestamp: bool, whether to include timestamps in filenames
             - profile_type: str, type of profiling for organizing artifacts
+            - dataset_name: str - Name of dataset - main
+            - force_recalculation: bool - Force operation even if cached results exist - False
+            - use_dask: bool - Use Dask for large dataset processing - False
+            - parallel_processes: int - Number of parallel processes to use - 1
+            - generate_visualization: bool - Create visualizations - True
+            - save_output: bool - Save processed data to output directory - True
+            - encrypt_output: bool - Override encryption setting for outputs - False
+            - visualization_theme: str - Override theme for visualizations - None
+            - visualization_backend: str - Override backend for visualizations - None
+            - visualization_strict: bool - Override strict mode for visualizations - False
+            - visualization_timeout: int - Override timeout for visualizations - 120
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
-        # Extract parameters from kwargs
-        near_zero_threshold = kwargs.get('near_zero_threshold', self.near_zero_threshold)
-        generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        profile_type = kwargs.get('profile_type', self.profile_type)
-        encryption_key = kwargs.get('encryption_key', None)
-
-        # Set up directories
-        dirs = self._prepare_directories(task_dir)
-        output_dir = dirs['output']
-        visualizations_dir = dirs['visualizations']
-
-        # Create the main result object with initial status
-        result = OperationResult(status=OperationStatus.SUCCESS)
-
-        # Update progress if tracker provided
-        if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+        global logger
+        if kwargs.get("logger"):
+            logger = kwargs.get("logger")
 
         try:
+            # Initialize timing and result
+            self.start_time = time.time()
+            self.process_count = 0
+            result = OperationResult(status=OperationStatus.SUCCESS)
+
+            # Decompose kwargs and introduce variables for clarity
+            near_zero_threshold = kwargs.get('near_zero_threshold', self.near_zero_threshold)
+            generate_plots = kwargs.get('generate_plots', self.generate_plots)
+            include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
+            profile_type = kwargs.get('profile_type', self.profile_type)
+            force_recalculation = kwargs.get("force_recalculation", False)
+            use_dask = kwargs.get("use_dask", self.use_dask)
+            parallel_processes = kwargs.get("parallel_processes", 1)
+            generate_visualization = kwargs.get("generate_visualization", True)
+            save_output = kwargs.get("save_output", True)
+            is_encryption_required = (kwargs.get("encrypt_output", False) or self.use_encryption)
+            encryption_key = kwargs.get('encryption_key', None)
+
+            self.use_dask = use_dask
+            self.parallel_processes = parallel_processes
+            self.include_timestamp = include_timestamp
+            self.is_encryption_required = is_encryption_required
+
+            # Extract visualization parameters
+            self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            logger.info(
+                f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, "
+                f"strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+            )
+
+            # Set up directories
+            dirs = self._prepare_directories(task_dir)
+            output_dir = dirs["output"]
+            visualizations_dir = dirs["visualizations"]
+            dictionaries_dir = dirs["dictionaries"]
+            cache_dir = dirs["cache"]
+
+            # Update progress if tracker provided
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+
             # Get DataFrame from data source
             dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
@@ -411,6 +582,18 @@ class NumericOperation(FieldOperation):
                 "operation_type": "numeric_analysis"
             })
 
+            # Check for cached results if caching is enabled
+            if self.use_cache and not force_recalculation:
+                cached_result = self._check_cache(df, reporter, task_dir, **kwargs)
+                if cached_result:
+                    logger.info(f"Using cached results for {self.field_name}")
+
+                    # Update progress if tracker provided
+                    if progress_tracker:
+                        progress_tracker.update(6, {"step": "Loaded from cache", "field": self.field_name})
+
+                    return cached_result
+
             # Adjust progress tracker total steps if provided
             total_steps = 4
             if generate_plots:
@@ -427,10 +610,16 @@ class NumericOperation(FieldOperation):
                 bins=self.bins,
                 should_detect_outliers=self.detect_outliers,
                 should_test_normality=self.test_normality,
+                chunk_size=self.chunk_size,
+                use_dask=self.use_dask,
+                npartitions=self.npartitions,
+                use_vectorization=self.use_vectorization,
+                parallel_processes=self.parallel_processes,
                 near_zero_threshold=near_zero_threshold,
                 track_progress=progress_tracker is not None
             )
 
+            artifacts = []
             # Check for errors
             if 'error' in analysis_results:
                 return OperationResult(
@@ -446,18 +635,25 @@ class NumericOperation(FieldOperation):
             stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
             stats_path = output_dir / stats_filename
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
+            encryption_mode = get_encryption_mode(analysis_results, **kwargs)
+            write_json(analysis_results, stats_path, encryption_key=encryption_key, encryption_mode=encryption_mode)
             result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
 
             # Add to reporter
             reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
+            artifacts.append({
+                "artifact_type": "json",
+                "path": str(stats_path),
+                "description": f"{self.field_name} statistical analysis",
+                "category": Constants.Artifact_Category_Output
+            })
 
             # Update progress
             if progress_tracker:
                 progress_tracker.update(1, {"step": "Saved analysis results"})
 
             # Generate visualizations if requested
-            if generate_plots:
+            if generate_plots and self.visualization_backend is not None:
                 # Update progress
                 if progress_tracker:
                     progress_tracker.update(0, {"step": "Generating visualizations"})
@@ -466,15 +662,22 @@ class NumericOperation(FieldOperation):
                     "use_encryption": kwargs.get('use_encryption', False),
                     "encryption_key": encryption_key
                 }
-                self._generate_visualizations(
-                    df,
-                    analysis_results,
-                    visualizations_dir,
-                    include_timestamp,
-                    result,
-                    reporter,
+                visualization_paths = self._handle_visualizations(
+                    df=df,
+                    analysis_results=analysis_results,
+                    visualizations_dir=visualizations_dir,
+                    include_timestamp=include_timestamp,
+                    result=result,
+                    reporter=reporter,
+                    vis_theme=self.visualization_theme,
+                    vis_backend=self.visualization_backend,
+                    vis_strict=self.visualization_strict,
+                    vis_timeout=self.visualization_timeout,
+                    progress_tracker=progress_tracker,
                     **kwargs_encryption
                 )
+
+                artifacts.extend(visualization_paths)
 
                 # Update progress
                 if progress_tracker:
@@ -497,6 +700,15 @@ class NumericOperation(FieldOperation):
             if 'normality' in stats_dict:
                 result.add_metric("is_normal", stats_dict['normality'].get('is_normal', False))
 
+            # Cache results if caching is enabled
+            if self.use_cache:
+                self._save_to_cache(
+                    df=df,
+                    analysis_results=analysis_results,
+                    artifacts=artifacts,
+                    task_dir=task_dir
+                )
+
             # Update progress to completion
             if progress_tracker:
                 progress_tracker.update(1, {"step": "Operation complete", "status": "success"})
@@ -513,8 +725,11 @@ class NumericOperation(FieldOperation):
                                                                  False) if 'normality' in stats_dict else False
             })
 
-            return result
+            self.end_time = time.time()
+            if self.end_time and self.start_time:
+                self.execution_time = self.end_time - self.start_time
 
+            return result
         except Exception as e:
             logger.exception(f"Error in numeric operation for {self.field_name}: {e}")
 
@@ -539,7 +754,10 @@ class NumericOperation(FieldOperation):
                                  include_timestamp: bool,
                                  result: OperationResult,
                                  reporter: Any,
-                                 **kwargs):
+                                 vis_theme: Optional[str],
+                                 vis_backend: Optional[str],
+                                 vis_strict: bool,
+                                 **kwargs_encryption) -> List[Dict[str, str]]:
         """
         Generate visualizations for the numeric field analysis.
 
@@ -557,7 +775,20 @@ class NumericOperation(FieldOperation):
             Operation result to add artifacts to
         reporter : Any
             Reporter to add artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+
+        Returns:
+        --------
+        List[Dict[str, str]]
+            Information of visualizations
         """
+        visualization_paths = []
+
         stats_dict = analysis_results.get('stats', {})
         valid_data = pd.to_numeric(df[self.field_name], errors='coerce').dropna()
 
@@ -586,12 +817,21 @@ class NumericOperation(FieldOperation):
                         x_label=self.field_name,
                         y_label="Frequency",
                         bins=self.bins,
-                        **kwargs
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        **kwargs_encryption
                     )
 
                     if not hist_result.startswith("Error"):
                         result.add_artifact("png", hist_path, f"{self.field_name} distribution histogram", category=Constants.Artifact_Category_Visualization)
                         reporter.add_artifact("png", str(hist_path), f"{self.field_name} distribution histogram")
+                        visualization_paths.append({
+                            "artifact_type": "png",
+                            "path": str(hist_path),
+                            "description": f"{self.field_name} distribution histogram",
+                            "category": Constants.Artifact_Category_Visualization
+                        })
 
         # Generate boxplot visualization if we have enough data
         if len(valid_data) > 5:
@@ -605,12 +845,21 @@ class NumericOperation(FieldOperation):
                 title=f"Boxplot of {self.field_name}",
                 y_label=self.field_name,
                 show_points=True,
-                **kwargs
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
+                **kwargs_encryption
             )
 
             if not boxplot_result.startswith("Error"):
                 result.add_artifact("png", boxplot_path, f"{self.field_name} boxplot", category=Constants.Artifact_Category_Visualization)
                 reporter.add_artifact("png", str(boxplot_path), f"{self.field_name} boxplot")
+                visualization_paths.append({
+                    "artifact_type": "png",
+                    "path": str(boxplot_path),
+                    "description": f"{self.field_name} boxplot",
+                    "category": Constants.Artifact_Category_Visualization
+                })
 
         # Generate Q-Q plot for normality if requested and we have results
         if self.test_normality and 'normality' in stats_dict and len(valid_data) > 10:
@@ -644,13 +893,534 @@ class NumericOperation(FieldOperation):
                 add_trendline=True,
                 add_histogram=False,
                 method="Q-Q Plot",
-                **kwargs
+                theme=vis_theme,
+                backend=vis_backend,
+                strict=vis_strict,
+                **kwargs_encryption
             )
 
             if not qq_result.startswith("Error"):
                 result.add_artifact("png", qq_path, f"{self.field_name} Q-Q plot (normality test)", category=Constants.Artifact_Category_Visualization)
                 reporter.add_artifact("png", str(qq_path), f"{self.field_name} Q-Q plot (normality test)")
+                visualization_paths.append({
+                    "artifact_type": "png",
+                    "path": str(qq_path),
+                    "description": f"{self.field_name} boxplot",
+                    "category": Constants.Artifact_Category_Visualization
+                })
 
+        return visualization_paths
+
+    def _check_cache(
+            self,
+            df: pd.DataFrame,
+            reporter: Any,
+            task_dir: Path,
+            **kwargs
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+        reporter : Any
+            The reporter to log artifacts to
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache, OperationCache
+
+            operation_cache_dir = OperationCache(cache_dir=task_dir/"cache")
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache_dir.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Restore artifacts from cache
+                artifacts_restored = 0
+
+                # Add artifacts
+                artifacts = cached_data.get("artifacts", [])
+                for artifact in artifacts:
+                    if artifact and isinstance(artifact, dict):
+                        if Path(artifact.get("path")).exists():
+                            artifacts_restored += 1
+                            cached_result.add_artifact(
+                                artifact.get("artifact_type"),
+                                artifact.get("path"),
+                                artifact.get("description"),
+                                category=artifact.get("category")
+                            )
+                            reporter.add_artifact(
+                                artifact.get("artifact_type"),
+                                artifact.get("path"),
+                                artifact.get("description")
+                            )
+
+                # Add cached metrics to result
+                analysis_results = cached_data.get("analysis_results", {})
+                stats_dict = analysis_results.get('stats', {})
+
+                cached_result.add_metric("total_rows", analysis_results.get('total_rows', 0))
+                cached_result.add_metric("null_count", analysis_results.get('null_count', 0))
+                cached_result.add_metric("null_percentage", analysis_results.get('null_percentage', 0))
+                cached_result.add_metric("min", stats_dict.get('min'))
+                cached_result.add_metric("max", stats_dict.get('max'))
+                cached_result.add_metric("mean", stats_dict.get('mean'))
+                cached_result.add_metric("median", stats_dict.get('median'))
+
+                if 'outliers' in stats_dict:
+                    cached_result.add_metric("outliers_count", stats_dict['outliers'].get('count', 0))
+                    cached_result.add_metric("outliers_percentage", stats_dict['outliers'].get('percentage', 0))
+
+                if 'normality' in stats_dict:
+                    cached_result.add_metric("is_normal", stats_dict['normality'].get('is_normal', False))
+
+                # Add final operation status to reporter
+                outliers = stats_dict.get('outliers', {})
+                normality = stats_dict.get('normality', {})
+                reporter.add_operation(f"Analysis of {self.field_name} completed", details={
+                    "valid_values": analysis_results.get('valid_count', 0),
+                    "null_percentage": analysis_results.get('null_percentage', 0),
+                    "min": stats_dict.get('min'),
+                    "max": stats_dict.get('max'),
+                    "mean": stats_dict.get('mean'),
+                    "outliers": outliers.get('count', 0),
+                    "is_normal": normality.get('is_normal', False)
+                })
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+                cached_result.add_metric("artifacts_restored", artifacts_restored)
+
+                return cached_result
+
+            logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            logger.warning(f"Error checking cache: {str(e)}")
+            return None
+
+    def _save_to_cache(
+            self,
+            df: pd.DataFrame,
+            analysis_results: Dict[str, Any],
+            artifacts: List[Dict[str, str]],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+        analysis_results : dict
+            Analysis results to cache
+        artifacts : list of dict
+            Artifacts
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache:
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache, OperationCache
+
+            # Generate operation cache
+            operation_cache_dir = OperationCache(cache_dir=task_dir/"cache")
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "analysis_results": analysis_results,
+                "artifacts": artifacts,
+                "data_info": {
+                    "df_length": len(df)
+                }
+            }
+
+            # Save to cache
+            logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache_dir.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                logger.info(f"Successfully saved results to cache")
+            else:
+                logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "field_name": self.field_name,
+            "bins": self.bins,
+            "detect_outliers": self.detect_outliers,
+            "test_normality": self.test_normality,
+            "near_zero_threshold": self.near_zero_threshold,
+            "version": self.version
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import json
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+    def _handle_visualizations(
+            self,
+            df: pd.DataFrame,
+            analysis_results: Dict[str, Any],
+            vis_dir: Path,
+            include_timestamp: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            vis_timeout: int,
+            progress_tracker: Optional[HierarchicalProgressTracker],
+            **kwargs_encryption
+    ) -> List[Dict[str, str]]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            DataFrame containing the data
+        analysis_results : Dict[str, Any]
+            Results of the analysis
+        vis_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in filenames
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        List[Dict[str, str]]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = []
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    visualization_paths = self._generate_visualizations(
+                        df=df,
+                        analysis_results=analysis_results,
+                        vis_dir=vis_dir,
+                        include_timestamp=include_timestamp,
+                        result=result,
+                        reporter=reporter,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        **kwargs_encryption
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths
+
+    def _prepare_directories(
+            self,
+            task_dir: Path
+    ) -> Dict[str, Path]:
+        """
+        Prepare standard directories for storing operation artifacts.
+
+        Parameters:
+        -----------
+        task_dir : Path
+            Base directory for the task
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with standard directory paths
+        """
+        from pamola_core.utils.io import ensure_directory
+
+        # Create standard directories
+        directories = {
+            "output": task_dir / "output",
+            "dictionaries": task_dir / "dictionaries",
+            "visualizations": task_dir / "visualizations",
+            "cache": task_dir / "cache",
+        }
+
+        # Ensure directories exist
+        for dir_path in directories.values():
+            ensure_directory(dir_path)
+
+        return directories
 
 def analyze_numeric_fields(data_source: DataSource,
                            task_dir: Path,
@@ -680,7 +1450,8 @@ def analyze_numeric_fields(data_source: DataSource,
     """
     # Get DataFrame from data source
     dataset_name = kwargs.get('dataset_name', "main")
-    df = load_data_operation(data_source, dataset_name)
+    settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+    df = load_data_operation(data_source, dataset_name, **settings_operation)
     if df is None:
         reporter.add_operation("Numeric fields analysis", status="error",
                                details={"error": "No valid DataFrame found in data source"})
@@ -705,7 +1476,7 @@ def analyze_numeric_fields(data_source: DataSource,
     overall_tracker = None
 
     if track_progress and numeric_fields:
-        overall_tracker = ProgressTracker(
+        overall_tracker = HierarchicalProgressTracker(
             total=len(numeric_fields),
             description=f"Analyzing {len(numeric_fields)} numeric fields",
             unit="fields",

--- a/pamola_core/profiling/analyzers/phone.py
+++ b/pamola_core/profiling/analyzers/phone.py
@@ -18,6 +18,8 @@ Operations:
 """
 
 import logging
+import time
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Union
 
@@ -25,18 +27,22 @@ import pandas as pd
 
 from pamola_core.profiling.commons.phone_utils import (
     analyze_phone_field,
+    analyze_phone_field_with_chunk,
+    analyze_phone_field_with_joblib,
+    analyze_phone_field_with_dask,
     create_country_code_dictionary,
     create_operator_code_dictionary,
     create_messenger_dictionary,
     estimate_resources
 )
 from pamola_core.utils.io import write_json, ensure_directory, get_timestamped_filename, load_data_operation, write_dataframe_to_csv, load_settings_operation
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.ops.op_base import FieldOperation
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
 from pamola_core.common.constants import Constants
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -53,6 +59,11 @@ class PhoneAnalyzer:
     def analyze(df: pd.DataFrame,
                 field_name: str,
                 patterns_csv: Optional[str] = None,
+                chunk_size: int = 10000,
+                use_dask: bool = False,
+                npartitions: int = 2,
+                use_vectorization: bool = False,
+                parallel_processes: int = 2,
                 **kwargs) -> Dict[str, Any]:
         """
         Analyze a phone field in the given DataFrame.
@@ -65,6 +76,16 @@ class PhoneAnalyzer:
             The name of the field to analyze
         patterns_csv : str, optional
             Path to CSV with messenger patterns
+        chunk_size : int
+            Size of data chunks for processing large datasets
+        use_dask : bool, optional
+            Whether to use Dask for processing (default: False).
+        npartitions : int, optional
+            Number of partitions use with Dask (default: 1).
+        use_vectorization : bool, optional
+            Whether to use vectorized (parallel) processing (default: False).
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1).
         **kwargs : dict
             Additional parameters for the analysis
 
@@ -73,12 +94,89 @@ class PhoneAnalyzer:
         Dict[str, Any]
             The results of the analysis
         """
-        return analyze_phone_field(
-            df=df,
-            field_name=field_name,
-            patterns_csv=patterns_csv,
-            **kwargs
-        )
+        analysis_results = {}
+        flag_processed = False
+        try:
+            if not flag_processed and use_dask and npartitions > 1:
+                logger.info("Parallel Enabled")
+                logger.info("Parallel Engine: Dask")
+                logger.info(f"Parallel Workers: {npartitions}")
+                logger.info(f"Using dask processing with chunk size {chunk_size}")
+
+                analysis_results = analyze_phone_field_with_dask(
+                    df=df,
+                    field_name=field_name,
+                    patterns_csv=patterns_csv,
+                    npartitions=npartitions,
+                    chunk_size=chunk_size,
+                    **kwargs
+                )
+
+                flag_processed = True
+        except Exception as e:
+            logger.exception(f"Error in using dask processing: {e}")
+            flag_processed = False
+
+        try:
+            if not flag_processed and use_vectorization and parallel_processes > 1:
+                logger.info("Parallel Enabled")
+                logger.info("Parallel Engine: Joblib")
+                logger.info(f"Parallel Workers: {parallel_processes}")
+                logger.info(f"Using vectorized processing with chunk size {chunk_size}")
+
+                analysis_results = analyze_phone_field_with_joblib(
+                    df=df,
+                    field_name=field_name,
+                    patterns_csv=patterns_csv,
+                    n_jobs=parallel_processes,
+                    chunk_size=chunk_size,
+                    **kwargs
+                )
+
+                flag_processed = True
+        except Exception as e:
+            logger.exception(f"Error in using joblib processing: {e}")
+            flag_processed = False
+
+        try:
+            if not flag_processed and len(df) > chunk_size:
+                logger.info(f"Processing in chunks with chunk size {chunk_size}")
+                total_chunks = (len(df) + chunk_size - 1) // chunk_size
+                logger.info(f"Total chunks to process: {total_chunks}")
+
+                analysis_results = analyze_phone_field_with_chunk(
+                    df=df,
+                    field_name=field_name,
+                    patterns_csv=patterns_csv,
+                    chunk_size=chunk_size,
+                    **kwargs
+                )
+
+                flag_processed = True
+        except Exception as e:
+            logger.exception(f"Error in using chunks processing: {e}")
+            flag_processed = False
+
+        try:
+            if not flag_processed:
+                logger.info("Fallback process as usual")
+
+                analysis_results = analyze_phone_field(
+                    df=df,
+                    field_name=field_name,
+                    patterns_csv=patterns_csv,
+                    **kwargs
+                )
+
+                flag_processed = True
+        except Exception as e:
+            logger.exception(f"Error in processing: {e}")
+            flag_processed = False
+
+        if not flag_processed:
+            logger.exception(f"Error in processing")
+
+        return analysis_results
 
     @staticmethod
     def create_country_code_dictionary(df: pd.DataFrame,
@@ -219,9 +317,20 @@ class PhoneOperation(FieldOperation):
                 profile_type: str = 'phone',
                 track_progress: bool = True,
                 country_code: Any = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_backend: Optional[str] = None,
+                 visualization_strict: bool = False,
+                 visualization_timeout: int = 120,
+                 chunk_size: int = 10000,
+                 use_dask: bool = False,
+                 npartitions: int = 2,
+                 use_vectorization: bool = False,
+                 parallel_processes: int = 2,
+                 use_cache: bool = True,
                 description: str = "",
                 use_encryption: bool = False,
-                encryption_key: Optional[Union[str, Path]] = None):
+                encryption_key: Optional[Union[str, Path]] = None,
+                encryption_mode: Optional[str] = None):
         """
         Initialize the phone operation.
 
@@ -235,12 +344,34 @@ class PhoneOperation(FieldOperation):
             Path to CSV file with messenger detection patterns
         description : str
             Description of the operation (optional)
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
+        chunk_size : int
+            Size of data chunks for processing large datasets
+        use_dask : bool, optional
+            Whether to use Dask for processing (default: False).
+        npartitions : int, optional
+            Number of partitions use with Dask (default: 1).
+        use_vectorization : bool, optional
+            Whether to use vectorized (parallel) processing (default: False).
+        parallel_processes : int, optional
+            Number of processes use with vectorized (parallel) (default: 1).
+        use_cache : bool
+            Whether to use caching for intermediate results
+
         """
         super().__init__(
             field_name=field_name,
             description=description or f"Analysis of phone field '{field_name}'",
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
             )
         
         self.min_frequency = min_frequency
@@ -250,12 +381,29 @@ class PhoneOperation(FieldOperation):
         self.profile_type = profile_type
         self.track_progress = track_progress
         self.country_code = country_code
+        self.visualization_theme = visualization_theme
+        self.visualization_backend = visualization_backend
+        self.visualization_strict = visualization_strict
+        self.visualization_timeout = visualization_timeout
+        self.chunk_size = chunk_size
+        self.use_dask = use_dask
+        self.npartitions = npartitions
+        self.use_vectorization = use_vectorization
+        self.parallel_processes = parallel_processes
+        self.use_cache = use_cache
+
+        # Set up performance tracking variables
+        self.is_encryption_required = False
+        self.start_time = None
+        self.end_time = None
+        self.execution_time = 0
+        self.process_count = 0
 
     def execute(self,
                 data_source: DataSource,
                 task_dir: Path,
                 reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None,
+                progress_tracker: Optional[HierarchicalProgressTracker] = None,
                 **kwargs) -> OperationResult:
         """
         Execute the phone analysis operation.
@@ -268,7 +416,7 @@ class PhoneOperation(FieldOperation):
             Directory where task artifacts should be saved
         reporter : Any
             Reporter object for tracking progress and artifacts
-        progress_tracker : ProgressTracker, optional
+        progress_tracker : HierarchicalProgressTracker, optional
             Progress tracker for the operation
         **kwargs : dict
             Additional parameters for the operation:
@@ -276,33 +424,73 @@ class PhoneOperation(FieldOperation):
             - include_timestamp: bool, whether to include timestamps in filenames
             - profile_type: str, type of profiling for organizing artifacts
             - country_code: str, specific country code to focus on for operator analysis
+            - dataset_name: str - Name of dataset - main
+            - force_recalculation: bool - Force operation even if cached results exist - False
+            - use_dask: bool - Use Dask for large dataset processing - False
+            - parallel_processes: int - Number of parallel processes to use - 1
+            - generate_visualization: bool - Create visualizations - True
+            - save_output: bool - Save processed data to output directory - True
+            - encrypt_output: bool - Override encryption setting for outputs - False
+            - visualization_theme: str - Override theme for visualizations - None
+            - visualization_backend: str - Override backend for visualizations - None
+            - visualization_strict: bool - Override strict mode for visualizations - False
+            - visualization_timeout: int - Override timeout for visualizations - 120
 
         Returns:
         --------
         OperationResult
             Results of the operation
         """
-        # Extract parameters from kwargs
-        generate_plots = kwargs.get('generate_plots', self.generate_plots)
-        include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
-        profile_type = kwargs.get('profile_type', self.profile_type)
-        country_code = kwargs.get('country_code', self.country_code)
-        encryption_key = kwargs.get('encryption_key', None)
-
-        # Set up directories
-        dirs = self._prepare_directories(task_dir)
-        output_dir = dirs['output']
-        visualizations_dir = dirs['visualizations']
-        dictionaries_dir = dirs['dictionaries']
-
-        # Create the main result object with initial status
-        result = OperationResult(status=OperationStatus.SUCCESS)
-
-        # Update progress if tracker provided
-        if progress_tracker:
-            progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+        global logger
+        if kwargs.get("logger"):
+            logger = kwargs.get("logger")
 
         try:
+            # Initialize timing and result
+            self.start_time = time.time()
+            self.process_count = 0
+            result = OperationResult(status=OperationStatus.SUCCESS)
+
+            # Decompose kwargs and introduce variables for clarity
+            generate_plots = kwargs.get('generate_plots', self.generate_plots)
+            include_timestamp = kwargs.get('include_timestamp', self.include_timestamp)
+            profile_type = kwargs.get('profile_type', self.profile_type)
+            country_code = kwargs.get('country_code', self.country_code)
+            force_recalculation = kwargs.get("force_recalculation", False)
+            use_dask = kwargs.get("use_dask", self.use_dask)
+            parallel_processes = kwargs.get("parallel_processes", 1)
+            generate_visualization = kwargs.get("generate_visualization", True)
+            save_output = kwargs.get("save_output", True)
+            is_encryption_required = (kwargs.get("encrypt_output", False) or self.use_encryption)
+            encryption_key = kwargs.get('encryption_key', None)
+
+            self.use_dask = use_dask
+            self.parallel_processes = parallel_processes
+            self.include_timestamp = include_timestamp
+            self.is_encryption_required = is_encryption_required
+
+            # Extract visualization parameters
+            self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            logger.info(
+                f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, "
+                f"strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+            )
+
+            # Set up directories
+            dirs = self._prepare_directories(task_dir)
+            output_dir = dirs['output']
+            visualizations_dir = dirs['visualizations']
+            dictionaries_dir = dirs['dictionaries']
+            cache_dir = dirs["cache"]
+
+            # Update progress if tracker provided
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparation", "field": self.field_name})
+
             # Get DataFrame from data source
             dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
@@ -327,6 +515,18 @@ class PhoneOperation(FieldOperation):
                 "operation_type": "phone_analysis"
             })
 
+            # Check for cached results if caching is enabled
+            if self.use_cache and not force_recalculation:
+                cached_result = self._check_cache(df, reporter, task_dir, **kwargs)
+                if cached_result:
+                    logger.info(f"Using cached results for {self.field_name}")
+
+                    # Update progress if tracker provided
+                    if progress_tracker:
+                        progress_tracker.update(5, {"step": "Loaded from cache", "field": self.field_name})
+
+                    return cached_result
+
             # Adjust progress tracker total steps if provided
             total_steps = 4  # Preparation, analysis, saving results, dictionaries
             if generate_plots:
@@ -341,6 +541,11 @@ class PhoneOperation(FieldOperation):
                 df=df,
                 field_name=self.field_name,
                 patterns_csv=self.patterns_csv,
+                chunk_size=self.chunk_size,
+                use_dask=self.use_dask,
+                npartitions=self.npartitions,
+                use_vectorization=self.use_vectorization,
+                parallel_processes=self.parallel_processes,
                 **kwargs
             )
 
@@ -351,6 +556,7 @@ class PhoneOperation(FieldOperation):
                     error_message=analysis_results['error']
                 )
 
+            artifacts = []
             # Update progress
             if progress_tracker:
                 progress_tracker.update(1, {"step": "Analysis complete", "field": self.field_name})
@@ -359,105 +565,45 @@ class PhoneOperation(FieldOperation):
             stats_filename = get_timestamped_filename(f"{self.field_name}_stats", "json", include_timestamp)
             stats_path = output_dir / stats_filename
 
-            write_json(analysis_results, stats_path, encryption_key=encryption_key)
+            encryption_mode = get_encryption_mode(analysis_results, **kwargs)
+            write_json(analysis_results, stats_path, encryption_key=encryption_key, encryption_mode=encryption_mode)
             result.add_artifact("json", stats_path, f"{self.field_name} statistical analysis", category=Constants.Artifact_Category_Output)
 
             # Add to reporter
             reporter.add_artifact("json", str(stats_path), f"{self.field_name} statistical analysis")
+            artifacts.append({
+                "artifact_type": "json",
+                "path": str(stats_path),
+                "description": f"{self.field_name} statistical analysis",
+                "category": Constants.Artifact_Category_Output
+            })
 
             # Update progress
             if progress_tracker:
                 progress_tracker.update(1, {"step": "Saved analysis results"})
 
             # Generate visualizations if requested
-            if generate_plots:
+            if generate_plots and self.visualization_backend is not None:
                 # Update progress
                 if progress_tracker:
                     progress_tracker.update(0, {"step": "Generating visualizations"})
 
-                # 1. Country code distribution visualization
-                if 'country_codes' in analysis_results and analysis_results['country_codes']:
-                    # Create visualization filename with extension "png"
-                    viz_filename = get_timestamped_filename(
-                        base_name=f"{self.field_name}_country_codes_distribution",
-                        extension="png",
-                        include_timestamp=include_timestamp
-                    )
-                    viz_path = visualizations_dir / viz_filename
-
-                    # Create visualization using the visualization module
-                    from pamola_core.utils.visualization import plot_value_distribution
-                    title = f"Country Code Distribution in {self.field_name}"
-
-                    viz_result = plot_value_distribution(
-                        data=analysis_results['country_codes'],
-                        output_path=str(viz_path),
-                        title=title,
-                        max_items=15,
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", viz_path, f"{self.field_name} country codes distribution", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(viz_path), f"{self.field_name} country codes distribution")
-                    else:
-                        logger.warning(f"Error creating country code visualization: {viz_result}")
-
-                # 2. Operator code distribution visualization
-                if 'operator_codes' in analysis_results and analysis_results['operator_codes']:
-                    # Create visualization filename with extension "png"
-                    viz_filename = get_timestamped_filename(
-                        base_name=f"{self.field_name}_operator_codes_distribution",
-                        extension="png",
-                        include_timestamp=include_timestamp
-                    )
-                    viz_path = visualizations_dir / viz_filename
-
-                    # Create visualization using the visualization module
-                    from pamola_core.utils.visualization import plot_value_distribution
-                    title = f"Operator Code Distribution in {self.field_name}"
-
-                    viz_result = plot_value_distribution(
-                        data=analysis_results['operator_codes'],
-                        output_path=str(viz_path),
-                        title=title,
-                        max_items=15,
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", viz_path, f"{self.field_name} operator codes distribution", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(viz_path), f"{self.field_name} operator codes distribution")
-                    else:
-                        logger.warning(f"Error creating operator code visualization: {viz_result}")
-
-                # 3. Messenger mentions visualization
-                if 'messenger_mentions' in analysis_results and any(analysis_results['messenger_mentions'].values()):
-                    # Create visualization filename with extension "png"
-                    viz_filename = get_timestamped_filename(
-                        base_name=f"{self.field_name}_messenger_mentions",
-                        extension="png",
-                        include_timestamp=include_timestamp
-                    )
-                    viz_path = visualizations_dir / viz_filename
-
-                    # Create visualization using the visualization module
-                    from pamola_core.utils.visualization import plot_value_distribution
-                    title = f"Messenger Mentions in {self.field_name}"
-
-                    viz_result = plot_value_distribution(
-                        data=analysis_results['messenger_mentions'],
-                        output_path=str(viz_path),
-                        title=title,
-                        max_items=10,
-                        **kwargs
-                    )
-
-                    if not viz_result.startswith("Error"):
-                        result.add_artifact("png", viz_path, f"{self.field_name} messenger mentions", category=Constants.Artifact_Category_Visualization)
-                        reporter.add_artifact("png", str(viz_path), f"{self.field_name} messenger mentions")
-                    else:
-                        logger.warning(f"Error creating messenger mentions visualization: {viz_result}")
+                safe_kwargs = filter_used_kwargs(kwargs, self._handle_visualizations)
+                visualization_paths = self._handle_visualizations(
+                    df=df,
+                    analysis_results=analysis_results,
+                    visualizations_dir=visualizations_dir,
+                    include_timestamp=include_timestamp,
+                    result=result,
+                    reporter=reporter,
+                    vis_theme=self.visualization_theme,
+                    vis_backend=self.visualization_backend,
+                    vis_strict=self.visualization_strict,
+                    vis_timeout=self.visualization_timeout,
+                    progress_tracker=progress_tracker,
+                    **safe_kwargs
+                )
+                artifacts.extend(visualization_paths)
 
                 # Update progress
                 if progress_tracker:
@@ -479,7 +625,6 @@ class PhoneOperation(FieldOperation):
 
                 # Create DataFrame and save to CSV
                 import pandas as pd
-                import pandas as pd
                 dict_df = pd.DataFrame(country_dict['country_codes'])
                 write_dataframe_to_csv(df=dict_df, file_path=dict_path, index=False, encoding='utf-8', encryption_key=encryption_key)
 
@@ -487,13 +632,26 @@ class PhoneOperation(FieldOperation):
                 json_dict_filename = get_timestamped_filename(f"{self.field_name}_country_codes_dictionary", "json",
                                                               include_timestamp)
                 json_dict_path = output_dir / json_dict_filename
-                write_json(country_dict, json_dict_path, encryption_key=encryption_key)
+                encryption_mode_country_dict = get_encryption_mode(country_dict, **kwargs)
+                write_json(country_dict, json_dict_path, encryption_key=encryption_key, encryption_mode=encryption_mode_country_dict)
 
                 result.add_artifact("csv", dict_path, f"{self.field_name} country codes dictionary (CSV)", category=Constants.Artifact_Category_Dictionary)
                 result.add_artifact("json", json_dict_path, f"{self.field_name} country codes dictionary (JSON)", category=Constants.Artifact_Category_Output)
 
                 reporter.add_artifact("csv", str(dict_path), f"{self.field_name} country codes dictionary (CSV)")
                 reporter.add_artifact("json", str(json_dict_path), f"{self.field_name} country codes dictionary (JSON)")
+                artifacts.append({
+                    "artifact_type": "csv",
+                    "path": str(dict_path),
+                    "description": f"{self.field_name} country codes dictionary (CSV)",
+                    "category": Constants.Artifact_Category_Dictionary
+                })
+                artifacts.append({
+                    "artifact_type": "json",
+                    "path": str(json_dict_path),
+                    "description": f"{self.field_name} country codes dictionary (JSON)",
+                    "category": Constants.Artifact_Category_Output
+                })
 
             # Create and save operator code dictionary (for specific country or all)
             operator_dict = PhoneAnalyzer.create_operator_code_dictionary(
@@ -519,7 +677,8 @@ class PhoneOperation(FieldOperation):
                 json_dict_filename = get_timestamped_filename(f"{self.field_name}_operator_codes_dictionary", "json",
                                                               include_timestamp)
                 json_dict_path = output_dir / json_dict_filename
-                write_json(operator_dict, json_dict_path, encryption_key=encryption_key)
+                encryption_mode_operator_dict = get_encryption_mode(operator_dict, **kwargs)
+                write_json(operator_dict, json_dict_path, encryption_key=encryption_key, encryption_mode=encryption_mode_operator_dict)
 
                 result.add_artifact("csv", dict_path, f"{self.field_name} operator codes dictionary (CSV)", category=Constants.Artifact_Category_Dictionary)
                 result.add_artifact("json", json_dict_path, f"{self.field_name} operator codes dictionary (JSON)", category=Constants.Artifact_Category_Output)
@@ -527,6 +686,18 @@ class PhoneOperation(FieldOperation):
                 reporter.add_artifact("csv", str(dict_path), f"{self.field_name} operator codes dictionary (CSV)")
                 reporter.add_artifact("json", str(json_dict_path),
                                       f"{self.field_name} operator codes dictionary (JSON)")
+                artifacts.append({
+                    "artifact_type": "csv",
+                    "path": str(dict_path),
+                    "description": f"{self.field_name} operator codes dictionary (CSV)",
+                    "category": Constants.Artifact_Category_Dictionary
+                })
+                artifacts.append({
+                    "artifact_type": "json",
+                    "path": str(json_dict_path),
+                    "description": f"{self.field_name} operator codes dictionary (JSON)",
+                    "category": Constants.Artifact_Category_Output
+                })
 
             # Create and save messenger dictionary
             messenger_dict = PhoneAnalyzer.create_messenger_dictionary(
@@ -552,13 +723,35 @@ class PhoneOperation(FieldOperation):
                 json_dict_filename = get_timestamped_filename(f"{self.field_name}_messenger_dictionary", "json",
                                                               include_timestamp)
                 json_dict_path = output_dir / json_dict_filename
-                write_json(messenger_dict, json_dict_path, encryption_key=encryption_key)
+                encryption_mode_messenger_dict = get_encryption_mode(messenger_dict, **kwargs)
+                write_json(messenger_dict, json_dict_path, encryption_key=encryption_key, encryption_mode=encryption_mode_messenger_dict)
 
                 result.add_artifact("csv", dict_path, f"{self.field_name} messenger dictionary (CSV)", category=Constants.Artifact_Category_Dictionary)
                 result.add_artifact("json", json_dict_path, f"{self.field_name} messenger dictionary (JSON)", category=Constants.Artifact_Category_Output)
 
                 reporter.add_artifact("csv", str(dict_path), f"{self.field_name} messenger dictionary (CSV)")
                 reporter.add_artifact("json", str(json_dict_path), f"{self.field_name} messenger dictionary (JSON)")
+                artifacts.append({
+                    "artifact_type": "csv",
+                    "path": str(dict_path),
+                    "description": f"{self.field_name} messenger dictionary (CSV)",
+                    "category": Constants.Artifact_Category_Dictionary
+                })
+                artifacts.append({
+                    "artifact_type": "json",
+                    "path": str(json_dict_path),
+                    "description": f"{self.field_name} messenger dictionary (JSON)",
+                    "category": Constants.Artifact_Category_Output
+                })
+
+            # Cache results if caching is enabled
+            if self.use_cache:
+                self._save_to_cache(
+                    df=df,
+                    analysis_results=analysis_results,
+                    artifacts=artifacts,
+                    task_dir=task_dir
+                )
 
             # Update progress
             if progress_tracker:
@@ -587,8 +780,11 @@ class PhoneOperation(FieldOperation):
                 "normalization_success": analysis_results.get('normalization_success_count', 0)
             })
 
-            return result
+            self.end_time = time.time()
+            if self.end_time and self.start_time:
+                self.execution_time = self.end_time - self.start_time
 
+            return result
         except Exception as e:
             logger.exception(f"Error in phone operation for {self.field_name}: {e}")
 
@@ -605,6 +801,578 @@ class PhoneOperation(FieldOperation):
                 status=OperationStatus.ERROR,
                 error_message=f"Error analyzing phone field {self.field_name}: {str(e)}"
             )
+
+    def _check_cache(
+            self,
+            df: pd.DataFrame,
+            reporter: Any,
+            task_dir: Path,
+            **kwargs
+    ) -> Optional[OperationResult]:
+        """
+        Check if a cached result exists for operation.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+        reporter : Any
+            The reporter to log artifacts to
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        Optional[OperationResult]
+            Cached result if found, None otherwise
+        """
+        if not self.use_cache:
+            return None
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache, OperationCache
+
+            operation_cache_dir = OperationCache(cache_dir=task_dir/"cache")
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Check for cached result
+            logger.debug(f"Checking cache for key: {cache_key}")
+            cached_data = operation_cache_dir.get_cache(
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__
+            )
+
+            if cached_data:
+                logger.info(f"Using cached result.")
+
+                # Create result object from cached data
+                cached_result = OperationResult(status=OperationStatus.SUCCESS)
+
+                # Restore artifacts from cache
+                artifacts_restored = 0
+
+                # Add artifacts
+                artifacts = cached_data.get("artifacts", [])
+                for artifact in artifacts:
+                    if artifact and isinstance(artifact, dict):
+                        if Path(artifact.get("path")).exists():
+                            artifacts_restored += 1
+                            cached_result.add_artifact(
+                                artifact.get("artifact_type"),
+                                artifact.get("path"),
+                                artifact.get("description"),
+                                category=artifact.get("category")
+                            )
+                            reporter.add_artifact(
+                                artifact.get("artifact_type"),
+                                artifact.get("path"),
+                                artifact.get("description")
+                            )
+
+                # Add cached metrics to result
+                analysis_results = cached_data.get("analysis_results", {})
+
+                cached_result.add_metric("total_records", analysis_results.get('total_rows', 0))
+                cached_result.add_metric("null_count", analysis_results.get('null_count', 0))
+                cached_result.add_metric("null_percentage", analysis_results.get('null_percentage', 0))
+                cached_result.add_metric("valid_count", analysis_results.get('valid_count', 0))
+                cached_result.add_metric("valid_percentage", analysis_results.get('valid_percentage', 0))
+                cached_result.add_metric("format_error_count", analysis_results.get('format_error_count', 0))
+                cached_result.add_metric("has_comment_count", analysis_results.get('has_comment_count', 0))
+
+                # Add normalization metrics if available
+                if 'normalization_success_count' in analysis_results:
+                    cached_result.add_metric("normalization_success_count",
+                                      analysis_results.get('normalization_success_count', 0))
+                    cached_result.add_metric("normalization_success_percentage",
+                                      analysis_results.get('normalization_success_percentage', 0))
+
+                # Add final operation status to reporter
+                reporter.add_operation(f"Analysis of {self.field_name} completed", details={
+                    "valid_phones": analysis_results.get('valid_count', 0),
+                    "format_errors": analysis_results.get('format_error_count', 0),
+                    "with_comments": analysis_results.get('has_comment_count', 0),
+                    "normalization_success": analysis_results.get('normalization_success_count', 0)
+                })
+
+                # Add cache information to result
+                cached_result.add_metric("cached", True)
+                cached_result.add_metric("cache_key", cache_key)
+                cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+                cached_result.add_metric("artifacts_restored", artifacts_restored)
+
+                return cached_result
+
+            logger.debug(f"No cache found for key: {cache_key}")
+            return None
+        except Exception as e:
+            logger.warning(f"Error checking cache: {str(e)}")
+            return None
+
+    def _save_to_cache(
+            self,
+            df: pd.DataFrame,
+            analysis_results: Dict[str, Any],
+            artifacts: List[Dict[str, str]],
+            task_dir: Path
+    ) -> bool:
+        """
+        Save operation results to cache.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+        analysis_results : dict
+            Analysis results to cache
+        artifacts : list of dict
+            Artifacts
+        task_dir : Path
+            Task directory
+
+        Returns:
+        --------
+        bool
+            True if successfully saved to cache, False otherwise
+        """
+        if not self.use_cache:
+            return False
+
+        try:
+            # Import and get global cache manager
+            from pamola_core.utils.ops.op_cache import operation_cache, OperationCache
+
+            # Generate operation cache
+            operation_cache_dir = OperationCache(cache_dir=task_dir/"cache")
+
+            # Generate cache key
+            cache_key = self._generate_cache_key(df)
+
+            # Prepare metadata for cache
+            operation_parameters = self._get_operation_parameters()
+
+            cache_data = {
+                "timestamp": datetime.now().isoformat(),
+                "parameters": operation_parameters,
+                "analysis_results": analysis_results,
+                "artifacts": artifacts,
+                "data_info": {
+                    "df_length": len(df)
+                }
+            }
+
+            # Save to cache
+            logger.debug(f"Saving to cache with key: {cache_key}")
+            success = operation_cache_dir.save_cache(
+                data=cache_data,
+                cache_key=cache_key,
+                operation_type=self.__class__.__name__,
+                metadata={"task_dir": str(task_dir)}
+            )
+
+            if success:
+                logger.info(f"Successfully saved results to cache")
+            else:
+                logger.warning(f"Failed to save results to cache")
+
+            return success
+        except Exception as e:
+            logger.warning(f"Error saving to cache: {str(e)}")
+            return False
+
+    def _generate_cache_key(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a deterministic cache key based on operation parameters and data characteristics.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Unique cache key
+        """
+        from pamola_core.utils.ops.op_cache import operation_cache
+
+        # Get operation parameters
+        parameters = self._get_operation_parameters()
+
+        # Generate data hash based on key characteristics
+        data_hash = self._generate_data_hash(df)
+
+        # Use the operation_cache utility to generate a consistent cache key
+        return operation_cache.generate_cache_key(
+            operation_name=self.__class__.__name__,
+            parameters=parameters,
+            data_hash=data_hash
+        )
+
+    def _get_operation_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        # Get basic operation parameters
+        parameters = {
+            "field_name": self.field_name,
+            "min_frequency": self.min_frequency,
+            "patterns_csv": self.patterns_csv,
+            "country_code": self.country_code,
+            "version": self.version
+        }
+
+        # Add operation-specific parameters
+        parameters.update(self._get_cache_parameters())
+
+        return parameters
+
+    def _get_cache_parameters(
+            self
+    ) -> Dict[str, Any]:
+        """
+        Get operation-specific parameters for cache key generation.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Parameters for cache key generation
+        """
+        return {}
+
+    def _generate_data_hash(
+            self,
+            df: pd.DataFrame
+    ) -> str:
+        """
+        Generate a hash representing the key characteristics of the data.
+
+        Parameters:
+        -----------
+        df : pd.DataFrame
+            Input data for the operation
+
+        Returns:
+        --------
+        str
+            Hash string representing the data
+        """
+        import json
+        import hashlib
+
+        try:
+            # Create data characteristics
+            characteristics = df.describe(include="all")
+
+            # Convert to JSON string and hash
+            json_str = characteristics.to_json(date_format='iso')
+        except Exception as e:
+            logger.warning(f"Error generating data hash: {str(e)}")
+
+            # Fallback to a simple hash of the data length and type
+            json_str = f"{len(df)}_{json.dumps(df.dtypes.apply(str).to_dict())}"
+
+        return hashlib.md5(json_str.encode()).hexdigest()
+
+    def _handle_visualizations(
+            self,
+            analysis_results: Dict[str, Any],
+            visualizations_dir: Path,
+            include_timestamp: bool,
+            result: OperationResult,
+            reporter: Any,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            vis_timeout: int,
+            progress_tracker: Optional[HierarchicalProgressTracker],
+            **kwargs
+    ) -> List[Dict[str, Path]]:
+        """
+        Generate and save visualizations.
+
+        Parameters:
+        -----------
+        analysis_results : Dict[str, Any]
+            Results of the analysis
+        visualizations_dir : Path
+            Directory to save visualizations
+        include_timestamp : bool
+            Whether to include timestamps in filenames
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+
+        Returns:
+        --------
+        List[Dict[str, Path]]
+            Dictionary with visualization types and paths
+        """
+        if progress_tracker:
+            progress_tracker.update(0, {"step": "Generating visualizations"})
+
+        logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = []
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+
+                    # 1. Country code distribution visualization
+                    if 'country_codes' in analysis_results and analysis_results['country_codes']:
+                        # Create visualization filename with extension "png"
+                        viz_filename = get_timestamped_filename(
+                            base_name=f"{self.field_name}_country_codes_distribution",
+                            extension="png",
+                            include_timestamp=include_timestamp
+                        )
+                        viz_path = visualizations_dir / viz_filename
+
+                        # Create visualization using the visualization module
+                        from pamola_core.utils.visualization import plot_value_distribution
+                        title = f"Country Code Distribution in {self.field_name}"
+
+                        viz_result = plot_value_distribution(
+                            data=analysis_results['country_codes'],
+                            output_path=str(viz_path),
+                            title=title,
+                            max_items=15,
+                            theme=vis_theme,
+                            backend=vis_backend,
+                            strict=vis_strict,
+                            **kwargs
+                        )
+
+                        if not viz_result.startswith("Error"):
+                            result.add_artifact("png", viz_path, f"{self.field_name} country codes distribution",
+                                                category=Constants.Artifact_Category_Visualization)
+                            reporter.add_artifact("png", str(viz_path), f"{self.field_name} country codes distribution")
+                            visualization_paths.append({
+                                "artifact_type": "png",
+                                "path": str(viz_path),
+                                "description": f"{self.field_name} country codes distribution",
+                                "category": Constants.Artifact_Category_Visualization
+                            })
+                        else:
+                            logger.warning(f"Error creating country code visualization: {viz_result}")
+
+                    # 2. Operator code distribution visualization
+                    if 'operator_codes' in analysis_results and analysis_results['operator_codes']:
+                        # Create visualization filename with extension "png"
+                        viz_filename = get_timestamped_filename(
+                            base_name=f"{self.field_name}_operator_codes_distribution",
+                            extension="png",
+                            include_timestamp=include_timestamp
+                        )
+                        viz_path = visualizations_dir / viz_filename
+
+                        # Create visualization using the visualization module
+                        from pamola_core.utils.visualization import plot_value_distribution
+                        title = f"Operator Code Distribution in {self.field_name}"
+
+                        viz_result = plot_value_distribution(
+                            data=analysis_results['operator_codes'],
+                            output_path=str(viz_path),
+                            title=title,
+                            max_items=15,
+                            theme=vis_theme,
+                            backend=vis_backend,
+                            strict=vis_strict,
+                            **kwargs
+                        )
+
+                        if not viz_result.startswith("Error"):
+                            result.add_artifact("png", viz_path, f"{self.field_name} operator codes distribution",
+                                                category=Constants.Artifact_Category_Visualization)
+                            reporter.add_artifact("png", str(viz_path),
+                                                  f"{self.field_name} operator codes distribution")
+                            visualization_paths.append({
+                                "artifact_type": "png",
+                                "path": str(viz_path),
+                                "description": f"{self.field_name} operator codes distribution",
+                                "category": Constants.Artifact_Category_Visualization
+                            })
+                        else:
+                            logger.warning(f"Error creating operator code visualization: {viz_result}")
+
+                    # 3. Messenger mentions visualization
+                    if 'messenger_mentions' in analysis_results and any(
+                            analysis_results['messenger_mentions'].values()):
+                        # Create visualization filename with extension "png"
+                        viz_filename = get_timestamped_filename(
+                            base_name=f"{self.field_name}_messenger_mentions",
+                            extension="png",
+                            include_timestamp=include_timestamp
+                        )
+                        viz_path = visualizations_dir / viz_filename
+
+                        # Create visualization using the visualization module
+                        from pamola_core.utils.visualization import plot_value_distribution
+                        title = f"Messenger Mentions in {self.field_name}"
+
+                        viz_result = plot_value_distribution(
+                            data=analysis_results['messenger_mentions'],
+                            output_path=str(viz_path),
+                            title=title,
+                            max_items=10,
+                            theme=vis_theme,
+                            backend=vis_backend,
+                            strict=vis_strict,
+                            **kwargs
+                        )
+
+                        if not viz_result.startswith("Error"):
+                            result.add_artifact("png", viz_path, f"{self.field_name} messenger mentions",
+                                                category=Constants.Artifact_Category_Visualization)
+                            reporter.add_artifact("png", str(viz_path), f"{self.field_name} messenger mentions")
+                            visualization_paths.append({
+                                "artifact_type": "png",
+                                "path": str(viz_path),
+                                "description": f"{self.field_name} messenger mentions",
+                                "category": Constants.Artifact_Category_Visualization
+                            })
+                        else:
+                            logger.warning(f"Error creating messenger mentions visualization: {viz_result}")
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_artifact(
+                    artifact_type="png",
+                    path=str(path),
+                    description=f"{viz_type} visualization"
+                )
+
+        return visualization_paths
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
@@ -624,17 +1392,19 @@ class PhoneOperation(FieldOperation):
         output_dir = task_dir / 'output'
         visualizations_dir = task_dir / 'visualizations'
         dictionaries_dir = task_dir / 'dictionaries'
+        cache_dir = task_dir / 'cache'
 
         ensure_directory(output_dir)
         ensure_directory(visualizations_dir)
         ensure_directory(dictionaries_dir)
+        ensure_directory(cache_dir)
 
         return {
             'output': output_dir,
             'visualizations': visualizations_dir,
-            'dictionaries': dictionaries_dir
+            'dictionaries': dictionaries_dir,
+            'cache': cache_dir
         }
-
 
 def analyze_phone_fields(
         data_source: DataSource,
@@ -673,7 +1443,8 @@ def analyze_phone_fields(
     """
     # Get DataFrame from data source
     dataset_name = kwargs.get('dataset_name', "main")
-    df = load_data_operation(data_source, dataset_name)
+    settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+    df = load_data_operation(data_source, dataset_name, **settings_operation)
     if df is None:
         reporter.add_operation("Phone fields analysis", status="error",
                                details={"error": "No valid DataFrame found in data source"})

--- a/pamola_core/profiling/commons/__init__.py
+++ b/pamola_core/profiling/commons/__init__.py
@@ -22,5 +22,5 @@ from pamola_core.profiling.commons.helpers import (
     infer_data_type, prepare_field_for_analysis, parse_multi_valued_field,
     detect_json_field, parse_json_field, detect_array_field, parse_array_field,
     is_valid_email, extract_email_domain, is_phone_number_format, parse_phone_number,
-    convert_numpy_types
+    convert_numpy_types, filter_used_kwargs
 )

--- a/pamola_core/profiling/commons/analysis_utils.py
+++ b/pamola_core/profiling/commons/analysis_utils.py
@@ -1,0 +1,358 @@
+
+import logging
+from typing import Dict, Iterator, Tuple, Iterable, Callable, Any, Union, Optional
+
+import pandas as pd
+
+from pamola_core.utils.progress import HierarchicalProgressTracker
+
+
+logger = logging.getLogger(__name__)
+
+
+def process_dataframe_with_config(
+        df: pd.DataFrame,
+        process_function: Callable,
+        chunk_size: int = 10000,
+        use_dask: bool = False,
+        npartitions: int = 1,
+        meta: Optional[Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple]] = None,
+        use_vectorization: bool = False,
+        parallel_processes: int = 1,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        task_logger: Optional[logging.Logger] = None,
+        **kwargs
+) -> Union[pd.DataFrame, None, Any]:
+    """
+    Process a DataFrame to handle large datasets efficiently.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to process.
+    process_function : Callable
+        Function to apply to each chunk, should take a DataFrame chunk as the first argument.
+    chunk_size : int, optional
+        Number of rows to process in each chunk (default: 10000).
+    use_dask : bool, optional
+        Whether to use Dask for processing (default: False).
+    npartitions : int, optional
+        Number of partitions use with Dask (default: 1).
+    meta : Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple], optional
+        Meta of output use with Dask.
+    use_vectorization : bool, optional
+        Whether to use vectorized (parallel) processing (default: False).
+    parallel_processes : int, optional
+        Number of processes use with vectorized (parallel) (default: 1).
+    progress_tracker : Optional[HierarchicalProgressTracker]
+        Progress tracker for monitoring the operation.
+    task_logger : Optional[logging.Logger]
+        Logger for tracking task progress and debugging.
+    **kwargs : dict
+        Additional arguments to pass to the process_function.
+
+    Returns
+    -------
+    pd.DataFrame
+        The processed DataFrame.
+    """
+    # Initialize task logger
+    if task_logger:
+        logger = task_logger
+
+    if len(df) == 0:
+        logger.warning("Empty DataFrame provided! Returning as is")
+        return df
+
+    if len(df) <= chunk_size:
+        logger.warning("Small DataFrame! Process as usual")
+        return process_function(df, **kwargs)
+
+    processed_df = None
+    flag_processed = False
+
+    logger.info("Process with config")
+
+    if not flag_processed and use_dask:
+        logger.info("Process using Dask")
+        logger.info("Parallel Enabled")
+        logger.info("Parallel Engine: Dask")
+        logger.info(f"Parallel Workers: {npartitions}")
+
+        processed_df, flag_processed = _process_dataframe_using_dask(
+            df=df,
+            process_function=process_function,
+            npartitions=npartitions,
+            chunksize=chunk_size,
+            meta=meta,
+            ** kwargs
+        )
+
+    if not flag_processed and use_vectorization:
+        logger.info("Process using Joblib")
+        logger.info("Parallel Enabled")
+        logger.info("Parallel Engine: Joblib")
+        logger.info(f"Parallel Workers: {parallel_processes}")
+
+        processed_df, flag_processed = _process_dataframe_using_joblib(
+            df=df,
+            process_function=process_function,
+            n_jobs=parallel_processes,
+            chunk_size=chunk_size,
+            ** kwargs
+        )
+
+    if not flag_processed and chunk_size > 1:
+        logger.info("Process using chunk")
+        logger.info("Parallel Enabled")
+        logger.info("Parallel Engine: Chunk")
+        logger.info(f"Parallel Workers")
+
+        processed_df, flag_processed = _process_dataframe_using_chunk(
+            df=df,
+            process_function=process_function,
+            chunk_size=chunk_size,
+            ** kwargs
+        )
+
+    if not flag_processed:
+        logger.info("Fallback process as usual")
+
+        processed_df = process_function(df, **kwargs)
+        flag_processed = True
+
+    return processed_df
+
+
+def _process_dataframe_using_chunk(
+        df: pd.DataFrame,
+        process_function: Callable,
+        chunk_size: int = 10000,
+        **kwargs
+) -> Tuple[pd.DataFrame, bool]:
+    """
+    Process DataFrame using chunk.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to process.
+    process_function : Callable
+        Function to apply to each chunk, should take a DataFrame chunk as the first argument.
+    chunk_size : int, optional
+        Number of rows to process in each chunk (default: 10000).
+    **kwargs : dict
+        Additional arguments to pass to the process_function.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, bool]
+        The processed DataFrame.
+    """
+    if chunk_size <= 1:
+        logger.warning("Chunk config not valid! Returning as is")
+        return df, False
+
+    logger.info(
+        f"Process DataFrame {len(df)} rows using chunk with {chunk_size} chunk size"
+    )
+
+    processed_chunks = []
+    try:
+        # Iterate through chunks using the generator function
+        for chunk, chunk_num, chunk_start, chunk_end, total_chunks in _generate_dataframe_chunks(
+                df, chunk_size=chunk_size
+        ):
+            logger.debug(f"Process chunk {chunk_num + 1}/{total_chunks} (rows {chunk_start}-{chunk_end - 1})")
+
+            try:
+                # Apply the processing function to the chunk
+                processed_chunk = process_function(chunk, **kwargs)
+
+                # Accumulate the results
+                processed_chunks.append(processed_chunk)
+            except Exception as e:
+                # Log any error encountered while processing the chunk
+                logger.error(f"Error processing chunk {chunk_num + 1}: {str(e)}")
+                processed_chunks.append(None)
+                continue  # Continue with the next chunk even if an error occurs
+
+        # Check if any processed chunks are None
+        if any(chunk is None for chunk in processed_chunks):
+            logger.warning("Some chunks failed to process.")
+            return df, False
+
+        return pd.concat(processed_chunks, ignore_index=True), True
+    except Exception as e:
+        # Catch any error that occurs during the entire processing loop
+        logger.error(f"Error during process using chunk: {str(e)}")
+        logger.warning("Returning as is")
+        return df, False
+
+
+def _generate_dataframe_chunks(
+        df: pd.DataFrame,
+        chunk_size: int = 10000
+) -> Iterator[tuple]:
+    """
+    Generate chunks of a DataFrame for efficient processing of large datasets.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to chunk.
+    chunk_size : int, optional
+        Number of rows in each chunk (default: 10000).
+
+    Yields
+    ------
+    tuple
+        Chunk of the original DataFrame with information.
+    """
+    if len(df) == 0:
+        logger.warning("Empty DataFrame provided to chunking function")
+        yield df, 0, 0, 0, 0
+        return
+
+    total_chunks = (len(df) + chunk_size - 1) // chunk_size
+    logger.info(f"Splitting DataFrame with {len(df)} rows into {total_chunks} chunks with size {chunk_size}")
+
+    for i in range(0, len(df), chunk_size):
+        chunk_start = i
+        chunk_end = min(i + chunk_size, len(df))
+        chunk_num = i // chunk_size
+
+        logger.debug(
+            f"Yielding chunk {chunk_num + 1}/{total_chunks} (rows {chunk_start}-{chunk_end - 1})"
+        )
+        yield df.iloc[chunk_start:chunk_end].copy(deep=True), chunk_num, chunk_start, chunk_end, total_chunks
+
+
+def _process_dataframe_using_joblib(
+        df: pd.DataFrame,
+        process_function: Callable,
+        n_jobs: int = -1,
+        chunk_size: int = 10000,
+        **kwargs
+) -> Tuple[pd.DataFrame, bool]:
+    """
+    Process DataFrame using Joblib.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to process.
+    process_function : Callable
+        Function to apply to each chunk, should take a DataFrame chunk as the first argument.
+    n_jobs : int, optional
+        Number of jobs to run in parallel (-1 to use all processors) (default: -1).
+    chunk_size : int, optional
+        Number of rows to process in each chunk (default: 10000).
+    **kwargs : dict
+        Additional arguments to pass to the process_function.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, bool]
+        The processed DataFrame.
+    """
+    from joblib import Parallel, delayed
+
+    if n_jobs <= 0 and n_jobs != -1:
+        logger.warning("Joblib config not valid! Returning as is")
+        return df, False
+
+    logger.info(
+        f"Process DataFrame {len(df)} rows using Joblib with {n_jobs} workers, {chunk_size} chunk size"
+    )
+
+    try:
+        # Function to process each chunk with error handling
+        def process_with_progress(chunk, chunk_idx):
+            try:
+                processed_chunk = process_function(chunk, **kwargs)
+                return processed_chunk
+            except Exception as e:
+                logger.error(f"Error processing chunk {chunk_idx + 1}: {str(e)}")
+                return None
+
+        # Directly use the generator to iterate through chunks
+        processed_chunks = Parallel(n_jobs=n_jobs)(
+            delayed(process_with_progress)(chunk, idx)
+            for idx, (chunk, chunk_num, chunk_start, chunk_end, total_chunks)
+            in enumerate(_generate_dataframe_chunks(df, chunk_size=chunk_size))
+        )
+
+        # Check if any processed chunks are None
+        if any(chunk is None for chunk in processed_chunks):
+            logger.warning("Some chunks failed to process.")
+            return df, False
+
+        return pd.concat(processed_chunks, ignore_index=True), True
+    except Exception as e:
+        logger.error(f"Error during process using Joblib: {str(e)}")
+        logger.warning("Returning as is")
+        return df, False
+
+
+def _process_dataframe_using_dask(
+        df: pd.DataFrame,
+        process_function: Callable,
+        npartitions: int = 2,
+        chunksize: int = 10000,
+        meta: Optional[Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple]] = None,
+        **kwargs
+) -> Tuple[pd.DataFrame, bool]:
+    """
+    Process DataFrame using Dask.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to process.
+    process_function : Callable
+        Function to apply to each chunk, should take a DataFrame chunk as the first argument.
+    npartitions : int, optional
+        Number of partitions use with Dask (default: 2).
+    chunksize : int, optional
+        Number of rows to process in each chunk (default: 10000).
+    meta : Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple], optional
+        Meta of output use with Dask.
+    **kwargs : dict
+        Additional arguments to pass to the process_function.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, bool]
+        The processed DataFrame.
+    """
+    import dask.dataframe as dd
+
+    if npartitions <= 1 and chunksize <= 0:
+        logger.warning("Dask config not valid! Returning as is")
+        return df, False
+
+    logger.info(
+        f"Process DataFrame {len(df)} rows using Dask with {npartitions} partitions, {chunksize} chunk size"
+    )
+
+    try:
+        # Convert to Dask DataFrame
+        if npartitions > 1:
+            ddf = dd.from_pandas(df, npartitions=npartitions)
+        else:
+            ddf = dd.from_pandas(df, chunksize=chunksize)
+
+        # Define a function for processing that can be applied to Dask partitions
+        def process_partition(partition):
+            processed_partition = process_function(partition.copy(deep=True), **kwargs)
+            return processed_partition
+
+        # Apply to Dask DataFrame
+        processed_partitions = ddf.map_partitions(process_partition)
+
+        return processed_partitions.compute(), True
+    except Exception as e:
+        logger.error(f"Error during process using Dask: {str(e)}")
+        logger.warning("Returning as is")
+        return df, False

--- a/pamola_core/profiling/commons/anonymity_utils.py
+++ b/pamola_core/profiling/commons/anonymity_utils.py
@@ -18,6 +18,7 @@ from pamola_core.utils.io import (
     write_dataframe_to_csv
     )
 from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -470,7 +471,9 @@ def prepare_field_uniqueness_data(df: pd.DataFrame, fields: List[str]) -> Dict[s
     return results
 
 
-def save_ka_index_map(ka_index_map: Dict[str, List[str]], output_path: str, encryption_key: Optional[str] = None) -> str:
+def save_ka_index_map(ka_index_map: Dict[str, List[str]], output_path: str, encryption_key: Optional[str] = None,
+                      use_encryption: bool = False,
+                      encryption_mode: Optional[str] = None) -> str:
     """
     Save KA index mapping to a CSV file.
 
@@ -498,7 +501,7 @@ def save_ka_index_map(ka_index_map: Dict[str, List[str]], output_path: str, encr
         df = pd.DataFrame(data)
 
         # Save to CSV
-        write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key)
+        write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key, use_encryption=use_encryption, encryption_mode=encryption_mode)
 
         return output_path
     except Exception as e:
@@ -547,8 +550,9 @@ def save_ka_metrics(ka_metrics: Dict[str, Dict[str, Any]], output_path: str, ka_
 
         # Save to CSV
         use_encryption = kwargs.get('use_encryption', False)
-        encryption_key= kwargs.get('encryption_key', None) if use_encryption else None
-        write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key)
+        encryption_key= kwargs.get('encryption_key', None)
+        encryption_mode = get_encryption_mode(df, **kwargs)
+        write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key, use_encryption=use_encryption, encryption_mode=encryption_mode)
         
         return output_path
     except Exception as e:
@@ -556,7 +560,9 @@ def save_ka_metrics(ka_metrics: Dict[str, Dict[str, Any]], output_path: str, ka_
         return str(e)
 
 
-def save_vulnerable_records(vulnerable_records: Dict[str, Dict[str, Any]], output_path: str, encryption_key: Optional[str] = None) -> str:
+def save_vulnerable_records(vulnerable_records: Dict[str, Dict[str, Any]], output_path: str, encryption_key: Optional[str] = None,
+                            use_encryption: bool = False,
+                            encryption_mode: Optional[str] = None) -> str:
     """
     Save information about vulnerable records to a JSON file.
 
@@ -585,7 +591,7 @@ def save_vulnerable_records(vulnerable_records: Dict[str, Dict[str, Any]], outpu
             })
 
         # Save to JSON
-        write_json(data, output_path, encryption_key=encryption_key)
+        write_json(data, output_path, encryption_key=encryption_key, use_encryption=use_encryption, encryption_mode=encryption_mode)
 
         return output_path
     except Exception as e:

--- a/pamola_core/profiling/commons/date_utils.py
+++ b/pamola_core/profiling/commons/date_utils.py
@@ -8,8 +8,9 @@ validation, distribution analysis, anomaly detection, and group analysis.
 import logging
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
-
 import pandas as pd
+
+from pamola_core.utils.progress import HierarchicalProgressTracker
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -316,6 +317,143 @@ def detect_date_inconsistencies_by_uid(df: pd.DataFrame, uid_column: str, date_c
 
     return results
 
+def partition_date_stats(partition):
+    """
+    Calculate date statistics (min, max, valid count) for a partition of date data.
+
+    Parameters:
+    -----------
+    partition : pd.Series or array-like
+        Partition of date values to analyze.
+
+    Returns:
+    --------
+    pd.Series
+        Series containing:
+            - min_date: Minimum valid date in the partition (pd.Timestamp or pd.NaT)
+            - max_date: Maximum valid date in the partition (pd.Timestamp or pd.NaT)
+            - valid_count: Number of valid (non-null) dates in the partition (int)
+    """
+    # Convert to datetime for this partition
+    partition_dates = pd.to_datetime(partition, errors='coerce')
+    valid_mask = ~partition_dates.isna()
+    valid_dates = partition_dates[valid_mask]
+    
+    if len(valid_dates) == 0:
+        return pd.Series({
+            'min_date': pd.NaT,
+            'max_date': pd.NaT,
+            'valid_count': 0
+        })
+    
+    return pd.Series({
+        'min_date': valid_dates.min(),
+        'max_date': valid_dates.max(),
+        'valid_count': len(valid_dates)
+    })
+
+def partition_distributions(partition):
+    """
+    Calculate date distributions (year, month, day of week, decade) for a partition of date data.
+
+    Parameters:
+    -----------
+    partition : pd.Series or array-like
+        Partition of date values to analyze.
+
+    Returns:
+    --------
+    pd.DataFrame
+        DataFrame with columns:
+            - type: Distribution type ('year', 'month', 'dow', 'decade')
+            - key: Distribution key (e.g., year, month number, day index, decade label)
+            - count: Count of occurrences for each key
+        If no valid dates are present, returns an empty DataFrame with these columns.
+    """
+    partition_dates = pd.to_datetime(partition, errors='coerce')
+    valid_mask = ~partition_dates.isna()
+    valid_dates = partition_dates[valid_mask]
+    
+    if len(valid_dates) == 0:
+        return pd.DataFrame({
+            'type': [], 'key': [], 'count': []
+        })
+    
+    # Return distributions for this partition
+    year_counts = valid_dates.dt.year.value_counts()
+    month_counts = valid_dates.dt.month.value_counts()
+    dow_counts = valid_dates.dt.dayofweek.value_counts()
+    decade_counts = (valid_dates.dt.year // 10 * 10).value_counts()
+    
+    # Combine all distributions into a single DataFrame
+    result_data = []
+    
+    for year, count in year_counts.items():
+        result_data.append({'type': 'year', 'key': str(year), 'count': count})
+    
+    for month, count in month_counts.items():
+        result_data.append({'type': 'month', 'key': str(month), 'count': count})
+    
+    for dow, count in dow_counts.items():
+        result_data.append({'type': 'dow', 'key': str(dow), 'count': count})
+    
+    for decade, count in decade_counts.items():
+        result_data.append({'type': 'decade', 'key': f"{decade}s", 'count': count})
+    
+    return pd.DataFrame(result_data)
+
+def aggregate_distributions_data(distributions_data: pd.DataFrame) -> Dict[str, Dict[str, int]]:
+    """
+    Aggregate distribution data from Dask partitions into the expected format.
+
+    Parameters:
+    -----------
+    distributions_data : pd.DataFrame
+        DataFrame with columns ['type', 'key', 'count'] containing distribution data
+
+    Returns:
+    --------
+    Dict[str, Dict[str, int]]
+        Dictionary with aggregated distributions in the expected format
+    """
+    if len(distributions_data) == 0:
+        return {}
+    
+    # Aggregate by grouping and summing counts
+    aggregated = distributions_data.groupby(['type', 'key'])['count'].sum().reset_index()
+    
+    # Convert back to the expected format
+    distributions = {}
+    # Year distribution
+    year_data = aggregated[aggregated['type'] == 'year']
+    if len(year_data) > 0:
+        # Sort by year in ascending order
+        year_data_sorted = year_data.sort_values('key', key=lambda x: x.astype(int))
+        distributions['year_distribution'] = dict(zip(year_data_sorted['key'], year_data_sorted['count']))
+    
+    # Month distribution
+    month_data = aggregated[aggregated['type'] == 'month']
+    if len(month_data) > 0:
+        # Sort by month in ascending order (1-12)
+        month_data_sorted = month_data.sort_values('key', key=lambda x: x.astype(int))
+        distributions['month_distribution'] = dict(zip(month_data_sorted['key'], month_data_sorted['count']))
+    
+    # Day of week distribution
+    dow_data = aggregated[aggregated['type'] == 'dow']
+    if len(dow_data) > 0:
+        day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        # Sort by day of week index (0=Monday to 6=Sunday) to maintain weekday order
+        dow_data_sorted = dow_data.sort_values('key')
+        distributions['day_of_week_distribution'] = {
+            day_names[int(k)]: int(v) for k, v in zip(dow_data_sorted['key'], dow_data_sorted['count'])
+        }
+    
+    # Decade distribution
+    decade_data = aggregated[aggregated['type'] == 'decade']
+    if len(decade_data) > 0:
+        distributions['decade_distribution'] = dict(zip(decade_data['key'], decade_data['count']))
+    
+    return distributions
 
 def analyze_date_field(df: pd.DataFrame,
                        field_name: str,
@@ -323,43 +461,74 @@ def analyze_date_field(df: pd.DataFrame,
                        max_year: int = 2005,
                        id_column: Optional[str] = None,
                        uid_column: Optional[str] = None,
+                       chunk_size: int = 10000,
+                       use_dask: bool = False,
+                       use_vectorization: bool = False,
+                       parallel_processes: int = 1,
+                       progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                       task_logger: Optional[logging.Logger] = None,
                        **kwargs) -> Dict[str, Any]:
     """
-    Comprehensive analysis of a date field.
+    Perform comprehensive analysis of a date field in a DataFrame, including statistics, distributions, anomaly detection, and optional group/UID analysis.
 
     Parameters:
     -----------
     df : pd.DataFrame
-        The DataFrame containing the data to analyze
+        The DataFrame containing the data to analyze.
     field_name : str
-        The name of the field to analyze
-    min_year : int
-        Minimum valid year for anomaly detection
-    max_year : int
-        Maximum valid year for anomaly detection
+        The name of the date field to analyze.
+    min_year : int, optional
+        Minimum valid year for anomaly detection (default: 1940).
+    max_year : int, optional
+        Maximum valid year for anomaly detection (default: 2005).
     id_column : str, optional
-        The column to use for group analysis
+        The column to use for group analysis (e.g., to detect date changes within groups).
     uid_column : str, optional
-        The column to use for UID analysis
+        The column to use for UID analysis (e.g., to detect inconsistencies by unique identifier).
+    chunk_size : int, optional
+        The number of rows per chunk for chunked or parallel processing (default: 10000).
+    use_dask : bool, optional
+        Whether to use Dask for large DataFrame processing (default: False).
+    use_vectorization : bool, optional
+        Whether to use vectorized parallel processing (default: False).
+    parallel_processes : int, optional
+        Number of parallel processes to use if vectorization is enabled (default: 1).
+    progress_tracker : HierarchicalProgressTracker, optional
+        Optional progress tracker for reporting progress.
+    task_logger : Optional[logging.Logger]
+        Logger for tracking task progress and debugging.
     **kwargs : dict
-        Additional parameters for the analysis
+        Additional keyword arguments for advanced configuration (e.g., npartitions for Dask).
 
     Returns:
     --------
     Dict[str, Any]
-        The results of the analysis
+        Dictionary containing analysis results, including:
+            - total_records, null_count, non_null_count, valid_count, invalid_count
+            - fill_rate, valid_rate
+            - min_date, max_date
+            - year_distribution, month_distribution, day_of_week_distribution, decade_distribution
+            - anomalies (counts and examples)
+            - date_changes_within_group (if id_column specified)
+            - date_inconsistencies_by_uid (if uid_column specified)
     """
+    if task_logger:
+        logger = task_logger
+
     logger.info(f"Analyzing date field: {field_name}")
 
     # Basic validation
     if field_name not in df.columns:
         return {'error': f"Field {field_name} not found in DataFrame"}
+    
+
+    total_records = len(df)
+    is_large_df = total_records > chunk_size
 
     # Get prepared data
     dates, null_count, non_null_count = prepare_date_data(df, field_name)
     total_records = len(df)
 
-    # Calculate valid and invalid counts
     valid_mask = ~dates.isna()
     valid_count = valid_mask.sum()
     invalid_count = non_null_count - valid_count
@@ -376,19 +545,265 @@ def analyze_date_field(df: pd.DataFrame,
         'valid_count': int(valid_count),
         'invalid_count': int(invalid_count),
         'fill_rate': fill_rate,
-        'valid_rate': valid_rate
-    }
+        'valid_rate': valid_rate    
+        }
+    if use_dask and is_large_df:
+        try:
+            npartitions = kwargs.get('npartitions', None)
 
-    # Calculate date range and distributions if we have valid dates
+            logger.info("Parallel Enabled")
+            logger.info("Parallel Engine: Dask")
+            logger.info(f"Parallel Workers: {npartitions}")
+
+            import dask.dataframe as dd
+            import dask
+
+            # Convert to Dask DataFrame
+            ddf = dd.from_pandas(df, npartitions=npartitions)
+            
+            logger.info(f"Using Dask for large dataset with {total_records} rows")
+
+            if valid_count > 0:
+                # Define function to calculate date stats for each partition                
+                # Calculate date stats using map_partitions
+                partition_stats_list = ddf[field_name].map_partitions(
+                    partition_date_stats,
+                    meta=pd.Series({
+                        'min_date': pd.Timestamp('2000-01-01'),
+                        'max_date': pd.Timestamp('2000-01-01'), 
+                        'valid_count': 0
+                    })
+                ).compute()
+
+                # Convert list of Series to list for processing
+                partition_stats_data = []
+                for stats in partition_stats_list:
+                    if isinstance(stats, pd.Series):
+                        partition_stats_data.append(stats)
+                    else:
+                        # Handle case where stats might be a different type
+                        partition_stats_data.append(pd.Series(stats))
+
+                # Aggregate results from all partitions
+                if len(partition_stats_data) > 0:
+                    # Filter for partitions with valid data
+                    valid_partitions = [stats for stats in partition_stats_data if stats.get('valid_count', 0) > 0]
+                    
+                    if len(valid_partitions) > 0:
+                        # Get min and max dates from valid partitions
+                        min_dates = [stats.get('min_date') for stats in valid_partitions if not pd.isna(stats.get('min_date'))]
+                        max_dates = [stats.get('max_date') for stats in valid_partitions if not pd.isna(stats.get('max_date'))]
+                        if min_dates and max_dates:
+                            overall_min = min(min_dates)
+                            overall_max = max(max_dates)
+                            
+                            date_stats = {
+                                'valid_count': int(valid_count),
+                                'min_date': overall_min.strftime('%Y-%m-%d') if not pd.isna(overall_min) else None,
+                                'max_date': overall_max.strftime('%Y-%m-%d') if not pd.isna(overall_max) else None
+                            }
+                            results.update(date_stats)
+
+                # Calculate distributions using map_partitions
+                distributions_data = ddf[field_name].map_partitions(
+                    partition_distributions,
+                    meta=pd.DataFrame({
+                        'type': pd.Series(dtype='object'),
+                        'key': pd.Series(dtype='object'), 
+                        'count': pd.Series(dtype='int64')
+                    })
+                ).compute()
+
+                # Aggregate distributions
+                if not distributions_data.empty:
+                    aggregated = aggregate_distributions_data(distributions_data)
+                    
+                    results.update(aggregated)
+                
+        except ImportError:
+            logger.warning("Dask requested but not available. Falling back to chunked processing.")
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Dask fallback",
+                    "warning": "Dask not available, using chunks"
+                })
+    elif use_vectorization and parallel_processes > 0:
+        try:
+            logger.info("Parallel Enabled")
+            logger.info("Parallel Engine: Joblib")
+            logger.info(f"Parallel Workers: {parallel_processes}")
+
+            from joblib import Parallel, delayed
+
+            logger.info(f"Using parallel processing with {parallel_processes} processes for {total_records} rows")
+            
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Parallel processing setup",
+                    "processes": parallel_processes,
+                    "chunk_size": chunk_size
+                })
+            
+            # Split DataFrame into chunks
+            chunks = []
+            for i in range(0, total_records, chunk_size):
+                chunk = df.iloc[i:i + chunk_size]
+                chunks.append(chunk)
+            
+            logger.info(f"Processing {len(chunks)} chunks in parallel")
+            
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Processing chunks",
+                    "total_chunks": len(chunks)
+                })
+              # Process chunks in parallel
+            processed_chunks = list(Parallel(n_jobs=parallel_processes)(
+                delayed(process_date_chunk)(i, chunk, field_name, min_year, max_year) 
+                for i, chunk in enumerate(chunks)
+            ))
+            
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Aggregating results",
+                    "chunks_processed": len(processed_chunks)
+                })
+            
+            # Aggregate results from all chunks
+            aggregated_results = aggregate_chunk_results(processed_chunks)
+            
+            if 'error' not in aggregated_results:
+                results.update(aggregated_results)
+                logger.info(f"Parallel processing completed successfully")
+            else:
+                logger.warning(f"Error in parallel processing: {aggregated_results['error']}")
+            
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Parallel processing completed"
+                })
+                
+        except Exception as e:
+            logger.error(f"Error in parallel processing: {str(e)}")
+            logger.info("Falling back to standard processing")
+            
+            if progress_tracker:
+                progress_tracker.update(0, {
+                    "step": "Parallel fallback",
+                    "error": str(e)
+                })
+    elif is_large_df and not use_dask:
+        # Process large DataFrame in chunks without Dask
+        logger.info(f"Processing large dataset with {total_records} rows using chunked processing")
+        
+        if progress_tracker:
+            progress_tracker.update(0, {
+                "step": "Chunked processing setup",
+                "total_rows": total_records,
+                "chunk_size": chunk_size
+            })
+        
+        total_chunks = (total_records + chunk_size - 1) // chunk_size
+        logger.info(f"Processing {total_chunks} chunks sequentially")
+        
+        # Initialize aggregated results for chunked processing
+        chunk_results = {
+            'date_stats': [],
+            'distributions': [],
+            'anomalies': []
+        }
+        
+        # Process chunks sequentially
+        for i in range(total_chunks):
+            start_idx = i * chunk_size
+            end_idx = min((i + 1) * chunk_size, total_records)
+            chunk = df.iloc[start_idx:end_idx]
+            
+            if progress_tracker:
+                progress_tracker.update(
+                    0, 
+                    {
+                        "step": f"Processing chunk {i + 1}/{total_chunks}",
+                        "chunk_start": start_idx,
+                        "chunk_end": end_idx
+                    }
+                )
+            
+            logger.debug(f"Processing chunk {i + 1}/{total_chunks} (rows {start_idx}-{end_idx})")
+            
+            # Process this chunk
+            chunk_dates = pd.to_datetime(chunk[field_name], errors='coerce')
+            valid_chunk_mask = ~chunk_dates.isna()
+            valid_chunk_dates = chunk_dates[valid_chunk_mask]
+            
+            if len(valid_chunk_dates) > 0:
+                # Calculate date stats for this chunk
+                chunk_min = valid_chunk_dates.min()
+                chunk_max = valid_chunk_dates.max()
+                chunk_results['date_stats'].append({
+                    'min_date': chunk_min,
+                    'max_date': chunk_max,
+                    'valid_count': len(valid_chunk_dates)
+                })
+                
+                # Calculate distributions for this chunk
+                chunk_distributions = calculate_distributions(chunk_dates)
+                chunk_results['distributions'].append(chunk_distributions)
+                
+        if progress_tracker:
+            progress_tracker.update(0, {
+                "step": "Aggregating chunk results",
+                "chunks_processed": total_chunks
+            })
+        
+        # Aggregate results from all chunks
+        if chunk_results['date_stats'] and valid_count > 0:
+            # Aggregate date stats
+            valid_stats = [stats for stats in chunk_results['date_stats'] if stats['valid_count'] > 0]
+            if valid_stats:
+                overall_min = min(stats['min_date'] for stats in valid_stats)
+                overall_max = max(stats['max_date'] for stats in valid_stats)
+                
+                results.update({
+                    'valid_count': int(valid_count),
+                    'min_date': overall_min.strftime('%Y-%m-%d') if not pd.isna(overall_min) else None,
+                    'max_date': overall_max.strftime('%Y-%m-%d') if not pd.isna(overall_max) else None
+                })
+            
+            # Aggregate distributions
+            aggregated_distributions = {}
+            for chunk_dist in chunk_results['distributions']:
+                for dist_type, dist_data in chunk_dist.items():
+                    if dist_type not in aggregated_distributions:
+                        aggregated_distributions[dist_type] = {}
+                    
+                    for key, count in dist_data.items():
+                        if key in aggregated_distributions[dist_type]:
+                            aggregated_distributions[dist_type][key] += count
+                        else:
+                            aggregated_distributions[dist_type][key] = count
+            
+            results.update(aggregated_distributions)
+        
+        if progress_tracker:
+            progress_tracker.update(0, {
+                "step": "Chunked processing completed",
+                "total_chunks": total_chunks
+            })
+        
+        logger.info(f"Chunked processing completed successfully")
+    else:
+        if valid_count > 0:
+            # Calculate date range and distributions if we have valid dates
+            # Get date range
+            date_stats = calculate_date_stats(dates)
+            results.update(date_stats)
+
+            # Calculate distributions
+            distributions = calculate_distributions(dates)
+            results.update(distributions)
+    
     if valid_count > 0:
-        # Get date range
-        date_stats = calculate_date_stats(dates)
-        results.update(date_stats)
-
-        # Calculate distributions
-        distributions = calculate_distributions(dates)
-        results.update(distributions)
-
         # Analyze anomalies
         anomalies = detect_date_anomalies(df[field_name], min_year=min_year, max_year=max_year)
         results['anomalies'] = {k: len(v) for k, v in anomalies.items()}
@@ -398,12 +813,12 @@ def analyze_date_field(df: pd.DataFrame,
             if examples:
                 results[f'{anomaly_type}_examples'] = examples[:10]  # First 10 examples
 
-    # Group analysis if id_column is specified
+    # Group analysis if id_column is specified (applies to all processing methods)
     if id_column and id_column in df.columns:
         group_changes = detect_date_changes_within_group(df, id_column, field_name)
         results['date_changes_within_group'] = group_changes
 
-    # UID analysis if uid_column is specified
+    # UID analysis if uid_column is specified (applies to all processing methods)
     if uid_column and uid_column in df.columns:
         uid_inconsistencies = detect_date_inconsistencies_by_uid(df, uid_column, field_name)
         results['date_inconsistencies_by_uid'] = uid_inconsistencies
@@ -471,3 +886,210 @@ def estimate_resources(df: pd.DataFrame, field_name: str) -> Dict[str, Any]:
             'estimated_time_seconds': 1,
             'error': f"Field {field_name} not found in DataFrame"
         }
+
+def process_date_chunk(chunk_index: int, chunk_data: pd.DataFrame, field_name: str, 
+                      min_year: int = 1940, max_year: int = 2005) -> Dict[str, Any]:
+    """
+    Process a single chunk of data for date analysis using vectorization.
+
+    Parameters:
+    -----------
+    chunk_index : int
+        Index of the chunk being processed
+    chunk_data : pd.DataFrame
+        The chunk of data to process
+    field_name : str
+        The name of the date field to analyze
+    min_year : int
+        Minimum valid year for anomaly detection
+    max_year : int
+        Maximum valid year for anomaly detection
+
+    Returns:
+    --------
+    Dict[str, Any]
+        Results from processing this chunk
+    """
+    if field_name not in chunk_data.columns:
+        return {
+            'chunk_index': chunk_index,
+            'error': f"Field {field_name} not found in chunk",
+            'valid_count': 0,
+            'distributions': {},
+            'anomalies': {}
+        }
+    
+    # Convert to datetime for this chunk
+    chunk_dates = pd.to_datetime(chunk_data[field_name], errors='coerce')
+    valid_mask = ~chunk_dates.isna()
+    valid_dates = chunk_dates[valid_mask]
+    
+    chunk_result = {
+        'chunk_index': chunk_index,
+        'valid_count': len(valid_dates),
+        'distributions': {},
+        'anomalies': {},
+        'date_stats': {}
+    }
+    
+    if len(valid_dates) == 0:
+        return chunk_result
+    
+    # Calculate date stats for this chunk
+    min_date = valid_dates.min()
+    max_date = valid_dates.max()
+    chunk_result['date_stats'] = {
+        'min_date': min_date,
+        'max_date': max_date,
+        'valid_count': len(valid_dates)
+    }
+    
+    # Calculate distributions for this chunk using vectorized operations
+    distributions = {}
+    
+    # Year distribution
+    year_counts = valid_dates.dt.year.value_counts()
+    distributions['year'] = year_counts.to_dict()
+    
+    # Month distribution
+    month_counts = valid_dates.dt.month.value_counts()
+    distributions['month'] = month_counts.to_dict()
+    
+    # Day of week distribution
+    dow_counts = valid_dates.dt.dayofweek.value_counts()
+    distributions['dow'] = dow_counts.to_dict()
+    
+    # Decade distribution
+    decade_counts = (valid_dates.dt.year // 10 * 10).value_counts()
+    distributions['decade'] = decade_counts.to_dict()
+    
+    chunk_result['distributions'] = distributions
+    
+    # Anomaly detection using vectorized operations
+    anomalies = {
+        'invalid_format': 0,
+        'too_old': 0,
+        'future_dates': 0,
+        'too_young': 0,
+        'negative_years': 0
+    }
+    
+    # Check for anomalies using vectorized operations
+    current_year = datetime.now().year
+    years = valid_dates.dt.year
+    
+    # Count anomalies
+    anomalies['too_old'] = (years < min_year).sum()
+    anomalies['future_dates'] = (years > current_year).sum()
+    anomalies['too_young'] = ((years > max_year) & (years <= current_year)).sum()
+    
+    # Check for invalid formats (non-null values that couldn't be converted)
+    non_null_mask = chunk_data[field_name].notna()
+    invalid_mask = non_null_mask & chunk_dates.isna()
+    anomalies['invalid_format'] = invalid_mask.sum()
+    
+    # Check for negative years (simple string check for performance)
+    if invalid_mask.any():
+        negative_strings = chunk_data.loc[invalid_mask, field_name].astype(str).str.startswith('-')
+        anomalies['negative_years'] = negative_strings.sum()
+        anomalies['invalid_format'] -= anomalies['negative_years']  # Adjust count
+    
+    chunk_result['anomalies'] = anomalies
+    
+    return chunk_result
+
+
+def aggregate_chunk_results(chunk_results) -> Dict[str, Any]:
+    """
+    Aggregate results from parallel chunk processing.
+
+    Parameters:
+    -----------
+    chunk_results : List[Dict[str, Any]]
+        List of results from each processed chunk
+
+    Returns:
+    --------
+    Dict[str, Any]
+        Aggregated results in the expected format
+    """
+    if not chunk_results:
+        return {}
+    
+    # Filter out error chunks
+    valid_chunks = [chunk for chunk in chunk_results if 'error' not in chunk]
+    
+    if not valid_chunks:
+        return {'error': 'No valid chunks processed'}
+    
+    # Aggregate date stats
+    min_dates = []
+    max_dates = []
+    total_valid_count = 0
+    
+    for chunk in valid_chunks:
+        if chunk['valid_count'] > 0 and 'date_stats' in chunk:
+            min_dates.append(chunk['date_stats']['min_date'])
+            max_dates.append(chunk['date_stats']['max_date'])
+            total_valid_count += chunk['valid_count']
+    
+    aggregated = {}
+    
+    if min_dates and max_dates:
+        overall_min = min(min_dates)
+        overall_max = max(max_dates)
+        aggregated.update({
+            'valid_count': total_valid_count,
+            'min_date': overall_min.strftime('%Y-%m-%d') if not pd.isna(overall_min) else None,
+            'max_date': overall_max.strftime('%Y-%m-%d') if not pd.isna(overall_max) else None
+        })
+    
+    # Aggregate distributions
+    combined_distributions = {
+        'year': {},
+        'month': {},
+        'dow': {},
+        'decade': {}
+    }
+    
+    for chunk in valid_chunks:
+        distributions = chunk.get('distributions', {})
+        for dist_type in combined_distributions:
+            if dist_type in distributions:
+                for key, count in distributions[dist_type].items():
+                    combined_distributions[dist_type][key] = combined_distributions[dist_type].get(key, 0) + count
+    
+    # Convert to expected format
+    if combined_distributions['year']:
+        aggregated['year_distribution'] = {str(k): int(v) for k, v in combined_distributions['year'].items()}
+    
+    if combined_distributions['month']:
+        aggregated['month_distribution'] = {str(k): int(v) for k, v in combined_distributions['month'].items()}
+    
+    if combined_distributions['dow']:
+        day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        aggregated['day_of_week_distribution'] = {
+            day_names[int(k)]: int(v) for k, v in combined_distributions['dow'].items()
+        }
+    
+    if combined_distributions['decade']:
+        aggregated['decade_distribution'] = {f"{k}s": int(v) for k, v in combined_distributions['decade'].items()}
+    
+    # Aggregate anomalies
+    combined_anomalies = {
+        'invalid_format': 0,
+        'too_old': 0,
+        'future_dates': 0,
+        'too_young': 0,
+        'negative_years': 0
+    }
+    
+    for chunk in valid_chunks:
+        anomalies = chunk.get('anomalies', {})
+        for anomaly_type in combined_anomalies:
+            if anomaly_type in anomalies:
+                combined_anomalies[anomaly_type] += anomalies[anomaly_type]
+    
+    aggregated['anomalies'] = combined_anomalies
+    
+    return aggregated

--- a/pamola_core/profiling/commons/email_utils.py
+++ b/pamola_core/profiling/commons/email_utils.py
@@ -22,6 +22,9 @@ from typing import Dict, Any, Optional
 import numpy as np
 import pandas as pd
 
+from pamola_core.profiling.commons.analysis_utils import process_dataframe_with_config
+from pamola_core.utils.progress import HierarchicalProgressTracker
+
 # Configure logger
 logger = logging.getLogger(__name__)
 
@@ -127,6 +130,13 @@ def detect_personal_patterns(emails: pd.Series) -> Dict[str, Any]:
 def analyze_email_field(df: pd.DataFrame,
                         field_name: str,
                         top_n: int = 20,
+                        use_dask: bool = False,
+                        use_vectorization: bool = False,
+                        chunk_size: int = 1000,
+                        npartitions: int = 1,
+                        parallel_processes: int = 1,
+                        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+                        task_logger: Optional[logging.Logger] = None,
                         **kwargs) -> Dict[str, Any]:
     """
     Analyze an email field in the given DataFrame.
@@ -134,11 +144,25 @@ def analyze_email_field(df: pd.DataFrame,
     Parameters:
     -----------
     df : pd.DataFrame
-        The DataFrame containing the data to analyze
+        The DataFrame containing the data to analyze.
     field_name : str
-        The name of the field to analyze
-    top_n : int
-        Number of top domains to include in the results
+        The name of the email field to analyze.
+    top_n : int, default 20
+        Number of top domains to include in the results.
+    use_dask : bool, default False
+        Whether to use Dask for parallel processing.
+    use_vectorization : bool, default False
+        Whether to use vectorized operations for processing.
+    chunk_size : int, default 1000
+        Batch size for chunked processing.
+    npartitions : int, default 1
+        Number of partitions if using Dask.
+    parallel_processes : int, default 1
+        Number of parallel processes to use.
+    progress_tracker : Optional[HierarchicalProgressTracker]
+        Progress tracker object for monitoring progress.
+    task_logger : Optional[logging.Logger]
+        Logger for tracking task progress and debugging.
     **kwargs : dict
         Additional parameters for the analysis
 
@@ -147,6 +171,9 @@ def analyze_email_field(df: pd.DataFrame,
     Dict[str, Any]
         The results of the analysis
     """
+    if task_logger:
+        logger = task_logger
+
     logger.info(f"Analyzing email field: {field_name}")
 
     if field_name not in df.columns:
@@ -166,10 +193,26 @@ def analyze_email_field(df: pd.DataFrame,
 
     # Extract domains
     domains = {}
-    for email in df[field_name].dropna():
-        domain = extract_email_domain(email)
-        if domain:
-            domains[domain] = domains.get(domain, 0) + 1
+    def process_batch(batch):
+        batch[f"{field_name}_analyzer"] = batch[field_name].dropna().apply(extract_email_domain)
+
+        return batch
+
+    processed_df = process_dataframe_with_config(
+        df=df,
+        process_function=process_batch,
+        chunk_size=chunk_size,
+        use_dask=use_dask,
+        npartitions=npartitions,
+        meta=None,
+        use_vectorization=use_vectorization,
+        parallel_processes=parallel_processes,
+        progress_tracker=progress_tracker,
+        task_logger=logger
+    )
+
+    if isinstance(processed_df, pd.DataFrame):
+        domains = processed_df[f"{field_name}_analyzer"].value_counts().to_dict()
 
     # Sort domains by frequency in descending order
     domains = dict(sorted(domains.items(), key=lambda x: x[1], reverse=True))

--- a/pamola_core/profiling/commons/group_utils.py
+++ b/pamola_core/profiling/commons/group_utils.py
@@ -8,7 +8,7 @@ Separates analytical logic from operational components.
 
 import hashlib
 import logging
-from typing import Dict, List, Any, Tuple, Optional, Union
+from typing import Dict, List, Any, Set, Tuple, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -657,3 +657,497 @@ def estimate_resources(df: pd.DataFrame, group_field: str, fields_weights: Dict[
             'estimated_time_seconds': 1,
             'error': f"Group field {group_field} not found in DataFrame"
         }
+
+def calculate_field_variance(field_series: pd.Series,
+                            text_length_threshold: int,
+                            hash_algorithm: str,
+                            use_minhash: bool,
+                            minhash_similarity_threshold: float,
+                            minhash_cache: Dict[str, Any],
+                            logger: logging.Logger) -> Tuple[float, float]:
+    """
+    Calculate the variance and duplication ratio for a single field.
+
+    Parameters:
+    -----------
+    field_series : pd.Series
+        Series containing values for a single field
+    text_length_threshold : int
+        Threshold for text length processing
+    hash_algorithm : str
+        Hash algorithm to use
+    use_minhash : bool
+        Whether to use MinHash algorithm
+    minhash_similarity_threshold : float
+        Similarity threshold for MinHash
+    minhash_cache : Dict[str, Any]
+        Cache for MinHash signatures
+    logger : logging.Logger
+        Logger instance
+
+    Returns:
+    --------
+    Tuple[float, float]
+        (variance, duplication_ratio)
+    """
+    total_records = len(field_series)
+
+    if total_records <= 1:
+        return 0.0, 0.0
+
+    # Get unique values
+    unique_values, value_counts = get_unique_values_improved(
+        field_series,
+        text_length_threshold=text_length_threshold,
+        hash_algorithm=hash_algorithm,
+        use_minhash=use_minhash,
+        minhash_similarity_threshold=minhash_similarity_threshold,
+        minhash_cache=minhash_cache,
+        logger=logger
+    )
+    unique_count = len(unique_values)
+
+    # Calculate variance: (unique_count - 1) / (total_records - 1)
+    # This gives 0 when all values are identical, 1 when all values are unique
+    # Low variance means many duplicates (high similarity), high variance means few duplicates
+    variance = (unique_count - 1) / (total_records - 1) if total_records > 1 else 0
+
+    # Calculate duplication ratio: total_records / unique_count
+    duplication_ratio = total_records / unique_count if unique_count > 0 else 0
+
+    return float(variance), float(duplication_ratio)
+
+def get_unique_values_improved(field_series: pd.Series,
+                                text_length_threshold: int,
+                                hash_algorithm: str,
+                                use_minhash: bool,
+                                minhash_similarity_threshold: float,
+                                minhash_cache: Dict[str, Any],
+                                logger: logging.Logger) -> Tuple[Set[Any], Dict[Any, int]]:
+    """
+    Get unique values from a field series, handling text and NULL values.
+    Improved version with better categorical data handling.
+
+    Parameters:
+    -----------
+    field_series : pd.Series
+        Series containing values for a single field
+    text_length_threshold : int
+        Threshold for text length processing
+    hash_algorithm : str
+        Hash algorithm to use
+    use_minhash : bool
+        Whether to use MinHash algorithm
+    minhash_similarity_threshold : float
+        Similarity threshold for MinHash
+    minhash_cache : Dict[str, Any]
+        Cache for MinHash signatures
+    logger : logging.Logger
+        Logger instance
+
+    Returns:
+    --------
+    Tuple[Set[Any], Dict[Any, int]]
+        Set of unique values and dictionary with value counts
+    """
+    unique_keys = set()
+    counts = {}
+
+    # Initialize MinHash-related variables
+    _minhash_imported = False
+    _compute_minhash = None
+
+    # Process each value individually to avoid categorical data issues
+    for raw_val in field_series:
+        # Handle NULL values
+        if pd.isna(raw_val):
+            key = None  # Use None as the key for NaN values
+        # Handle string values with potential hashing
+        elif isinstance(raw_val, str):
+            text = raw_val.strip()
+            if len(text) > text_length_threshold:
+                if use_minhash:
+                    # Lazy import MinHash only if needed
+                    if not _minhash_imported:
+                        try:
+                            # Dynamically import minhash module when needed
+                            from pamola_core.utils.nlp.minhash import compute_minhash
+                            _compute_minhash = compute_minhash
+                            _minhash_imported = True
+                        except ImportError:
+                            logger.warning("MinHash library not available, falling back to MD5")
+                            use_minhash = False
+                            _minhash_imported = False
+                            _compute_minhash = lambda _: []
+
+                    if use_minhash and _minhash_imported:
+                        # Use cached MinHash signatures when possible
+                        if text not in minhash_cache:
+                            minhash_cache[text] = _compute_minhash(text)
+
+                        # Use the first 8 elements of the signature as the key
+                        signature = minhash_cache[text]
+                        signature_str = str(signature[:8])  # Convert to string for consistent keys
+                        key = signature_str
+                    else:
+                        # Fallback to MD5 if MinHash is not available
+                        key = hashlib.md5(text.encode('utf-8')).hexdigest()
+                else:
+                    # Use MD5 for exact matching of long texts
+                    key = hashlib.md5(text.encode('utf-8')).hexdigest()
+            else:
+                # Use the text directly for short strings
+                key = text
+        else:
+            # For other types (numbers, dates, etc.), use direct comparison
+            key = raw_val
+
+        # Count occurrences
+        unique_keys.add(key)
+        counts[key] = counts.get(key, 0) + 1
+
+    # For MinHash, we could cluster similar signatures here if needed
+    if use_minhash and _minhash_imported:
+        minhash_keys = [k for k in counts.keys() if isinstance(k, str) and k.startswith('[')]
+
+        if len(minhash_keys) > 1:
+            # Group similar signatures
+            clusters = cluster_minhash_signatures_from_keys(
+                minhash_keys, minhash_similarity_threshold
+            )
+
+            # Update counts based on clusters
+            for cluster in clusters:
+                if len(cluster) > 1:
+                    # Use the first signature as the representative
+                    primary_key = cluster[0]
+                    total_count = counts.get(primary_key, 0)
+
+                    # Combine counts from all similar signatures
+                    for other_key in cluster[1:]:
+                        if other_key in counts:
+                            total_count += counts.pop(other_key)
+                            unique_keys.remove(other_key)
+
+                    # Update count for the primary key
+                    counts[primary_key] = total_count
+
+    return unique_keys, counts
+
+def cluster_minhash_signatures_from_keys(signature_keys: List[str], 
+                                        minhash_similarity_threshold: float) -> List[List[str]]:
+    """
+    Cluster similar MinHash signature keys.
+
+    Parameters:
+    -----------
+    signature_keys : List[str]
+        List of MinHash signature keys to cluster
+    minhash_similarity_threshold : float
+        Similarity threshold for clustering
+
+    Returns:
+    --------
+    List[List[str]]
+        List of clusters, where each cluster is a list of similar signature keys
+    """
+    if len(signature_keys) <= 1:
+        return [signature_keys]
+
+    # Parse signatures from string representation
+    parsed_signatures = []
+    for key in signature_keys:
+        try:
+            # Extract numbers from string representation like '[1, 2, 3, 4]'
+            nums = key.strip('[]').split(',')
+            sig = [int(n.strip()) for n in nums if n.strip()]
+            parsed_signatures.append((key, sig))
+        except (ValueError, AttributeError):
+            # Skip keys that can't be parsed as signatures
+            continue
+
+    # Create clusters
+    clusters = []
+    processed = set()
+
+    # For each signature, find similar signatures and create a cluster
+    for i, (key1, sig1) in enumerate(parsed_signatures):
+        if key1 in processed:
+            continue
+
+        # Start a new cluster with this key
+        cluster = [key1]
+        processed.add(key1)
+
+        # Compare with all other signatures
+        for key2, sig2 in parsed_signatures[i + 1:]:
+            if key2 in processed:
+                continue
+
+            # Calculate Jaccard similarity
+            similarity = calculate_simple_jaccard(sig1, sig2)
+
+            # If similar enough, add to the cluster
+            if similarity >= minhash_similarity_threshold:
+                cluster.append(key2)
+                processed.add(key2)
+
+        # Add the cluster to the results
+        clusters.append(cluster)
+
+    return clusters
+
+def calculate_simple_jaccard(sig1: List[int], sig2: List[int]) -> float:
+    """
+    Calculate a simple Jaccard similarity between two signatures.
+
+    Parameters:
+    -----------
+    sig1 : List[int]
+        First signature
+    sig2 : List[int]
+        Second signature
+
+    Returns:
+    --------
+    float
+        Jaccard similarity (0-1)
+    """
+    # Ensure both signatures have values
+    if not sig1 or not sig2:
+        return 0.0
+
+    # Convert to sets for intersection and union
+    set1 = set(sig1)
+    set2 = set(sig2)
+
+    # Calculate Jaccard similarity: |intersection| / |union|
+    intersection = len(set1.intersection(set2))
+    union = len(set1.union(set2))
+
+    return intersection / union if union > 0 else 0.0
+
+def calculate_weighted_variance(field_variances: Dict[str, float], 
+                                fields_config: Dict[str, int]) -> float:
+    """
+    Calculate weighted variance across all fields.
+
+    Parameters:
+    -----------
+    field_variances : Dict[str, float]
+        Dictionary mapping field names to their variance values
+    fields_config : Dict[str, int]
+        Configuration mapping field names to their weights
+
+    Returns:
+    --------
+    float
+        Weighted variance across all fields
+    """
+    weighted_sum = 0
+    total_weight = 0
+
+    for field, variance in field_variances.items():
+        weight = fields_config.get(field, 1)
+        weighted_sum += variance * weight
+        total_weight += weight
+
+    return weighted_sum / total_weight if total_weight > 0 else 0
+
+def should_aggregate(weighted_variance: float, 
+                    group_size: int,
+                    variance_threshold: float,
+                    large_group_threshold: int,
+                    large_group_variance_threshold: float) -> bool:
+    """
+    Determine if a group should be aggregated based on variance and size.
+
+    Parameters:
+    -----------
+    weighted_variance : float
+        Weighted variance of the group
+    group_size : int
+        Number of records in the group
+    variance_threshold : float
+        Variance threshold for normal groups
+    large_group_threshold : int
+        Threshold for large group size
+    large_group_variance_threshold : float
+        Variance threshold for large groups
+
+    Returns:
+    --------
+    bool
+        True if the group should be aggregated, False otherwise
+    """
+    # Apply different thresholds based on group size
+    if group_size > large_group_threshold:
+        return weighted_variance <= large_group_variance_threshold
+    else:
+        return weighted_variance <= variance_threshold
+
+def calculate_field_metrics(group_metrics: Dict[str, Dict[str, Any]], 
+                            fields: List[str]) -> Dict[str, Dict[str, float]]:
+    """
+    Calculate metrics for each field across all groups.
+
+    Parameters:
+    -----------
+    group_metrics : Dict[str, Dict[str, Any]]
+        Dictionary with metrics for each group
+    fields : List[str]
+        List of fields to analyze
+
+    Returns:
+    --------
+    Dict[str, Dict[str, float]]
+        Dictionary with metrics for each field
+    """
+    field_metrics = {}
+
+    for field in fields:
+        # Initialize metrics for this field
+        field_metrics[field] = {
+            "avg_variance": 0,
+            "max_variance": 0,
+            "avg_duplication_ratio": 0,
+            "unique_values_total": 0
+        }
+
+        # Collect variances and duplication ratios for this field
+        variances = []
+        duplication_ratios = []
+        unique_values_count = 0
+
+        for group_data in group_metrics.values():
+            if field in group_data["field_variances"]:
+                variances.append(group_data["field_variances"][field])
+
+            if field in group_data["duplication_ratios"]:
+                duplication_ratios.append(group_data["duplication_ratios"][field])
+
+                # Estimate unique values from duplication ratio: total_records / duplication_ratio
+                if group_data["duplication_ratios"][field] > 0:
+                    unique_values_count += group_data["total_records"] / group_data["duplication_ratios"][field]
+
+        # Calculate average and max values
+        field_metrics[field]["avg_variance"] = float(np.mean(variances)) if variances else 0
+        field_metrics[field]["max_variance"] = float(np.max(variances)) if variances else 0
+        field_metrics[field]["avg_duplication_ratio"] = float(
+            np.mean(duplication_ratios)) if duplication_ratios else 0
+        field_metrics[field]["unique_values_total"] = int(unique_values_count)
+
+    return field_metrics
+
+def analyze_group(group_df: pd.DataFrame,
+                  fields: List[str],
+                  fields_config: Dict[str, int],
+                  text_length_threshold: int,
+                  hash_algorithm: str,
+                  use_minhash: bool,
+                  minhash_similarity_threshold: float,
+                  minhash_cache: Dict[str, Any],
+                  large_group_threshold: int,
+                  large_group_variance_threshold: float,
+                  variance_threshold: float) -> Dict[str, Any]:
+        """
+        Analyze a single group of records.
+
+        Parameters:
+        -----------
+        group_df : pd.DataFrame
+            DataFrame containing records for a single group.
+        fields : List[str]
+            List of field names to analyze.
+        fields_config : Dict[str, int]
+            Dictionary mapping field names to their weights for weighted variance calculation.
+        text_length_threshold : int
+            Threshold for text length to determine when to use hashing or MinHash.
+        hash_algorithm : str
+            Hash algorithm to use for text fields (e.g., 'md5').
+        use_minhash : bool
+            Whether to use MinHash for long text fields.
+        minhash_similarity_threshold : float
+            Similarity threshold for clustering MinHash signatures.
+        minhash_cache : Dict[str, Any]
+            Cache for MinHash signatures to avoid recomputation.
+        large_group_threshold : int
+            Size above which a group is considered "large" for aggregation logic.
+        large_group_variance_threshold : float
+            Variance threshold for large groups.
+        variance_threshold : float
+            Variance threshold for normal groups.
+
+        Returns:
+        --------
+        Dict[str, Any]
+            Dictionary with group metrics
+        """
+        # Initialize metrics
+        field_variances = {}
+        duplication_ratios = {}
+
+        # Calculate variance and duplication ratio for each field
+        for field in fields:
+            # Calculate variance for this field
+            variance, duplications = calculate_field_variance(group_df[field],
+                                                              text_length_threshold,
+                                                              hash_algorithm,
+                                                              use_minhash,
+                                                              minhash_similarity_threshold,
+                                                              minhash_cache,
+                                                              logger)
+
+            field_variances[field] = variance
+            duplication_ratios[field] = duplications
+
+        # Calculate weighted variance
+        weighted_variance = calculate_weighted_variance(field_variances, fields_config)
+
+        # Determine if this group should be aggregated
+        should_aggregate = is_group_aggregatable(weighted_variance, len(group_df),
+                                            large_group_threshold, large_group_variance_threshold,variance_threshold)
+
+        # Get max field variance
+        max_field_variance = max(field_variances.values()) if field_variances else 0
+
+        return {
+            "weighted_variance": weighted_variance,
+            "max_field_variance": max_field_variance,
+            "total_records": len(group_df),
+            "field_variances": field_variances,
+            "duplication_ratios": duplication_ratios,
+            "should_aggregate": should_aggregate
+        }
+
+def is_group_aggregatable(weighted_variance: float,
+                     group_size: int,
+                     large_group_threshold: int,
+                     large_group_variance_threshold: float,
+                     variance_threshold: float) -> bool:
+        """
+        Determine if a group should be aggregated based on variance and size.
+
+        Parameters:
+        -----------
+        weighted_variance : float
+            Weighted variance of the group
+        group_size : int
+            Number of records in the group
+        variance_threshold : float
+            Variance threshold for normal groups
+        large_group_threshold : int
+            Threshold for large group size
+        large_group_variance_threshold : float
+            Variance threshold for large groups
+
+        Returns:
+        --------
+        bool
+            True if the group should be aggregated, False otherwise
+        """
+        # Apply different thresholds based on group size
+        if group_size > large_group_threshold:
+            return weighted_variance <= large_group_variance_threshold
+        else:
+            return weighted_variance <= variance_threshold

--- a/pamola_core/profiling/commons/helpers.py
+++ b/pamola_core/profiling/commons/helpers.py
@@ -12,6 +12,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
+import inspect
 
 import numpy as np
 import pandas as pd
@@ -593,3 +594,14 @@ def save_profiling_results(result: Dict[str, Any],
 
     # Return path as string for compatibility
     return str(file_path)
+
+def filter_used_kwargs(kwargs: dict, func) -> dict:
+    """
+    Remove keys from kwargs that conflict with the named parameters of the given function.
+
+    :param kwargs: A dictionary of keyword arguments to filter.
+    :param func: The target function or method to check against.
+    :return: A filtered kwargs dictionary excluding keys that match the function's parameters.
+    """
+    used_keys = set(inspect.signature(func).parameters)
+    return {k: v for k, v in kwargs.items() if k not in used_keys}

--- a/pamola_core/profiling/commons/identity_utils.py
+++ b/pamola_core/profiling/commons/identity_utils.py
@@ -6,12 +6,16 @@ identifier distribution analysis, consistency checking, and cross-matching.
 These functions are used by the identity analyzer module.
 """
 
+from rapidfuzz import fuzz
 import hashlib
 import logging
 from collections import Counter
+from pathlib import Path
 from typing import Dict, List, Any, Optional
 
 import pandas as pd
+
+from pamola_core.utils.visualization import create_bar_plot, plot_value_distribution
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -34,7 +38,7 @@ def calculate_hash(values: List[Any], algorithm: str = "md5") -> str:
         Calculated hash value
     """
     # Convert all values to strings and concatenate
-    values_str = ''.join([str(v) if v is not None else '' for v in values])
+    values_str = "".join([str(v) if v is not None else "" for v in values])
 
     # Calculate hash using the specified algorithm
     if algorithm.lower() == "md5":
@@ -47,9 +51,9 @@ def calculate_hash(values: List[Any], algorithm: str = "md5") -> str:
         raise ValueError(f"Unsupported hash algorithm: {algorithm}")
 
 
-def compute_identifier_stats(df: pd.DataFrame,
-                             id_field: str,
-                             entity_field: Optional[str] = None) -> Dict[str, Any]:
+def compute_identifier_stats(
+    df: pd.DataFrame, id_field: str, entity_field: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Compute basic statistics about an identifier field.
 
@@ -69,18 +73,22 @@ def compute_identifier_stats(df: pd.DataFrame,
     """
     if id_field not in df.columns:
         return {
-            'error': f"Field {id_field} not found in DataFrame",
-            'total_records': len(df),
-            'unique_identifiers': 0,
-            'null_identifiers': 0,
-            'coverage_percentage': 0
+            "error": f"Field {id_field} not found in DataFrame",
+            "total_records": len(df),
+            "unique_identifiers": 0,
+            "null_identifiers": 0,
+            "coverage_percentage": 0,
         }
 
     # Compute basic statistics
     total_records = len(df)
     null_identifiers = df[id_field].isnull().sum()
     unique_identifiers = df[id_field].nunique()
-    coverage_percentage = 100 * (total_records - null_identifiers) / total_records if total_records > 0 else 0
+    coverage_percentage = (
+        100 * (total_records - null_identifiers) / total_records
+        if total_records > 0
+        else 0
+    )
 
     # Compute relationship statistics if entity_field is provided
     relationship_stats = {}
@@ -99,45 +107,47 @@ def compute_identifier_stats(df: pd.DataFrame,
             one_to_many_count = len(entities_per_id[entities_per_id > 1])
 
             relationship_stats = {
-                'avg_entities_per_id': float(entities_per_id.mean()),
-                'max_entities_per_id': int(entities_per_id.max()),
-                'one_to_one_count': one_to_one_count,
-                'one_to_many_count': one_to_many_count
+                "avg_entities_per_id": float(entities_per_id.mean()),
+                "max_entities_per_id": int(entities_per_id.max()),
+                "one_to_one_count": one_to_one_count,
+                "one_to_many_count": one_to_many_count,
             }
         else:
             relationship_stats = {
-                'avg_entities_per_id': 0,
-                'max_entities_per_id': 0,
-                'one_to_one_count': 0,
-                'one_to_many_count': 0
+                "avg_entities_per_id": 0,
+                "max_entities_per_id": 0,
+                "one_to_one_count": 0,
+                "one_to_many_count": 0,
             }
 
         # Add metrics for the other direction of the relationship
         if not ids_per_entity.empty:
-            relationship_stats.update({
-                'avg_ids_per_entity': float(ids_per_entity.mean()),
-                'max_ids_per_entity': int(ids_per_entity.max())
-            })
+            relationship_stats.update(
+                {
+                    "avg_ids_per_entity": float(ids_per_entity.mean()),
+                    "max_ids_per_entity": int(ids_per_entity.max()),
+                }
+            )
         else:
-            relationship_stats.update({
-                'avg_ids_per_entity': 0,
-                'max_ids_per_entity': 0
-            })
+            relationship_stats.update(
+                {"avg_ids_per_entity": 0, "max_ids_per_entity": 0}
+            )
 
     return {
-        'total_records': total_records,
-        'unique_identifiers': unique_identifiers,
-        'null_identifiers': null_identifiers,
-        'coverage_percentage': coverage_percentage,
-        'uniqueness_ratio': unique_identifiers / total_records if total_records > 0 else 0,
-        **relationship_stats
+        "total_records": total_records,
+        "unique_identifiers": unique_identifiers,
+        "null_identifiers": null_identifiers,
+        "coverage_percentage": coverage_percentage,
+        "uniqueness_ratio": (
+            unique_identifiers / total_records if total_records > 0 else 0
+        ),
+        **relationship_stats,
     }
 
 
-def analyze_identifier_distribution(df: pd.DataFrame,
-                                    id_field: str,
-                                    entity_field: Optional[str] = None,
-                                    top_n: int = 15) -> Dict[str, Any]:
+def analyze_identifier_distribution(
+    df: pd.DataFrame, id_field: str, entity_field: Optional[str] = None, top_n: int = 15
+) -> Dict[str, Any]:
     """
     Analyze the distribution of entities per identifier.
 
@@ -159,13 +169,15 @@ def analyze_identifier_distribution(df: pd.DataFrame,
     """
     if id_field not in df.columns:
         return {
-            'error': f"Field {id_field} not found in DataFrame",
-            'total_records': len(df)
+            "error": f"Field {id_field} not found in DataFrame",
+            "total_records": len(df),
         }
 
     if entity_field and entity_field not in df.columns:
         entity_field = None
-        logger.warning(f"Entity field {entity_field} not found in DataFrame. Using record counts instead.")
+        logger.warning(
+            f"Entity field {entity_field} not found in DataFrame. Using record counts instead."
+        )
 
     # Analyze distribution based on entity field or just count occurrences
     if entity_field:
@@ -185,7 +197,9 @@ def analyze_identifier_distribution(df: pd.DataFrame,
 
     # Create distribution of counts
     distribution = Counter(counts.values)
-    distribution_data = {str(count): freq for count, freq in sorted(distribution.items())}
+    distribution_data = {
+        str(count): freq for count, freq in sorted(distribution.items())
+    }
 
     # Get top examples
     top_examples = []
@@ -194,12 +208,16 @@ def analyze_identifier_distribution(df: pd.DataFrame,
     if not counts.empty:
         # Convert to dictionary, sort by value (count), and get top N
         counts_dict = {str(k): v for k, v in counts.items()}
-        top_ids = sorted(counts_dict.keys(), key=lambda k: counts_dict[k], reverse=True)[:top_n]
+        top_ids = sorted(
+            counts_dict.keys(), key=lambda k: counts_dict[k], reverse=True
+        )[:top_n]
 
         for id_val in top_ids:
             count_val = counts_dict[id_val]
             example_rows = df[df[id_field] == id_val]
-            sample_row = example_rows.iloc[0].to_dict() if not example_rows.empty else {}
+            sample_row = (
+                example_rows.iloc[0].to_dict() if not example_rows.empty else {}
+            )
 
             # If entity_field exists, include list of entities
             entities = []
@@ -207,29 +225,35 @@ def analyze_identifier_distribution(df: pd.DataFrame,
                 entities = example_rows[entity_field].unique().tolist()
 
             # Create example record
-            top_examples.append({
-                'identifier': id_val,
-                'count': int(count_val),
-                'entities': entities,
-                'sample': {k: v for k, v in sample_row.items() if k in [id_field, entity_field]
-                           if k is not None}  # Filter out None keys
-            })
+            top_examples.append(
+                {
+                    "identifier": id_val,
+                    "count": int(count_val),
+                    "entities": entities,
+                    "sample": {
+                        k: v
+                        for k, v in sample_row.items()
+                        if k in [id_field, entity_field]
+                        if k is not None
+                    },  # Filter out None keys
+                }
+            )
 
     return {
-        'total_identifiers': total_ids,
-        'total_records': int(total_records),
-        'max_count': int(max_count),
-        'min_count': int(min_count),
-        'avg_count': float(avg_count),
-        'median_count': float(median_count),
-        'distribution': distribution_data,
-        'top_examples': top_examples
+        "total_identifiers": total_ids,
+        "total_records": int(total_records),
+        "max_count": int(max_count),
+        "min_count": int(min_count),
+        "avg_count": float(avg_count),
+        "median_count": float(median_count),
+        "distribution": distribution_data,
+        "top_examples": top_examples,
     }
 
 
-def analyze_identifier_consistency(df: pd.DataFrame,
-                                   id_field: str,
-                                   reference_fields: List[str]) -> Dict[str, Any]:
+def analyze_identifier_consistency(
+    df: pd.DataFrame, id_field: str, reference_fields: List[str]
+) -> Dict[str, Any]:
     """
     Analyze consistency between an identifier and reference fields.
 
@@ -249,16 +273,18 @@ def analyze_identifier_consistency(df: pd.DataFrame,
     """
     if id_field not in df.columns:
         return {
-            'error': f"Field {id_field} not found in DataFrame",
-            'total_records': len(df)
+            "error": f"Field {id_field} not found in DataFrame",
+            "total_records": len(df),
         }
 
     # Validate reference fields
-    valid_reference_fields = [field for field in reference_fields if field in df.columns]
+    valid_reference_fields = [
+        field for field in reference_fields if field in df.columns
+    ]
     if not valid_reference_fields:
         return {
-            'error': f"None of the reference fields {reference_fields} found in DataFrame",
-            'total_records': len(df)
+            "error": f"None of the reference fields {reference_fields} found in DataFrame",
+            "total_records": len(df),
         }
 
     # Create a copy of the DataFrame with only needed columns
@@ -289,117 +315,593 @@ def analyze_identifier_consistency(df: pd.DataFrame,
 
                 # Create a sample for reporting
                 if isinstance(group_values, tuple):
-                    group_dict = {field: value for field, value in zip(valid_reference_fields, group_values)}
+                    group_dict = {
+                        field: value
+                        for field, value in zip(valid_reference_fields, group_values)
+                    }
                 else:
                     group_dict = {valid_reference_fields[0]: group_values}
 
                 # Add to inconsistent groups
-                inconsistent_groups.append({
-                    'reference_values': group_dict,
-                    'id_values': unique_ids.tolist(),
-                    'count': len(group_df)
-                })
+                inconsistent_groups.append(
+                    {
+                        "reference_values": group_dict,
+                        "id_values": unique_ids.tolist(),
+                        "count": len(group_df),
+                    }
+                )
 
     # Calculate match percentage
-    match_percentage = 100 * (
-                total_combinations - inconsistent_combinations) / total_combinations if total_combinations > 0 else 0
+    match_percentage = (
+        100 * (total_combinations - inconsistent_combinations) / total_combinations
+        if total_combinations > 0
+        else 0
+    )
 
     # Find top mismatch examples
-    top_mismatches = sorted(inconsistent_groups, key=lambda x: x['count'], reverse=True)[:15]
+    top_mismatches = sorted(
+        inconsistent_groups, key=lambda x: x["count"], reverse=True
+    )[:15]
 
     return {
-        'total_records': len(analysis_df),
-        'total_combinations': total_combinations,
-        'consistent_combinations': total_combinations - inconsistent_combinations,
-        'inconsistent_combinations': inconsistent_combinations,
-        'match_percentage': match_percentage,
-        'mismatch_count': inconsistent_combinations,
-        'reference_fields_used': valid_reference_fields,
-        'mismatch_examples': top_mismatches
+        "total_records": len(analysis_df),
+        "total_combinations": total_combinations,
+        "consistent_combinations": total_combinations - inconsistent_combinations,
+        "inconsistent_combinations": inconsistent_combinations,
+        "match_percentage": match_percentage,
+        "mismatch_count": inconsistent_combinations,
+        "reference_fields_used": valid_reference_fields,
+        "mismatch_examples": top_mismatches,
     }
 
 
-def find_cross_matches(df: pd.DataFrame,
-                       id_field: str,
-                       reference_fields: List[str],
-                       min_similarity: float = 0.8,
-                       fuzzy_matching: bool = False) -> Dict[str, Any]:
+def find_cross_matches(
+    df: pd.DataFrame,
+    id_field: str,
+    reference_fields: List[str],
+    min_similarity: float = 0.8,
+    fuzzy_matching: bool = False,
+) -> Dict[str, Any]:
     """
     Find cases where reference fields match but identifiers differ.
+
+    If fuzzy_matching is True, use fuzzy matching based on min_similarity.
+    Otherwise, use exact matching on reference fields.
 
     Parameters:
     -----------
     df : pd.DataFrame
-        DataFrame containing the data
+        Input data frame.
     id_field : str
-        Identifier field to analyze
+        Identifier field name.
     reference_fields : List[str]
-        Fields that define an entity's identity
-    min_similarity : float
-        Minimum similarity for fuzzy matching
-    fuzzy_matching : bool
-        Whether to use fuzzy matching
+        List of fields defining an entity's identity.
+    min_similarity : float, optional
+        Minimum similarity threshold for fuzzy matching (default 0.8).
+    fuzzy_matching : bool, optional
+        Whether to use fuzzy matching (default False).
 
     Returns:
     --------
     Dict[str, Any]
-        Cross-matching analysis results
+        Cross-matching analysis result.
     """
+    if fuzzy_matching:
+        # Use fuzzy matching function
+        return find_cross_matches_fuzzy(df, id_field, reference_fields, min_similarity)
+
+    # Exact matching code
     if id_field not in df.columns:
         return {
-            'error': f"Field {id_field} not found in DataFrame",
-            'total_records': len(df)
+            "error": f"Field {id_field} not found in DataFrame",
+            "total_records": len(df),
         }
 
-    # Validate reference fields
-    valid_reference_fields = [field for field in reference_fields if field in df.columns]
+    valid_reference_fields = [
+        field for field in reference_fields if field in df.columns
+    ]
     if not valid_reference_fields:
         return {
-            'error': f"None of the reference fields {reference_fields} found in DataFrame",
-            'total_records': len(df)
+            "error": f"None of the reference fields {reference_fields} found in DataFrame",
+            "total_records": len(df),
         }
 
-    # Create a copy of the DataFrame with only needed columns
     columns_to_use = [id_field] + valid_reference_fields
     analysis_df = df[columns_to_use].copy()
 
-    # Drop rows where id_field or any reference field is null
+    # Drop rows with nulls in relevant columns
     analysis_df = analysis_df.dropna(subset=[id_field] + valid_reference_fields)
 
-    # Find cases where reference fields match but id_field differs
     cross_matches = []
     total_cross_matches = 0
 
-    # Group by the combination of reference fields
+    # Group by the exact combination of reference fields
     grouped = analysis_df.groupby(valid_reference_fields)
 
-    # Check each group for different id_field values
     for group_values, group_df in grouped:
         unique_ids = group_df[id_field].unique()
-
-        # If more than one unique ID, add to cross matches
         if len(unique_ids) > 1:
             total_cross_matches += 1
 
-            # Create a sample for reporting
             if isinstance(group_values, tuple):
-                group_dict = {field: value for field, value in zip(valid_reference_fields, group_values)}
+                group_dict = {
+                    field: value
+                    for field, value in zip(valid_reference_fields, group_values)
+                }
             else:
                 group_dict = {valid_reference_fields[0]: group_values}
 
-            # Add to cross matches
-            cross_matches.append({
-                'reference_values': group_dict,
-                'id_values': unique_ids.tolist(),
-                'count': len(group_df)
-            })
-
-    # Get top cross matches by count
-    top_cross_matches = sorted(cross_matches, key=lambda x: x['count'], reverse=True)[:15]
+            cross_matches.append(
+                {
+                    "reference_values": group_dict,
+                    "id_values": unique_ids.tolist(),
+                    "count": len(group_df),
+                }
+            )
 
     return {
-        'total_records': len(analysis_df),
-        'total_cross_matches': total_cross_matches,
-        'reference_fields_used': valid_reference_fields,
-        'cross_match_examples': top_cross_matches
+        "total_records": len(analysis_df),
+        "total_cross_matches": total_cross_matches,
+        "reference_fields_used": valid_reference_fields,
+        "cross_match_examples": sorted(
+            cross_matches, key=lambda x: x["count"], reverse=True
+        )[:15],
     }
+
+
+def find_cross_matches_fuzzy(
+    df: pd.DataFrame,
+    id_field: str,
+    reference_fields: List[str],
+    min_similarity: float = 0.8,
+) -> Dict[str, Any]:
+    """
+    Find groups of records where reference fields are similar (using fuzzy matching)
+    but identifiers differ.
+
+    Parameters:
+    -----------
+    df : pd.DataFrame
+        Input data frame.
+    id_field : str
+        Identifier field name.
+    reference_fields : List[str]
+        List of fields to compare for similarity.
+    min_similarity : float
+        Minimum similarity threshold between 0 and 1.
+
+    Returns:
+    --------
+    Dict[str, Any]
+        Cross-matching analysis result.
+    """
+    if id_field not in df.columns:
+        return {"error": f"{id_field} not found", "total_records": len(df)}
+
+    valid_fields = [f for f in reference_fields if f in df.columns]
+    if not valid_fields:
+        return {"error": f"No valid reference fields found", "total_records": len(df)}
+
+    # Keep only relevant columns and drop nulls
+    df_clean = df[[id_field] + valid_fields].dropna()
+
+    matched_indices = set()
+    groups = []
+    rows = df_clean.to_dict(orient="records")
+
+    for i in range(len(rows)):
+        if i in matched_indices:
+            continue
+
+        base_row = rows[i]
+        group = [i]
+        matched_indices.add(i)
+
+        for j in range(i + 1, len(rows)):
+            if j in matched_indices:
+                continue
+
+            compare_row = rows[j]
+            similarity = all(
+                fuzz.ratio(str(base_row[f]), str(compare_row[f])) / 100
+                >= min_similarity
+                for f in valid_fields
+            )
+
+            if similarity:
+                group.append(j)
+                matched_indices.add(j)
+
+        if len(set(df_clean.iloc[group][id_field])) > 1:
+            groups.append(
+                {
+                    "reference_values": {
+                        f: df_clean.iloc[group[0]][f] for f in valid_fields
+                    },
+                    "id_values": df_clean.iloc[group][id_field].unique().tolist(),
+                    "count": len(group),
+                }
+            )
+
+    return {
+        "total_records": len(df_clean),
+        "total_cross_matches": len(groups),
+        "reference_fields_used": valid_fields,
+        "cross_match_examples": groups[:15],
+    }
+
+
+def generate_identifier_statistics_vis(
+    identifier_stats: Dict[str, Any],
+    field_label: str,
+    operation_name: str,
+    task_dir: Path,
+    timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
+    visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Generate bar chart for identifier statistics using create_bar_plot.
+
+    Parameters
+    ----------
+    identifier_stats : Dict[str, Any]
+        The dictionary containing identifier statistics.
+    field_label : str
+        Label used in naming the output visualization file.
+    operation_name : str
+        Name of the operation for tracking or labeling purposes.
+    task_dir : Path
+        Directory path where the output pie chart will be saved.
+    timestamp : str
+        Timestamp string to help uniquely name the output file.
+    theme : Optional[str], optional
+        Visualization theme to use (if any).
+    backend : Optional[str], optional
+        Visualization backend to use (if any).
+    strict : Optional[bool], optional
+        Whether to enforce strict visualization rules.
+    visualization_paths : Optional[Dict[str, Any]], optional
+        Dictionary to store and return paths to visualization outputs. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for the pie chart creation function.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with visualization paths including:
+        - "identifier_stats_bar_chart": Path to the generated bar chart file.
+    """
+    if visualization_paths is None:
+        visualization_paths = {}
+
+    logger.debug(
+        "Generating identifier statistics bar chart for operation '%s' (field_label='%s')",
+        operation_name,
+        field_label,
+    )
+    bar_data = [
+        {"key": "Total Records", "value": identifier_stats["total_records"]},
+        {"key": "Unique Identifiers", "value": identifier_stats["unique_identifiers"]},
+        {"key": "Null Identifiers", "value": identifier_stats["null_identifiers"]},
+    ]
+
+    # Add 1-n relationship if any
+    if (
+        "one_to_one_count" in identifier_stats
+        and "one_to_many_count" in identifier_stats
+    ):
+        bar_data.extend(
+            [
+                {
+                    "key": "1-to-1 Relationships",
+                    "value": identifier_stats["one_to_one_count"],
+                },
+                {
+                    "key": "1-to-N Relationships",
+                    "value": identifier_stats["one_to_many_count"],
+                },
+            ]
+        )
+
+    # Add avg and max ids per entity if any
+    if (
+        "avg_ids_per_entity" in identifier_stats
+        and "max_ids_per_entity" in identifier_stats
+    ):
+        bar_data.extend(
+            [
+                {
+                    "key": "Avg IDs per Entity",
+                    "value": identifier_stats["avg_ids_per_entity"],
+                },
+                {
+                    "key": "Max IDs per Entity",
+                    "value": identifier_stats["max_ids_per_entity"],
+                },
+            ]
+        )
+
+    identifier_stats_path = (
+        task_dir / f"{field_label}_{operation_name}_identifier_stats_{timestamp}.png"
+    )
+
+    bar_chart_result_path = create_bar_plot(
+        data=bar_data,
+        output_path=identifier_stats_path,
+        title=f"Identifier Statistics for '{field_label}'",
+        x_label="Metric",
+        y_label="Value",
+        orientation="v",
+        sort_by="key",
+        showlegend=False,
+        theme=theme,
+        backend=backend,
+        strict=strict,
+        **kwargs,
+    )
+
+    logger.debug("Bar chart saved to: %s", bar_chart_result_path)
+    visualization_paths["identifier_stats_bar_chart"] = bar_chart_result_path
+    return visualization_paths
+
+
+def generate_consistency_analysis_vis(
+    consistency_analysis: Dict[str, Any],
+    field_label: str,
+    operation_name: str,
+    task_dir: Path,
+    timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
+    visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Generate bar chart for consistency analysis using create_bar_plot.
+
+    Parameters
+    ----------
+    consistency_analysis : Dict[str, Any]
+        The dictionary containing consistency analysis results.
+    field_label : str
+        Label used in naming the output visualization file.
+    operation_name : str
+        Name of the operation for tracking or labeling purposes.
+    task_dir : Path
+        Directory path where the output pie chart will be saved.
+    timestamp : str
+        Timestamp string to help uniquely name the output file.
+    theme : Optional[str], optional
+        Visualization theme to use (if any).
+    backend : Optional[str], optional
+        Visualization backend to use (if any).
+    strict : Optional[bool], optional
+        Whether to enforce strict visualization rules.
+    visualization_paths : Optional[Dict[str, Any]], optional
+        Dictionary to store and return paths to visualization outputs. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for the pie chart creation function.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with visualization paths including:
+        - "consistency_analysis_bar_chart": Path to the generated bar chart file.
+    """
+    if visualization_paths is None:
+        visualization_paths = {}
+
+    logger.debug(
+        "Generating consistency analysis bar chart for operation '%s' (field_label='%s')",
+        operation_name,
+        field_label,
+    )
+
+    # Correct format for bar chart
+    match_percentage = consistency_analysis.get("match_percentage", 0)
+    consistency_data = [
+        {"key": "Consistent", "value": match_percentage},
+        {"key": "Inconsistent", "value": 100 - match_percentage},
+    ]
+
+    consistency_stats_path = (
+        task_dir / f"{field_label}_{operation_name}_consistency_stats_{timestamp}.png"
+    )
+
+    consistency_stats_result = create_bar_plot(
+        data=consistency_data,
+        output_path=str(consistency_stats_path),
+        title=f"{field_label} Consistency Analysis",
+        x_label="Consistency",
+        y_label="Percentage",
+        orientation="h",  # Horizontal for proportion clarity
+        theme=theme,
+        backend=backend,
+        strict=strict,
+        **kwargs,
+    )
+
+    logger.debug("Bar chart saved to: %s", consistency_stats_result)
+    visualization_paths["consistency_stats_bar_chart"] = consistency_stats_result
+    return visualization_paths
+
+
+def generate_field_distribution_vis(
+    distribution_analysis: Dict[str, Any],
+    field_label: str,
+    operation_name: str,
+    task_dir: Path,
+    timestamp: str,
+    top_n: int = 15,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
+    visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Generate bar chart for distribution analysis using create_bar_plot.
+
+    Parameters
+    ----------
+    distribution_analysis : Dict[str, Any]
+        The dictionary containing distribution analysis results.
+    field_label : str
+        Label used in naming the output visualization file.
+    operation_name : str
+        Name of the operation for tracking or labeling purposes.
+    task_dir : Path
+        Directory path where the output pie chart will be saved.
+    timestamp : str
+        Timestamp string to help uniquely name the output file.
+    top_n : int, optional
+        Number of top items to include in the visualization (default is 15).
+    theme : Optional[str], optional
+        Visualization theme to use (if any).
+    backend : Optional[str], optional
+        Visualization backend to use (if any).
+    strict : Optional[bool], optional
+        Whether to enforce strict visualization rules.
+    visualization_paths : Optional[Dict[str, Any]], optional
+        Dictionary to store and return paths to visualization outputs. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for the pie chart creation function.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with visualization paths including:
+        - "consistency_analysis_bar_chart": Path to the generated bar chart file.
+    """
+    if visualization_paths is None:
+        visualization_paths = {}
+
+    logger.debug(
+        "Generating field distribution bar chart for operation '%s' (field_label='%s')",
+        operation_name,
+        field_label,
+    )
+
+    # Check if distribution exists
+    distribution = distribution_analysis.get("distribution", {})
+    if not distribution:
+        logger.warning(
+            "No distribution data found for field '%s'. Skipping visualization.",
+            field_label,
+        )
+        return visualization_paths
+
+    # Prepare output path
+    distribution_analysis_path = (
+        task_dir
+        / f"{field_label}_{operation_name}_distribution_analysis_{timestamp}.png"
+    )
+
+    # Create bar chart using helper
+    distribution_stats_result = plot_value_distribution(
+        data=distribution,
+        output_path=str(distribution_analysis_path),
+        title=f"Distribution of '{field_label}' Values",
+        max_items=top_n,
+        theme=theme,
+        backend=backend,
+        strict=strict,
+        **kwargs,
+    )
+
+    logger.debug("Distribution bar chart saved to: %s", distribution_stats_result)
+    visualization_paths["distribution_stats_bar_chart"] = distribution_stats_result
+    return visualization_paths
+
+
+def generate_cross_match_distribution_vis(
+    cross_match_analysis: Dict[str, Any],
+    field_label: str,
+    operation_name: str,
+    task_dir: Path,
+    timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
+    visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Generate bar chart for cross match analysis using create_bar_plot.
+
+    Parameters
+    ----------
+    cross_match_analysis : Dict[str, Any]
+        The dictionary containing cross match analysis results.
+    field_label : str
+        Label used in naming the output visualization file.
+    operation_name : str
+        Name of the operation for tracking or labeling purposes.
+    task_dir : Path
+        Directory path where the output pie chart will be saved.
+    timestamp : str
+        Timestamp string to help uniquely name the output file.
+    top_n : int, optional
+        Number of top items to include in the visualization (default is 15).
+    theme : Optional[str], optional
+        Visualization theme to use (if any).
+    backend : Optional[str], optional
+        Visualization backend to use (if any).
+    strict : Optional[bool], optional
+        Whether to enforce strict visualization rules.
+    visualization_paths : Optional[Dict[str, Any]], optional
+        Dictionary to store and return paths to visualization outputs. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for the pie chart creation function.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with visualization paths including:
+        - "consistency_analysis_bar_chart": Path to the generated bar chart file.
+    """
+    if visualization_paths is None:
+        visualization_paths = {}
+
+    logger.debug(
+        "Generating cross match bar chart for operation '%s' (field_label='%s')",
+        operation_name,
+        field_label,
+    )
+
+    cross_match_examples = cross_match_analysis.get("cross_match_examples", [])
+
+    if not cross_match_examples:
+        logger.warning("No cross match examples found for visualization.")
+        return visualization_paths
+
+    # Tạo dict dữ liệu: {'label': count}
+    cross_match_data = {}
+    for example in cross_match_examples:
+        ref_vals = example.get("reference_values", {})
+        label = ", ".join(f"{k}={v}" for k, v in ref_vals.items())  # readable label
+        cross_match_data[label] = example.get("count", 0)
+
+    cross_match_path = (
+        task_dir / f"{field_label}_{operation_name}_cross_match_bar_{timestamp}.png"
+    )
+
+    cross_match_chart_path = create_bar_plot(
+        data=cross_match_data,
+        output_path=str(cross_match_path),
+        title=f"Top Cross Match Examples by '{field_label}'",
+        orientation="v",
+        theme=theme,
+        backend=backend,
+        strict=strict,
+        **kwargs,
+    )
+
+    logger.debug("Cross match bar chart saved to: %s", cross_match_chart_path)
+    visualization_paths["cross_match_bar_chart"] = cross_match_chart_path
+    return visualization_paths

--- a/pamola_core/profiling__old_15_04/detect/detect_profiling.py
+++ b/pamola_core/profiling__old_15_04/detect/detect_profiling.py
@@ -24,44 +24,173 @@ Author: Realm Inveo Inc. & DGT Network Inc.
 """
 
 import re
-from typing import List, Tuple
+import gc
+import time
+from typing import List, Tuple, Dict, Any
 import pandas as pd
+import dask.dataframe as dd
+from joblib import Parallel, delayed
 from abc import ABC
+import logging
+import psutil
+import math
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from pamola_core.common.regex.patterns import Patterns
 from pamola_core.profiling__old_15_04.base import BaseProfilingProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class SystemResourceMonitor:
+    """Monitor and manage system resources for optimal processing."""
+
+    def __init__(self):
+        self.total_memory = psutil.virtual_memory().total
+        self.cpu_count = psutil.cpu_count(logical=True)
+        self.available_memory = psutil.virtual_memory().available
+
+    def get_optimal_settings(self, data_size: int, num_columns: int) -> Dict[str, Any]:
+        """
+        Determine optimal processing settings based on system capacity and data characteristics.
+
+        Args:
+            data_size: Size of dataset in bytes
+            num_columns: Number of columns in dataset
+
+        Returns:
+            Dict containing optimal processing settings
+        """
+        # Get current system status
+        memory_info = psutil.virtual_memory()
+        cpu_info = psutil.cpu_percent(interval=1)
+
+        # Calculate available resources
+        available_memory = memory_info.available
+        memory_usage_percent = memory_info.percent
+
+        # Determine processing strategy based on data size and system capacity
+        memory_ratio = data_size / available_memory
+
+        # Small dataset: Use joblib with threading
+        if data_size < 100 * 1024 * 1024:  # < 100MB
+            return {
+                "strategy": "joblib_threading",
+                "n_jobs": min(self.cpu_count, num_columns, 4),
+                "backend": "threading",
+                "chunk_size": None,
+                "use_dask": False,
+            }
+
+        # Medium dataset: Use joblib with processes or Dask based on memory
+        elif data_size < 500 * 1024 * 1024:  # < 500MB
+            if memory_usage_percent < 70:  # System has enough memory
+                return {
+                    "strategy": "joblib_processes",
+                    "n_jobs": min(self.cpu_count // 2, num_columns, 4),
+                    "backend": "multiprocessing",
+                    "chunk_size": None,
+                    "use_dask": False,
+                }
+            else:  # Memory constrained, use Dask
+                return {
+                    "strategy": "dask_local",
+                    "n_jobs": min(self.cpu_count // 2, 4),
+                    "backend": None,
+                    "chunk_size": 64 * 1024 * 1024,  # 64MB chunks
+                    "use_dask": True,
+                    "n_partitions": max(
+                        2, min(8, math.ceil(data_size / (64 * 1024 * 1024)))
+                    ),
+                }
+
+        # Large dataset: Use Dask with optimized settings
+        else:  # >= 500MB
+            # Check if Dask is available and working
+            try:
+                import dask.dataframe as dd_test
+
+                # Test basic Dask functionality
+                test_df = pd.DataFrame({"test": [1, 2, 3]})
+                test_ddf = dd_test.from_pandas(test_df, npartitions=1)
+                _ = test_ddf.sum().compute()
+                dask_available = True
+            except Exception as e:
+                logger.warning(f"Dask not available or not working: {str(e)}")
+                dask_available = False
+
+            if dask_available:
+                # Calculate optimal chunk size based on available memory
+                optimal_chunk_size = min(
+                    available_memory // 8,  # Use 1/8 of available memory per chunk
+                    128 * 1024 * 1024,  # Max 128MB per chunk
+                )
+
+                n_partitions = max(
+                    4, min(16, math.ceil(data_size / optimal_chunk_size))
+                )
+
+                return {
+                    "strategy": "dask_optimized",
+                    "n_jobs": min(self.cpu_count, 6),  # Cap at 6 workers for stability
+                    "backend": None,
+                    "chunk_size": optimal_chunk_size,
+                    "use_dask": True,
+                    "n_partitions": n_partitions,
+                    "scheduler": (
+                        "threads" if memory_usage_percent < 60 else "synchronous"
+                    ),
+                }
+            else:
+                # Fallback to joblib with processes for large datasets
+                return {
+                    "strategy": "joblib_processes_large",
+                    "n_jobs": min(self.cpu_count // 2, 4),
+                    "backend": "multiprocessing",
+                    "chunk_size": None,
+                    "use_dask": False,
+                }
 
 
 class DetectProfilingProcessor(BaseProfilingProcessor, ABC):
     """
     Processor for detecting direct identifiers, quasi-identifiers, sensitive attributes,
     indirect identifiers, and non-sensitive attributes in datasets.
-
-    Attributes:
-        unique_threshold (float): Threshold to classify columns as direct identifiers.
-        sensitive_keywords (List[str]): Keywords used to identify sensitive attributes.
-        indirect_keywords (List[str]): Keywords used to identify indirect identifiers.
+    Auto-manages Dask and Joblib based on system capacity.
     """
+
+    # Category constants
+    CATEGORY_DIRECT = "direct"
+    CATEGORY_QUASI = "quasi"
+    CATEGORY_SENSITIVE = "sensitive"
+    CATEGORY_INDIRECT = "indirect"
+    CATEGORY_NON_SENSITIVE = "non_sensitive"
+    CATEGORY_ERROR = "error"
 
     def __init__(
         self,
         unique_threshold: float = 0.9,
-        sample_size: int = 100,
+        sample_size: int = 1000,
         sensitive_keywords: List[str] = None,
         indirect_keywords: List[str] = None,
+        timeout_seconds: int = 300,
     ):
         """
-        Initializes DetectProfilingProcessor.
+        Initialize DetectProfilingProcessor with auto-resource management.
 
         Args:
-            unique_threshold (float): Threshold for direct identifier detection. Default is 0.9.
-            sample_size (int, optional): Number of samples for pattern matching. Default is 100.
-            sensitive_keywords (List[str], optional): Keywords to identify sensitive attributes.
-            indirect_keywords (List[str], optional): Keywords to identify indirect identifiers.
+            unique_threshold (float): Threshold for direct identifier detection.
+            sample_size (int): Number of samples for pattern matching.
+            sensitive_keywords (List[str], optional): Keywords for sensitive attributes.
+            indirect_keywords (List[str], optional): Keywords for indirect identifiers.
+            timeout_seconds (int): Processing timeout in seconds.
         """
-        super().__init__() 
+        super().__init__()
         self.unique_threshold = unique_threshold
         self.sample_size = sample_size
+        self.timeout_seconds = timeout_seconds
+        self.resource_monitor = SystemResourceMonitor()
+
         self.sensitive_keywords = sensitive_keywords or [
             "disease",
             "income",
@@ -91,100 +220,515 @@ class DetectProfilingProcessor(BaseProfilingProcessor, ABC):
             "company",
         ]
 
+    def _process_column(
+        self,
+        series_data,
+        col: str,
+        patterns: dict,
+        unique_threshold: float,
+        sample_size: int,
+        sensitive_keywords: List[str],
+        indirect_keywords: List[str],
+        is_dask: bool = False,
+    ) -> Tuple:
+        """
+        Process a single column to determine its attribute type.
+        Works with both pandas Series and Dask Series.
+
+        Parameters:
+            series_data (pd.Series or dask.Series): The column data to analyze.
+            col (str): The name of the column.
+            patterns (dict): Dictionary of regex patterns used to detect sensitive formats (e.g., emails, SSNs).
+            unique_threshold (float): Threshold above which a column is considered a direct identifier.
+            sample_size (int): Number of values to sample from object columns for pattern matching.
+            sensitive_keywords (List[str]): Keywords indicating highly sensitive attributes (e.g., 'name', 'email').
+            indirect_keywords (List[str]): Keywords indicating indirect identifiers (e.g., 'zipcode', 'region').
+            is_dask (bool): Whether the column is a Dask Series (True) or pandas Series (False).
+
+        Returns:
+            Tuple[str, str]: A tuple containing the column name and the inferred category:
+                - CATEGORY_SENSITIVE
+                - CATEGORY_DIRECT
+                - CATEGORY_INDIRECT
+                - CATEGORY_QUASI
+                - CATEGORY_NON_SENSITIVE
+                - CATEGORY_ERROR (in case of failure)
+        """
+        try:
+            col_lower = col.lower()
+
+            # 1. Check sensitive attributes first (no computation needed)
+            if any(keyword in col_lower for keyword in sensitive_keywords):
+                return col, self.CATEGORY_SENSITIVE
+
+            # 4. Check indirect identifiers (no computation needed)
+            if any(keyword in col_lower for keyword in indirect_keywords):
+                return col, self.CATEGORY_INDIRECT
+
+            # Handle Dask vs Pandas operations
+            if is_dask:
+                # For Dask series - compute operations carefully
+                try:
+                    # Calculate all required values ​​in one go
+                    computed_series = series_data.compute()
+                    unique_values = computed_series.nunique()
+                    row_count = len(computed_series)
+                    series_dtype = computed_series.dtype
+
+                    # Sample data for object dtype
+                    if pd.api.types.is_object_dtype(series_dtype):
+                        # Get non-null values first
+                        non_null_series = computed_series.dropna().astype(str)
+                        series_length = len(non_null_series)
+
+                        if series_length > 0:
+                            # Calculate sample size
+                            actual_sample_size = min(sample_size, series_length)
+                            # Sample from Dask series
+                            if actual_sample_size < series_length:
+                                sample_data = non_null_series.sample(
+                                    n=actual_sample_size, random_state=42
+                                )
+                            else:
+                                sample_data = non_null_series
+                        else:
+                            sample_data = pd.Series([], dtype=str)
+                    else:
+                        sample_data = pd.Series([], dtype=str)
+                except Exception as e:
+                    logger.warning(f"Dask computation error for column {col}: {str(e)}")
+                    # Fallback to basic analysis
+                    unique_values = 0
+                    row_count = 1
+                    sample_data = pd.Series([], dtype=str)
+            else:
+                # For pandas series
+                unique_values = series_data.nunique(dropna=True)
+                row_count = len(series_data)
+                series_dtype = series_data.dtype
+
+                # Sample data for pattern checking
+                if pd.api.types.is_object_dtype(series_dtype):
+                    non_null_values = series_data.dropna().astype(str)
+                    sample_data = (
+                        non_null_values.sample(
+                            min(sample_size, len(non_null_values)), random_state=42
+                        )
+                        if len(non_null_values) > 0
+                        else pd.Series([], dtype=str)
+                    )
+                else:
+                    sample_data = pd.Series([], dtype=str)
+
+            # Calculate cardinality ratio
+            cardinality_ratio = unique_values / row_count if row_count > 0 else 0
+
+            # 2. Check direct identifiers by cardinality
+            if cardinality_ratio > unique_threshold:
+                return col, self.CATEGORY_DIRECT
+
+            # 3. Check patterns for object dtype columns
+            if pd.api.types.is_object_dtype(series_dtype) and len(sample_data) > 0:
+                for pattern in patterns.values():
+                    if sample_data.str.contains(pattern, regex=True, na=False).any():
+                        return col, self.CATEGORY_DIRECT
+
+            # 5. Check quasi-identifiers
+            if 0.1 < cardinality_ratio < unique_threshold:
+                return col, self.CATEGORY_QUASI
+
+            # 6. Default to non-sensitive
+            return col, self.CATEGORY_NON_SENSITIVE
+
+        except Exception as e:
+            logger.error(f"Error processing column {col}: {str(e)}")
+            return col, self.CATEGORY_ERROR
+
+    def _process_with_joblib(
+        self,
+        df: pd.DataFrame,
+        settings: dict,
+        patterns: dict,
+        unique_threshold: float,
+        sample_size: int,
+        sensitive_keywords: List[str],
+        indirect_keywords: List[str],
+    ) -> List[Tuple[str, str]]:
+        """
+        Process dataset using Joblib parallel processing.
+
+        Parameters:
+            df (pd.DataFrame): The input pandas DataFrame to be analyzed.
+            settings (dict): Configuration for Joblib processing, including:
+                - 'strategy' (str): Label indicating the strategy being used (for logging/debugging).
+                - 'n_jobs' (int): Number of parallel workers to use.
+                - 'backend' (str): Backend for Joblib ('threading' or 'loky').
+            patterns (dict): Dictionary of regex patterns used to match known sensitive data formats.
+            unique_threshold (float): Threshold ratio above which a column is considered a direct identifier.
+            sample_size (int): Number of sample values to evaluate patterns in object columns.
+            sensitive_keywords (List[str]): List of keywords that, if found in column names, classify them as sensitive.
+            indirect_keywords (List[str]): List of keywords that, if found in column names, classify them as indirect identifiers.
+
+        Returns:
+            List[Tuple[str, str]]: A list of tuples with column names and their inferred data sensitivity category.
+                                Possible categories: 'sensitive', 'direct', 'indirect',
+                                'quasi', 'non-sensitive', or 'error'.
+        """
+        logger.info(
+            f"Processing with joblib: {settings['strategy']}, n_jobs={settings['n_jobs']}"
+        )
+
+        try:
+            results = Parallel(
+                n_jobs=settings["n_jobs"],
+                backend=settings["backend"],
+                timeout=self.timeout_seconds,
+            )(
+                delayed(self._process_column)(
+                    df[col],
+                    col,
+                    patterns,
+                    unique_threshold,
+                    sample_size,
+                    sensitive_keywords,
+                    indirect_keywords,
+                    False,
+                )
+                for col in df.columns
+            )
+            return results
+        except Exception as e:
+            logger.error(f"Joblib processing failed: {str(e)}")
+            raise
+
+    def _process_with_dask(
+        self,
+        df: pd.DataFrame,
+        settings: dict,
+        patterns: dict,
+        unique_threshold: float,
+        sample_size: int,
+        sensitive_keywords: List[str],
+        indirect_keywords: List[str],
+    ) -> List[Tuple[str, str]]:
+        """
+        Process dataset using Dask local processing.
+
+        Parameters:
+            df (pd.DataFrame): The input pandas DataFrame to be processed.
+            settings (dict): Configuration settings for Dask, including:
+                - 'strategy' (str): A label for the processing strategy used (for logging/debugging).
+                - 'n_partitions' (int): Number of partitions to split the DataFrame into.
+                - 'scheduler' (str, optional): Dask scheduler to use ('threads', 'processes', or 'synchronous').
+            patterns (dict): Dictionary of regex patterns to identify specific data types (e.g., emails, phone numbers).
+            unique_threshold (float): Ratio threshold for determining direct identifiers.
+            sample_size (int): Number of samples to use when testing patterns in text columns.
+            sensitive_keywords (List[str]): Keywords to match against column names for detecting sensitive attributes.
+            indirect_keywords (List[str]): Keywords to match against column names for detecting indirect identifiers.
+
+        Returns:
+            List[Tuple[str, str]]: A list of (column_name, category) tuples, where category is one of:
+                'sensitive', 'direct', 'indirect', 'quasi', 'non-sensitive', or 'error'.
+        """
+        logger.info(
+            f"Processing with Dask: {settings['strategy']}, partitions={settings['n_partitions']}"
+        )
+
+        try:
+            # Convert to Dask DataFrame
+            ddf = dd.from_pandas(df, npartitions=settings["n_partitions"])
+
+            # Use appropriate scheduler
+            scheduler = settings.get("scheduler", "threads")
+
+            # Process columns using simple Dask operations
+            results = []
+
+            # Set scheduler context
+            if scheduler == "synchronous":
+                import dask
+
+                with dask.config.set(scheduler="synchronous"):
+                    for col in df.columns:
+                        try:
+                            computed_result = self._process_column(
+                                ddf[col],
+                                col,
+                                patterns,
+                                unique_threshold,
+                                sample_size,
+                                sensitive_keywords,
+                                indirect_keywords,
+                                True,
+                            )
+                            results.append(computed_result)
+                        except Exception as e:
+                            logger.error(
+                                f"Error processing column {col} with Dask: {str(e)}"
+                            )
+                            results.append((col, self.CATEGORY_ERROR))
+            else:
+                # Use threads scheduler (default)
+                for col in df.columns:
+                    try:
+                        computed_result = self._process_column(
+                            ddf[col],
+                            col,
+                            patterns,
+                            unique_threshold,
+                            sample_size,
+                            sensitive_keywords,
+                            indirect_keywords,
+                            True,
+                        )
+                        results.append(computed_result)
+                    except Exception as e:
+                        logger.error(
+                            f"Error processing column {col} with Dask: {str(e)}"
+                        )
+                        results.append((col, self.CATEGORY_ERROR))
+
+            return results
+
+        except Exception as e:
+            logger.error(f"Dask processing failed: {str(e)}")
+            # Fallback to joblib if Dask fails
+            logger.info("Falling back to joblib processing")
+            fallback_settings = {"n_jobs": 2, "backend": "threading"}
+            return self._process_with_joblib(
+                df,
+                fallback_settings,
+                patterns,
+                unique_threshold,
+                sample_size,
+                sensitive_keywords,
+                indirect_keywords,
+            )
+        finally:
+            # Force cleanup
+            gc.collect()
+
+    def _process_with_threading(
+        self,
+        df: pd.DataFrame,
+        settings: dict,
+        patterns: dict,
+        unique_threshold: float,
+        sample_size: int,
+        sensitive_keywords: List[str],
+        indirect_keywords: List[str],
+    ) -> List[Tuple[str, str]]:
+        """
+        Process dataset using ThreadPoolExecutor for fine-grained control.
+
+        Parameters:
+            df (pd.DataFrame): The input pandas DataFrame to process.
+            settings (dict): Configuration settings containing the number of worker threads (expects 'n_jobs' key).
+            patterns (dict): Dictionary of regex patterns used to detect specific data types (e.g., email, phone).
+            unique_threshold (float): Threshold (0 to 1) above which a column is considered a direct identifier.
+            sample_size (int): Number of values to sample from the column for pattern matching.
+            sensitive_keywords (List[str]): List of keywords that identify sensitive fields based on column names.
+            indirect_keywords (List[str]): List of keywords that identify indirect identifiers based on column names.
+
+        Returns:
+            List[Tuple[str, str]]: A list of tuples where each tuple contains:
+                - str: The column name.
+                - str: The detected category (e.g., 'sensitive', 'direct', 'indirect', 'quasi', 'non-sensitive', or 'error').
+        """
+        logger.info(
+            f"Processing with ThreadPoolExecutor: n_workers={settings['n_jobs']}"
+        )
+
+        results = []
+        with ThreadPoolExecutor(max_workers=settings["n_jobs"]) as executor:
+            # Submit all column processing tasks
+            future_to_col = {
+                executor.submit(
+                    self._process_column,
+                    df[col],
+                    col,
+                    patterns,
+                    unique_threshold,
+                    sample_size,
+                    sensitive_keywords,
+                    indirect_keywords,
+                    False,
+                ): col
+                for col in df.columns
+            }
+
+            # Collect results with timeout
+            for future in as_completed(future_to_col, timeout=self.timeout_seconds):
+                try:
+                    result = future.result(timeout=30)  # 30s per column
+                    results.append(result)
+                except Exception as e:
+                    col = future_to_col[future]
+                    logger.error(f"Error processing column {col}: {str(e)}")
+                    results.append((col, self.CATEGORY_ERROR))
+
+        return results
+
     def execute(
         self,
         df: pd.DataFrame,
         **kwargs,
     ) -> Tuple[List[str], List[str], List[str], List[str], List[str]]:
         """
-        Detects direct identifiers, quasi-identifiers, sensitive attributes, indirect identifiers, and non-sensitive attributes.
+        Detects attributes using auto-managed Dask/Joblib based on system capacity.
 
         Parameters:
             df (pd.DataFrame): The dataset to analyze.
 
         Kwargs:
-            unique_threshold (float, optional): Threshold for identifying direct identifiers. Defaults to self.unique_threshold.
-            sensitive_keywords (List[str], optional): Keywords to detect sensitive attributes. Defaults to self.sensitive_keywords.
-            indirect_keywords (List[str], optional): Keywords to detect indirect identifiers. Defaults to self.indirect_keywords.
-            sample_size (int, optional): Number of samples for pattern matching. Defaults to self.sample_size.
+            unique_threshold (float, optional): Threshold for identifying direct identifiers.
+            sensitive_keywords (List[str], optional): Keywords to detect sensitive attributes.
+            indirect_keywords (List[str], optional): Keywords to detect indirect identifiers.
+            sample_size (int, optional): Number of samples for pattern matching.
 
         Returns:
             Tuple[List[str], List[str], List[str], List[str], List[str]]: Lists of
-            direct identifiers, quasi-identifiers, sensitive attributes, indirect identifiers, and non-sensitive attributes.
+            direct identifiers, quasi-identifiers, sensitive attributes, indirect identifiers,
+            and non-sensitive attributes.
         """
-        unique_threshold = kwargs.get("unique_threshold", self.unique_threshold)
-        sensitive_keywords = kwargs.get("sensitive_keywords", self.sensitive_keywords)
-        indirect_keywords = kwargs.get("indirect_keywords", self.indirect_keywords)
-        sample_size = kwargs.get("sample_size", self.sample_size)
+        start_time = time.time()
 
-        direct_identifiers, quasi_identifiers, sensitive_attributes = [], [], []
-        indirect_identifiers, non_sensitive_attributes = [], []
+        try:
+            # Get parameters from kwargs or defaults
+            unique_threshold = kwargs.get("unique_threshold", self.unique_threshold)
+            sensitive_keywords = kwargs.get(
+                "sensitive_keywords", self.sensitive_keywords
+            )
+            indirect_keywords = kwargs.get("indirect_keywords", self.indirect_keywords)
+            sample_size = kwargs.get("sample_size", self.sample_size)
 
-        # Regex patterns for common identifiers
-        patterns = {
-            "email": re.compile(Patterns.EMAIL_REGEX),
-            "phone": re.compile(Patterns.PHONE_REGEX),
-            "credit_card": re.compile(Patterns.CREDIT_CARD),
-        }
+            if len(df) == 0:
+                return [], [], [], [], []
 
-        row_count = len(df)
+            # Analyze dataset characteristics
+            data_size = df.memory_usage(deep=True).sum()
+            num_columns = len(df.columns)
+            num_rows = len(df)
 
-        if row_count == 0:
-            return (
-                direct_identifiers,
-                quasi_identifiers,
-                sensitive_attributes,
-                indirect_identifiers,
-                non_sensitive_attributes,
+            logger.info(
+                f"Dataset: {num_rows:,} rows, {num_columns} columns, "
+                f"{data_size / (1024**2):.1f} MB"
             )
 
-        for col in df.columns:
-            unique_values = df[col].nunique(dropna=True)
-            cardinality_ratio = unique_values / row_count
-            col_lower = col.lower()
+            # Get optimal processing settings based on system capacity
+            settings = self.resource_monitor.get_optimal_settings(
+                data_size, num_columns
+            )
+            logger.info(f"Selected strategy: {settings['strategy']}")
 
-            # 1. Detect **Sensitive Attributes**
-            if any(keyword in col_lower for keyword in sensitive_keywords):
-                sensitive_attributes.append(col)
-                continue
+            # Compile regex patterns once
+            patterns = {
+                "email": re.compile(Patterns.EMAIL_REGEX),
+                "phone": re.compile(Patterns.PHONE_REGEX),
+                "credit_card": re.compile(Patterns.CREDIT_CARD),
+            }
 
-            # 2. Detect **Direct Identifiers**
-            if cardinality_ratio > unique_threshold:
-                direct_identifiers.append(col)
-                continue
+            # Process based on selected strategy
+            try:
+                # Log settings
+                logger.info("Settings used for processing:")
+                for key, value in settings.items():
+                    logger.info("  - %s: %s", key, value)
 
-            # Object-type columns: Check regex patterns for direct identifiers
-            if pd.api.types.is_object_dtype(df[col].dtype):
-                non_null_values = df[col].dropna().astype(str)
-                if len(non_null_values) > 0:
-                    sample_data = non_null_values.sample(
-                        min(sample_size, len(non_null_values)), random_state=42
+                if settings["strategy"] == "joblib_threading":
+                    results = self._process_with_joblib(
+                        df,
+                        settings,
+                        patterns,
+                        unique_threshold,
+                        sample_size,
+                        sensitive_keywords,
+                        indirect_keywords,
                     )
+                elif settings["strategy"] in [
+                    "joblib_processes",
+                    "joblib_processes_large",
+                ]:
+                    results = self._process_with_joblib(
+                        df,
+                        settings,
+                        patterns,
+                        unique_threshold,
+                        sample_size,
+                        sensitive_keywords,
+                        indirect_keywords,
+                    )
+                elif settings["use_dask"]:
+                    results = self._process_with_dask(
+                        df,
+                        settings,
+                        patterns,
+                        unique_threshold,
+                        sample_size,
+                        sensitive_keywords,
+                        indirect_keywords,
+                    )
+                else:
+                    # Fallback to threading
+                    results = self._process_with_threading(
+                        df,
+                        settings,
+                        patterns,
+                        unique_threshold,
+                        sample_size,
+                        sensitive_keywords,
+                        indirect_keywords,
+                    )
+            except Exception as processing_error:
+                logger.error(
+                    f"Primary processing strategy failed: {str(processing_error)}"
+                )
+                logger.info("Falling back to simple threading approach")
 
-                    if any(
-                        sample_data.str.contains(pattern, regex=True).any()
-                        for pattern in patterns.values()
-                    ):
-                        direct_identifiers.append(col)
-                        continue
+                # Ultimate fallback - simple threading
+                fallback_settings = {
+                    "strategy": "fallback_threading",
+                    "n_jobs": min(4, num_columns),
+                    "backend": "threading",
+                }
+                results = self._process_with_threading(
+                    df,
+                    fallback_settings,
+                    patterns,
+                    unique_threshold,
+                    sample_size,
+                    sensitive_keywords,
+                    indirect_keywords,
+                )
 
-            # 3. Detect **Indirect Identifiers**
-            if any(keyword in col_lower for keyword in indirect_keywords):
-                indirect_identifiers.append(col)
-                continue
+            # Initialize category lists
+            category_lists = {
+                self.CATEGORY_DIRECT: [],
+                self.CATEGORY_QUASI: [],
+                self.CATEGORY_SENSITIVE: [],
+                self.CATEGORY_INDIRECT: [],
+                self.CATEGORY_NON_SENSITIVE: [],
+            }
 
-            # 4. Detect **Quasi-Identifiers**
-            if 0.1 < cardinality_ratio < unique_threshold:
-                quasi_identifiers.append(col)
-                continue
+            # Organize results
+            for col, category in results:
+                if category in category_lists:
+                    category_lists[category].append(col)
+                else:
+                    logger.warning(f"Column {col} had processing errors")
 
-            # 5. Everything else → **Non-Sensitive Attributes**
-            non_sensitive_attributes.append(col)
+            processing_time = time.time() - start_time
+            logger.info(f"Processing completed in {processing_time:.2f} seconds")
 
-        return (
-            direct_identifiers,
-            quasi_identifiers,
-            sensitive_attributes,
-            indirect_identifiers,
-            non_sensitive_attributes,
-        )
+            return (
+                category_lists[self.CATEGORY_DIRECT],
+                category_lists[self.CATEGORY_QUASI],
+                category_lists[self.CATEGORY_SENSITIVE],
+                category_lists[self.CATEGORY_INDIRECT],
+                category_lists[self.CATEGORY_NON_SENSITIVE],
+            )
+
+        except Exception as e:
+            logger.error(f"Error in execute method: {str(e)}")
+            gc.collect()  # Force cleanup on error
+            raise

--- a/pamola_core/transformations/cleaning/clean_invalid_values.py
+++ b/pamola_core/transformations/cleaning/clean_invalid_values.py
@@ -41,13 +41,14 @@ from pandas.api.types import (
 
 from pamola_core.utils.ops.op_config import OperationConfig
 from pamola_core.utils.ops.op_data_source import DataSource
-from pamola_core.utils.ops.op_data_writer import DataWriter
+from pamola_core.utils.ops.op_data_writer import DataWriter, WriterResult
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
 from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.common.constants import Constants
 from pamola_core.utils.io import load_data_operation, load_settings_operation
 from pamola_core.transformations.base_transformation_op import TransformationOperation
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 # Configure module logger
 logger = logging.getLogger(__name__)
@@ -62,25 +63,23 @@ class CleanInvalidValuesConfig(OperationConfig):
             "whitelist_path": {"type": ["object", "null"]},
             "blacklist_path": {"type": ["object", "null"]},
             "null_replacement": {"type": ["string", "object", "null"]},
-
             "output_format": {"type": "string", "enum": ["csv", "json", "parquet"]},
-
-            "name": {"type": "string"},
-            "description": {"type": "string"},
-
-            "field_name": {"type": "string"},
+            "name": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "field_name": {"type": ["string", "null"]},
             "mode": {"type": "string", "enum": ["REPLACE", "ENRICH"]},
             "output_field_name": {"type": ["string", "null"]},
             "column_prefix": {"type": "string"},
-
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {"type": ["string", "null"], "enum": ["plotly", "matplotlib", None]},
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
             "chunk_size": {"type": "integer"},
             "use_dask": {"type": "boolean"},
             "npartitions": {"type": "integer"},
-            "meta": {"type": ["object", "null"]},
             "use_vectorization": {"type": "boolean"},
             "parallel_processes": {"type": "integer"},
-
-            "batch_size": {"type": "integer", "minimum": 1},
             "use_cache": {"type": "boolean"},
             "use_encryption": {"type": "boolean"},
             "encryption_key": {"type": ["string", "null"]}
@@ -99,28 +98,26 @@ class CleanInvalidValuesOperation(TransformationOperation):
             whitelist_path: Optional[Dict[str, Path]] = None,
             blacklist_path: Optional[Dict[str, Path]] = None,
             null_replacement: Optional[Union[str, Dict[str, Any]]] = None,
-
             output_format: str = "csv",
-
             name: str = "clean_invalid_values_operation",
             description: str = "Clean values violating constraints",
-
             field_name: str = "",
             mode: str = "REPLACE",
             output_field_name: Optional[str] = None,
             column_prefix: str = "_",
-
+            visualization_theme: Optional[str] = None,
+            visualization_backend: Optional[str] = None,
+            visualization_strict: bool = False,
+            visualization_timeout: int = 120,
             chunk_size: int = 10000,
             use_dask: bool = False,
             npartitions: int = 2,
-            meta: Optional[Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple]] = None,
             use_vectorization: bool = False,
             parallel_processes: int = 2,
-
-            batch_size: int = 10000,
             use_cache: bool = True,
             use_encryption: bool = False,
-            encryption_key: Optional[Union[str, Path]] = None
+            encryption_key: Optional[Union[str, Path]] = None,
+            encryption_mode: Optional[str] = None,
     ):
         """
         Initialize operation.
@@ -135,15 +132,12 @@ class CleanInvalidValuesOperation(TransformationOperation):
             Blacklist
         null_replacement : str or dict, optional
             null replacement
-
         output_format : str
             Output format: "csv" or "json" or "parquet" (default: "csv")
-
         name : str
             Name of the operation (default: "clean_invalid_values_operation")
         description : str
             Operation description (default: "Clean values violating constraints")
-
         field_name : str
             Field name to transform (default: "")
         mode : str
@@ -152,22 +146,24 @@ class CleanInvalidValuesOperation(TransformationOperation):
             Name for the output field if mode is "ENRICH" (default: None)
         column_prefix : str, optional
             Prefix for new column if mode is "ENRICH" (default: "_")
-
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
         chunk_size : int, optional
             Number of rows to process in each chunk (default: 10000).
         use_dask : bool, optional
             Whether to use Dask for processing (default: False).
         npartitions : int, optional
             Number of partitions use with Dask (default: 1).
-        meta : Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple], optional
-            Meta of output use with Dask.
         use_vectorization : bool, optional
             Whether to use vectorized (parallel) processing (default: False).
         parallel_processes : int, optional
             Number of processes use with vectorized (parallel) (default: 1).
-
-        batch_size : int
-            Batch size for processing large datasets (default: 10000)
         use_cache : bool
             Whether to use operation caching (default: True)
         use_encryption : bool
@@ -181,25 +177,22 @@ class CleanInvalidValuesOperation(TransformationOperation):
             whitelist_path=whitelist_path,
             blacklist_path=blacklist_path,
             null_replacement=null_replacement,
-
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
+            visualization_theme=visualization_theme,
+            visualization_backend=visualization_backend,
+            visualization_strict=visualization_strict,
+            visualization_timeout=visualization_timeout,
             chunk_size=chunk_size,
             use_dask=use_dask,
             npartitions=npartitions,
-            meta=meta,
             use_vectorization=use_vectorization,
             parallel_processes=parallel_processes,
-
-            batch_size=batch_size,
             use_cache=use_cache,
             use_encryption=use_encryption,
             encryption_key=encryption_key
@@ -208,26 +201,27 @@ class CleanInvalidValuesOperation(TransformationOperation):
         # Initialize base class
         super().__init__(
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
-            batch_size=batch_size,
+            chunk_size=chunk_size,
             use_cache=use_cache,
             use_dask=use_dask,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
         )
 
+        self.visualization_theme = config.get("visualization_theme")
+        self.visualization_backend = config.get("visualization_backend")
+        self.visualization_strict = config.get("visualization_strict")
+        self.visualization_timeout = config.get("visualization_timeout")
         self.chunk_size = config.get("chunk_size")
         self.use_dask = config.get("use_dask")
         self.npartitions = config.get("npartitions")
-        self.meta = config.get("meta")
         self.use_vectorization = config.get("use_vectorization")
         self.parallel_processes = config.get("parallel_processes")
 
@@ -276,6 +270,10 @@ class CleanInvalidValuesOperation(TransformationOperation):
             - include_timestamp: bool - Include timestamp in filenames - True
             - save_output: bool - Save processed data to output directory - True
             - encrypt_output: bool - Override encryption setting for outputs - False
+            - visualization_theme: str - Override theme for visualizations - None
+            - visualization_backend: str - Override backend for visualizations - None
+            - visualization_strict: bool - Override strict mode for visualizations - False
+            - visualization_timeout: int - Override timeout for visualizations - 120
 
         Returns:
         --------
@@ -283,6 +281,8 @@ class CleanInvalidValuesOperation(TransformationOperation):
             Results of the operation
         """
         try:
+            # Config logger task for operatiions
+            self.logger = kwargs.get('logger', self.logger)
             # Initialize timing and result
             self.start_time = time.time()
             self.process_count = 0
@@ -308,6 +308,16 @@ class CleanInvalidValuesOperation(TransformationOperation):
             is_encryption_required = (kwargs.get("encrypt_output", False) or self.use_encryption)
             encryption_key = kwargs.get('encryption_key', None)
 
+            # Extract visualization parameters
+            vis_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            vis_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            vis_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            vis_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            self.logger.info(
+                f"Visualization settings: theme={vis_theme}, backend={vis_backend}, strict={vis_strict}, timeout={vis_timeout}s"
+            )
+
             self.use_dask = use_dask
             self.parallel_processes = parallel_processes
             self.include_timestamp = include_timestamp
@@ -328,7 +338,7 @@ class CleanInvalidValuesOperation(TransformationOperation):
                     progress_tracker.update(current_steps, {"step": "Checking Cache"})
 
                 self.logger.info("Checking operation cache...")
-                cache_result = self._check_cache(data_source, **kwargs)
+                cache_result = self._check_cache(data_source, reporter, **kwargs)
 
                 if cache_result:
                     self.logger.info("Cache hit! Using cached results.")
@@ -410,6 +420,7 @@ class CleanInvalidValuesOperation(TransformationOperation):
 
             # Initialize metrics in scope
             metrics = {}
+            metrics_result = DataWriter
             self.end_time = time.time()
             if self.end_time and self.start_time:
                 self.execution_time = self.end_time - self.start_time
@@ -417,7 +428,7 @@ class CleanInvalidValuesOperation(TransformationOperation):
             try:
                 metrics = self._calculate_all_metrics(original_df, processed_df)
 
-                self._save_metrics(
+                metrics_result = self._save_metrics(
                     metrics=metrics,
                     task_dir=task_dir,
                     writer=writer,
@@ -435,19 +446,24 @@ class CleanInvalidValuesOperation(TransformationOperation):
                 current_steps += 1
                 progress_tracker.update(current_steps, {"step": "Finalization"})
 
+            visualizations = {}
             # Generate visualizations if required
-            if generate_visualization:
+            if generate_visualization and vis_backend is not None:
                 try:
                     kwargs_encryption = {
                         "use_encryption": kwargs.get('use_encryption', False),
                         "encryption_key": encryption_key
                     }
-                    self._handle_visualizations(
+                    visualizations = self._handle_visualizations(
                         original_df=original_df,
                         processed_df=processed_df,
                         task_dir=task_dir,
                         result=result,
                         reporter=reporter,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        vis_timeout=vis_timeout,
                         progress_tracker=progress_tracker,
                         **kwargs_encryption
                     )
@@ -456,16 +472,18 @@ class CleanInvalidValuesOperation(TransformationOperation):
                     self.logger.warning(error_message)
                     # Continue execution - visualization failure is not critical
 
+            output_result = DataWriter
             # Save output data if required
             if save_output:
                 try:
-                    self._save_output_data(
+                    output_result = self._save_output_data(
                         processed_df=processed_df,
                         task_dir=task_dir,
                         writer=writer,
                         result=result,
                         reporter=reporter,
-                        progress_tracker=progress_tracker
+                        progress_tracker=progress_tracker,
+                        **kwargs
                     )
                 except Exception as e:
                     error_message = f"Error saving output data: {str(e)}"
@@ -479,6 +497,9 @@ class CleanInvalidValuesOperation(TransformationOperation):
                         original_df=original_df,
                         processed_df=processed_df,
                         metrics=metrics,
+                        metrics_result=metrics_result,
+                        output_result=output_result,
+                        visualizations=visualizations,
                         task_dir=task_dir
                     )
                 except Exception as e:
@@ -553,23 +574,30 @@ class CleanInvalidValuesOperation(TransformationOperation):
                         batch[output_field_name] = batch[field_name]
 
                 if is_numeric_dtype(batch[output_field_name]):
-                    min_value = field_config.get("min_value")
-                    max_value = field_config.get("max_value")
+                    try:
+                        min_value = float(field_config.get("min_value"))
+                    except (ValueError, TypeError):
+                        min_value = None
+
+                    try:
+                        max_value = float(field_config.get("max_value"))
+                    except (ValueError, TypeError):
+                        max_value = None
 
                     # Clean with min_value
-                    if constraint_type == "min_value":
+                    if constraint_type == "min_value" and min_value is not None:
                         batch[output_field_name] = batch[output_field_name].where(
                             batch[output_field_name] >= min_value
                         )
 
                     # Clean with max_value
-                    if constraint_type == "max_value":
+                    if constraint_type == "max_value" and max_value is not None:
                         batch[output_field_name] = batch[output_field_name].where(
                             batch[output_field_name] <= max_value
                         )
 
                     # Clean with valid_range
-                    if constraint_type == "valid_range":
+                    if constraint_type == "valid_range" and min_value is not None and max_value is not None:
                         batch[output_field_name] = batch[output_field_name].where(
                             (batch[output_field_name] >= min_value)
                             & (batch[output_field_name] <= max_value)
@@ -774,7 +802,13 @@ class CleanInvalidValuesOperation(TransformationOperation):
                         choice_values, size=num_missing
                     )
                 elif isinstance(strategy, (str, int, float, pd.Timestamp)):
-                    batch[output_column] = batch[output_column].fillna(strategy)
+                    try:
+                        # Attempt to cast strategy to column dtype
+                        column_dtype = batch[output_column].dtype
+                        casted_strategy = column_dtype.type(strategy)
+                        batch[output_column] = batch[output_column].fillna(casted_strategy)
+                    except Exception:
+                        pass  # Do nothing on failure
 
         processed_batch = batch
 
@@ -837,6 +871,7 @@ class CleanInvalidValuesOperation(TransformationOperation):
     def _check_cache(
             self,
             data_source: DataSource,
+            reporter: Any,
             **kwargs
     ) -> Optional[OperationResult]:
         """
@@ -846,6 +881,8 @@ class CleanInvalidValuesOperation(TransformationOperation):
         -----------
         data_source : DataSource
             Data source for the operation
+        reporter : Any
+            The reporter to log artifacts to
         task_dir : Path
             Task directory
         dataset_name: str
@@ -896,10 +933,83 @@ class CleanInvalidValuesOperation(TransformationOperation):
                         if isinstance(value, (int, float, str, bool)):
                             cached_result.add_metric(key, value)
 
+                # Restore artifacts from cache
+                artifacts_restored = 0
+
+                # Add metrics artifact if exists
+                metrics_result_path = cached_data.get("metrics_result_path")
+                if metrics_result_path:
+                    metrics_path = Path(metrics_result_path)
+                    if metrics_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="json",
+                            path=metrics_path,
+                            description=f"Generalization metrics (cached)",
+                            category=Constants.Artifact_Category_Metrics
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalization metrics (cached)",
+                                details={
+                                    "artifact_type": "json",
+                                    "path": str(metrics_path)
+                                }
+                            )
+
+                # Add output artifact if file exists
+                output_result_path = cached_data.get("output_result_path")
+                if output_result_path:
+                    output_path = Path(output_result_path)
+                    if output_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type=self.output_format,
+                            path=output_path,
+                            description=f"Generalized data (cached)",
+                            category=Constants.Artifact_Category_Output
+                        )
+                        artifacts_restored += 1
+
+                        # Also report to reporter
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalized data (cached)",
+                                details={
+                                    "artifact_type": self.output_format,
+                                    "path": str(output_path)
+                                }
+                            )
+                    else:
+                        self.logger.warning(f"Cached output file not found: {output_path}")
+
+                # Add visualization artifacts
+                visualizations = cached_data.get("visualizations", {})
+                for viz_type, viz_path in visualizations.items():
+                    path = Path(viz_path)
+                    if path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="png",
+                            path=path,
+                            description=f"{viz_type} visualization (cached)",
+                            category=Constants.Artifact_Category_Visualization
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"{viz_type} visualization (cached)",
+                                details={
+                                    "artifact_type": "png",
+                                    "path": str(path)
+                                }
+                            )
+
                 # Add cache information to result
                 cached_result.add_metric("cached", True)
                 cached_result.add_metric("cache_key", cache_key)
                 cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+                cached_result.add_metric("artifacts_restored", artifacts_restored)
 
                 return cached_result
 
@@ -1042,10 +1152,11 @@ class CleanInvalidValuesOperation(TransformationOperation):
             chunk_size = self.chunk_size,
             use_dask = self.use_dask,
             npartitions = self.npartitions,
-            meta = self.meta,
+            meta = None,
             use_vectorization = self.use_vectorization,
             parallel_processes = self.parallel_processes,
-            progress_tracker = progress_tracker
+            progress_tracker = progress_tracker,
+            task_logger = self.logger
         )
 
         return processed_df
@@ -1133,7 +1244,7 @@ class CleanInvalidValuesOperation(TransformationOperation):
             result: OperationResult,
             reporter: Any,
             progress_tracker: Optional[HierarchicalProgressTracker]
-    ) -> None:
+    ) -> WriterResult:
         """
         Save metrics.
 
@@ -1151,6 +1262,11 @@ class CleanInvalidValuesOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -1195,6 +1311,8 @@ class CleanInvalidValuesOperation(TransformationOperation):
                 description=f"Clean invalid values metrics"
             )
 
+        return metrics_result
+
     def _handle_visualizations(
             self,
             original_df: pd.DataFrame,
@@ -1202,9 +1320,13 @@ class CleanInvalidValuesOperation(TransformationOperation):
             task_dir: Path,
             result: OperationResult,
             reporter: Any,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            vis_timeout: int,
             progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
-    ) -> None:
+    ) -> Dict[str, Path]:
         """
         Generate and save visualizations.
 
@@ -1220,19 +1342,137 @@ class CleanInvalidValuesOperation(TransformationOperation):
             The operation result to add artifacts to
         reporter : Any
             The reporter to log artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
         """
         if progress_tracker:
             progress_tracker.update(0, {"step": "Generating visualizations"})
 
-        # Generate visualizations
-        visualization_paths = self._generate_visualizations(
-            original_df=original_df,
-            processed_df=processed_df,
-            task_dir=task_dir,
-            **kwargs
-        )
+        self.logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                self.logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        self.logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    visualization_paths = self._generate_visualizations(
+                        original_df=original_df,
+                        processed_df=processed_df,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                self.logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                self.logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                self.logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            self.logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
 
         # Register visualization artifacts
         for viz_type, path in visualization_paths.items():
@@ -1252,11 +1492,17 @@ class CleanInvalidValuesOperation(TransformationOperation):
                     description=f"{viz_type} visualization"
                 )
 
+        return visualization_paths
+
     def _generate_visualizations(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             task_dir: Path,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
     ) -> Dict[str, Path]:
         """
@@ -1270,6 +1516,14 @@ class CleanInvalidValuesOperation(TransformationOperation):
             The anonymized data after processing
         task_dir : Path
             Task directory for saving visualizations
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
 
         Returns:
         --------
@@ -1277,7 +1531,11 @@ class CleanInvalidValuesOperation(TransformationOperation):
             Dictionary with visualization types and paths
         """
         from pamola_core.transformations.commons.visualization_utils import (
-            generate_field_count_comparison_vis
+            generate_dataset_overview_vis,
+            generate_field_count_comparison_vis,
+            generate_record_count_comparison_vis,
+            generate_data_distribution_comparison_vis,
+            sample_large_dataset
         )
 
         visualization_paths = {}
@@ -1285,20 +1543,140 @@ class CleanInvalidValuesOperation(TransformationOperation):
         # Create timestamp for filenames
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-        visualization_paths.update(
-            generate_field_count_comparison_vis(
-                original_df=original_df,
-                transformed_df=processed_df,
-                field_label="Clean invalid values",
-                operation_name=f"{self.__class__.__name__}",
-                task_dir=task_dir,
-                timestamp=timestamp,
-                visualization_paths=visualization_paths,
-                **kwargs
-            )
-        )
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(f"Skipping visualization (backend=None)")
+            return visualization_paths
 
-        return visualization_paths
+        self.logger.info(f"[VIZ] Starting visualization generation")
+        self.logger.debug(f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+        try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
+            # Sample large datasets for visualization
+            if len(original_df) > 10000:
+                self.logger.info(f"[VIZ] Sampling large dataset: {len(original_df)} -> 10000 samples")
+                original_for_viz = sample_large_dataset(original_df, max_samples=10000)
+                processed_for_viz = sample_large_dataset(processed_df, max_samples=10000)
+            else:
+                original_for_viz = original_df
+                processed_for_viz = processed_df
+
+            self.logger.debug(f"[VIZ] Data prepared for visualization: {len(original_for_viz)} samples")
+
+            # Step 2 & 3: Create visualization & Save visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Create visualization"})
+                progress_tracker.update(3, {"step": "Save visualization"})
+
+            # Generate visualization
+            field_names = set()
+            if self.field_constraints:
+                field_names.update(self.field_constraints.keys())
+            if self.whitelist_path:
+                field_names.update(self.whitelist_path.keys())
+            if self.blacklist_path:
+                field_names.update(self.blacklist_path.keys())
+            if self.null_replacement:
+                if isinstance(self.null_replacement, dict):
+                    field_names.update(self.null_replacement.keys())
+                elif isinstance(self.null_replacement, str) and original_df is not None:
+                    field_names.update(original_df.columns)
+            field_names = list(field_names)
+
+            output_field_names = field_names
+            if self.mode == "ENRICH" and self.column_prefix:
+                output_field_names = [f"{self.column_prefix}{field_name}" for field_name in field_names]
+
+            for field_name in field_names:
+                output_field_name = field_name
+                if self.mode == "ENRICH" and self.column_prefix:
+                    output_field_name = f"{self.column_prefix}{field_name}"
+
+                visualization_paths.update(
+                    generate_data_distribution_comparison_vis(
+                        original_data=original_for_viz[field_name],
+                        transformed_data=processed_for_viz[output_field_name],
+                        field_label=field_name,
+                        operation_name=f"{self.__class__.__name__}",
+                        task_dir=task_dir / "visualizations",
+                        timestamp=timestamp,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=None
+                    )
+                )
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=original_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="original",
+                    field_label=",".join(field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=processed_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="transformed",
+                    field_label=",".join(output_field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                 generate_record_count_comparison_vis(
+                     original_df=original_for_viz,
+                     transformed_dfs={"transformed": processed_for_viz},
+                     field_label= ",".join(field_names),
+                     operation_name=f"{self.__class__.__name__}",
+                     task_dir=task_dir / "visualizations",
+                     timestamp=timestamp,
+                     theme=vis_theme,
+                     backend=vis_backend,
+                     strict=vis_strict,
+                     visualization_paths=None
+                 )
+            )
+
+            visualization_paths.update(
+                 generate_field_count_comparison_vis(
+                     original_df=original_for_viz,
+                     transformed_df=processed_for_viz,
+                     field_label= ",".join(field_names),
+                     operation_name=f"{self.__class__.__name__}",
+                     task_dir=task_dir / "visualizations",
+                     timestamp=timestamp,
+                     theme=vis_theme,
+                     backend=vis_backend,
+                     strict=vis_strict,
+                     visualization_paths=None
+                 )
+            )
+
+            self.logger.info(f"[VIZ] Visualization generation completed. Created {len(visualization_paths)} visualizations")
+            return visualization_paths
+        except Exception as e:
+            self.logger.error(f"[VIZ] Error in visualization generation: {type(e).__name__}: {e}")
+            self.logger.debug(f"[VIZ] Stack trace:", exc_info=True)
+            return {}
 
     def _save_output_data(
             self,
@@ -1307,8 +1685,9 @@ class CleanInvalidValuesOperation(TransformationOperation):
             writer: DataWriter,
             result: OperationResult,
             reporter: Any,
-            progress_tracker: Optional[HierarchicalProgressTracker]
-    ) -> None:
+            progress_tracker: Optional[HierarchicalProgressTracker],
+            **kwargs
+    ) -> WriterResult:
         """
         Save the processed output data.
 
@@ -1326,6 +1705,11 @@ class CleanInvalidValuesOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -1342,13 +1726,15 @@ class CleanInvalidValuesOperation(TransformationOperation):
             include_timestamp=self.include_timestamp
         )
 
+        encryption_mode = get_encryption_mode(processed_df, **kwargs)
         output_result = writer.write_dataframe(
             df=processed_df,
             name=output_filename.replace(".csv", ""),  # writer appends .csv
             format="csv",
             subdir="output",
             timestamp_in_name=False,  # Already included in the filename
-            encryption_key=self.encryption_key if self.is_encryption_required else None
+            encryption_key=self.encryption_key if self.is_encryption_required else None,
+            encryption_mode=encryption_mode
         )
 
         # Register output artifact with the result
@@ -1367,11 +1753,16 @@ class CleanInvalidValuesOperation(TransformationOperation):
                 description=f"Clean invalid values"
             )
 
+        return output_result
+
     def _save_to_cache(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             metrics: Dict[str, Any],
+            metrics_result: WriterResult,
+            output_result: WriterResult,
+            visualizations: Dict[str, Any],
             task_dir: Path
     ) -> bool:
         """
@@ -1385,6 +1776,12 @@ class CleanInvalidValuesOperation(TransformationOperation):
             Processed DataFrame
         metrics : dict
             The metrics of operation
+        metrics_result : WriterResult
+            The result of metrics
+        output_result : WriterResult
+            The result of output
+        visualizations : dict
+            The visualizations of operation
         task_dir : Path
             Task directory
 
@@ -1410,6 +1807,9 @@ class CleanInvalidValuesOperation(TransformationOperation):
                 "timestamp": datetime.now().isoformat(),
                 "parameters": operation_parameters,
                 "metrics": metrics,
+                "metrics_result_path": str(metrics_result.path),
+                "output_result_path": str(output_result.path),
+                "visualizations": visualizations,
                 "data_info": {
                     "original_df_length": len(original_df),
                     "processed_df_length": len(processed_df)

--- a/pamola_core/transformations/commons/aggregation_utils.py
+++ b/pamola_core/transformations/commons/aggregation_utils.py
@@ -87,6 +87,9 @@ def generate_record_count_per_group_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -107,6 +110,12 @@ def generate_record_count_per_group_vis(
         Directory to save plots.
     timestamp : str
         For unique filenames.
+    theme : Optional[str]
+        Theme for visualizations (default: None, uses PAMOLA default).
+    backend : Optional[str]
+        Backend for visualizations (default: None, uses PAMOLA default).
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules (default: False).
     visualization_paths : Optional[Dict[str, Any]]
         Dict to collect plot paths.
 
@@ -138,6 +147,9 @@ def generate_record_count_per_group_vis(
         orientation="v",
         sort_by="value",
         max_items=30,
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Bar chart saved to: %s", vis_path)
@@ -213,6 +225,9 @@ def generate_aggregation_comparison_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -235,6 +250,12 @@ def generate_aggregation_comparison_vis(
         Directory to save plots.
     timestamp : str
         For unique filenames.
+    theme : Optional[str]
+        Theme for visualizations (default: None, uses PAMOLA default).
+    backend : Optional[str]
+        Backend for visualizations (default: None, uses PAMOLA default).
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules (default: False).
     visualization_paths : Optional[Dict[str, Any]]
         Dict to collect plot paths.
 
@@ -269,6 +290,9 @@ def generate_aggregation_comparison_vis(
             orientation="v",
             sort_by="value",
             max_items=30,
+            theme=theme,
+            backend=backend,
+            strict=strict,
             **kwargs
         )
         logger.debug(
@@ -337,6 +361,9 @@ def generate_group_size_distribution_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -357,6 +384,13 @@ def generate_group_size_distribution_vis(
         Directory to save plots.
     timestamp : str
         For unique filenames.
+    theme : Optional[str]
+        Theme for visualizations (default: None, uses PAMOLA default).
+    backend : Optional[str]
+        Backend for visualizations (default: None, uses PAMOLA default).
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules (default: False).
+
     visualization_paths : Optional[Dict[str, Any]]
         Dict to collect plot paths.
 
@@ -387,6 +421,9 @@ def generate_group_size_distribution_vis(
         y_label="Frequency",
         bins=20,
         kde=False,
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Group size distribution histogram saved to: %s", vis_path)

--- a/pamola_core/transformations/commons/merging_utils.py
+++ b/pamola_core/transformations/commons/merging_utils.py
@@ -111,6 +111,9 @@ def generate_record_overlap_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -135,8 +138,16 @@ def generate_record_overlap_vis(
         Directory where the Venn diagram image will be saved.
     timestamp : str
         Timestamp string for uniquely naming output files.
+    theme : Optional[str]
+        Visualization theme to use.
+    backend : Optional[str]
+        Visualization backend to use.
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules.
     visualization_paths : Optional[Dict[str, Any]]
-        Dictionary to store visualization output paths. Will be updated with the new Venn diagram path.
+        Dictionary to store paths to generated visualizations. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -165,6 +176,9 @@ def generate_record_overlap_vis(
         set1_label="Left",
         set2_label="Right",
         title="Record Overlap (Key Fields)",
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Venn diagram saved to: %s", venn_diagram_result_path)
@@ -230,6 +244,9 @@ def generate_dataset_size_comparison_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -252,9 +269,16 @@ def generate_dataset_size_comparison_vis(
         Directory path where the output image will be saved.
     timestamp : str
         Timestamp string used to uniquely name the output file.
+    theme : Optional[str]
+        Visualization theme to use.
+    backend : Optional[str]
+        Visualization backend to use.
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules.
     visualization_paths : Optional[Dict[str, Any]]
-        Dictionary storing paths to previously generated visualizations.
-        Will be updated with the new bar chart path if not None.
+        Dictionary to store paths to generated visualizations. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -291,6 +315,9 @@ def generate_dataset_size_comparison_vis(
         orientation="v",
         sort_by="key",
         showlegend=False,
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Bar chart saved to: %s", bar_chart_result_path)
@@ -367,6 +394,9 @@ def generate_field_overlap_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -387,9 +417,16 @@ def generate_field_overlap_vis(
         Directory where the generated image should be saved.
     timestamp : str
         Timestamp string for uniquely naming the visualization file.
-    visualization_paths : Optional[Dict[str, Any]], optional
-        Dictionary to store the path to generated visualizations. Will be updated with
-        the field overlap Venn diagram path.
+    theme : Optional[str]
+        Visualization theme to use.
+    backend : Optional[str]
+        Visualization backend to use.
+    strict : Optional[bool]
+        Whether to enforce strict visualization rules.
+    visualization_paths : Optional[Dict[str, Any]]
+        Dictionary to store paths to generated visualizations. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -418,6 +455,9 @@ def generate_field_overlap_vis(
         set1_label="Left Fields",
         set2_label="Right Fields",
         title="Field Overlap",
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Field overlap Venn diagram saved to: %s", venn_diagram_result_path)
@@ -496,6 +536,9 @@ def generate_join_type_distribution_vis(
     operation_name: str,
     task_dir: Path,
     timestamp: str,
+    theme: Optional[str] = None,
+    backend: Optional[str] = None,
+    strict: Optional[bool] = None,
     visualization_paths: Optional[Dict[str, Any]] = None,
     **kwargs
 ) -> Dict[str, Any]:
@@ -520,8 +563,16 @@ def generate_join_type_distribution_vis(
         Directory path where the output pie chart will be saved.
     timestamp : str
         Timestamp string to help uniquely name the output file.
+    theme : Optional[str], optional
+        Visualization theme to use (if any).
+    backend : Optional[str], optional
+        Visualization backend to use (if any).
+    strict : Optional[bool], optional
+        Whether to enforce strict visualization rules.
     visualization_paths : Optional[Dict[str, Any]], optional
         Dictionary to store and return paths to visualization outputs. If None, a new one is created.
+    **kwargs : Any
+        Additional keyword arguments for the pie chart creation function.
 
     Returns
     -------
@@ -555,6 +606,9 @@ def generate_join_type_distribution_vis(
         output_path=join_path,
         title=f"Join Result Distribution ({join_type} join)",
         show_percentages=True,
+        theme=theme,
+        backend=backend,
+        strict=strict,
         **kwargs
     )
     logger.debug("Pie chart saved to: %s", pie_chart_result_path)

--- a/pamola_core/transformations/commons/visualization_utils.py
+++ b/pamola_core/transformations/commons/visualization_utils.py
@@ -420,6 +420,7 @@ def generate_dataset_overview_vis(
     backend: Optional[str] = None,
     strict: bool = False,
     visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs: Any
 ) -> Dict[str, Any]:
     """
     Generate visualization charts for a dataset overview.
@@ -446,6 +447,8 @@ def generate_dataset_overview_vis(
         Whether to enforce strict type checking.
     visualization_paths : Optional[Dict[str, Any]]
         Dictionary to update with chart paths.
+    kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -479,6 +482,7 @@ def generate_dataset_overview_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
         visualization_paths[f"{dataset_label}_dtype_counts_bar_chart"] = vis_path
 
@@ -507,6 +511,7 @@ def generate_dataset_overview_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
         visualization_paths[f"{dataset_label}_columns_null_percentage_bar_chart"] = (
             vis_path
@@ -533,6 +538,7 @@ def generate_dataset_overview_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
         visualization_paths[f"{dataset_label}_columns_cardinality_bar_chart"] = vis_path
 
@@ -561,6 +567,7 @@ def generate_dataset_overview_vis(
                     theme=theme,
                     backend=backend,
                     strict=strict,
+                    **kwargs
                 )
                 visualization_paths[f"{dataset_label}_numeric_{stat}_bar_chart"] = (
                     vis_path
@@ -596,6 +603,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[
                 f"{dataset_label}_categorical_top_value_count_bar_chart"
@@ -617,6 +625,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[
                 f"{dataset_label}_categorical_unique_count_bar_chart"
@@ -652,6 +661,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[f"{dataset_label}_datetime_min_bar_chart"] = vis_path
 
@@ -671,6 +681,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[f"{dataset_label}_datetime_max_bar_chart"] = vis_path
 
@@ -704,6 +715,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[f"{dataset_label}_boolean_true_counts_bar_chart"] = (
                 vis_path
@@ -725,6 +737,7 @@ def generate_dataset_overview_vis(
                 theme=theme,
                 backend=backend,
                 strict=strict,
+                **kwargs
             )
             visualization_paths[f"{dataset_label}_boolean_false_counts_bar_chart"] = (
                 vis_path
@@ -744,6 +757,7 @@ def generate_data_distribution_comparison_vis(
     backend: Optional[str] = None,
     strict: bool = False,
     visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs: Any
 ) -> Dict[str, Any]:
     """
     Generate distribution comparison visualization for a single field.
@@ -770,6 +784,8 @@ def generate_data_distribution_comparison_vis(
         Whether to enforce strict type checking.
     visualization_paths : Optional[Dict[str, Any]]
         Dictionary to store visualization paths.
+    kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -803,6 +819,7 @@ def generate_data_distribution_comparison_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
         visualization_paths["numeric_comparison_histogram"] = vis_path
 
@@ -823,6 +840,7 @@ def generate_data_distribution_comparison_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
         visualization_paths["category_comparison_bar_chart"] = vis_path
 
@@ -840,6 +858,7 @@ def generate_record_count_comparison_vis(
     backend: Optional[str] = None,
     strict: bool = False,
     visualization_paths: Optional[Dict[str, Any]] = None,
+    **kwargs: Any
 ) -> Dict[str, Any]:
     """
     Generate record count comparison visualization between original and transformed dataset.
@@ -866,6 +885,8 @@ def generate_record_count_comparison_vis(
         Whether to enforce strict type checking.
     visualization_paths : Optional[Dict[str, Any]]
         Dict to collect plot paths.
+    **kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------
@@ -898,6 +919,7 @@ def generate_record_count_comparison_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
 
         visualization_paths["record_count_distribution_pie_chart"] = (
@@ -926,6 +948,7 @@ def generate_record_count_comparison_vis(
             theme=theme,
             backend=backend,
             strict=strict,
+            **kwargs
         )
 
         visualization_paths["record_count_comparison_bar_chart"] = bar_chart_result_path
@@ -971,6 +994,8 @@ def generate_field_count_comparison_vis(
         Whether to enforce strict type checking.
     visualization_paths : Optional[Dict[str, Any]]
         Dict to collect plot paths.
+    **kwargs : Any
+        Additional keyword arguments for visualization functions.
 
     Returns
     -------

--- a/pamola_core/transformations/field_ops/add_modify_fields.py
+++ b/pamola_core/transformations/field_ops/add_modify_fields.py
@@ -32,13 +32,14 @@ import pandas as pd
 
 from pamola_core.utils.ops.op_config import OperationConfig
 from pamola_core.utils.ops.op_data_source import DataSource
-from pamola_core.utils.ops.op_data_writer import DataWriter
+from pamola_core.utils.ops.op_data_writer import DataWriter, WriterResult
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
 from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.common.constants import Constants
 from pamola_core.utils.io import load_data_operation, load_settings_operation
 from pamola_core.transformations.base_transformation_op import TransformationOperation
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 # Configure module logger
 logger = logging.getLogger(__name__)
@@ -51,25 +52,23 @@ class AddOrModifyFieldsConfig(OperationConfig):
         "properties": {
             "field_operations": {"type": ["object", "null"]},
             "lookup_tables": {"type": ["object", "null"]},
-
             "output_format": {"type": "string", "enum": ["csv", "json", "parquet"]},
-
-            "name": {"type": "string"},
-            "description": {"type": "string"},
-
-            "field_name": {"type": "string"},
+            "name": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "field_name": {"type": ["string", "null"]},
             "mode": {"type": "string", "enum": ["REPLACE", "ENRICH"]},
             "output_field_name": {"type": ["string", "null"]},
             "column_prefix": {"type": "string"},
-
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {"type": ["string", "null"], "enum": ["plotly", "matplotlib", None]},
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
             "chunk_size": {"type": "integer"},
             "use_dask": {"type": "boolean"},
             "npartitions": {"type": "integer"},
-            "meta": {"type": ["object", "null"]},
             "use_vectorization": {"type": "boolean"},
             "parallel_processes": {"type": "integer"},
-
-            "batch_size": {"type": "integer", "minimum": 1},
             "use_cache": {"type": "boolean"},
             "use_encryption": {"type": "boolean"},
             "encryption_key": {"type": ["string", "null"]}
@@ -88,28 +87,26 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             self,
             field_operations: Optional[Dict[str, Dict[str, Any]]] = None,
             lookup_tables: Optional[Dict[str, Union[Path, Dict[Any, Any]]]] = None,
-
             output_format: str = "csv",
-
             name: str = "add_modify_fields_operation",
             description: str = "Add or modify fields",
-
             field_name: str = "",
             mode: str = "REPLACE",
             output_field_name: Optional[str] = None,
             column_prefix: str = "_",
-
+            visualization_theme: Optional[str] = None,
+            visualization_backend: Optional[str] = None,
+            visualization_strict: bool = False,
+            visualization_timeout: int = 120,
             chunk_size: int = 10000,
             use_dask: bool = False,
             npartitions: int = 2,
-            meta: Optional[Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple]] = None,
             use_vectorization: bool = False,
             parallel_processes: int = 2,
-
-            batch_size: int = 10000,
             use_cache: bool = True,
             use_encryption: bool = False,
-            encryption_key: Optional[Union[str, Path]] = None
+            encryption_key: Optional[Union[str, Path]] = None,
+            encryption_mode: Optional[str] = None,
     ):
         """
         Initialize operation.
@@ -120,15 +117,12 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             Fields operations
         lookup_tables : dict, optional
             Lookup tables
-
         output_format : str
             Output format: "csv" or "json" or "parquet" (default: "csv")
-
         name : str
             Name of the operation (default: "add_modify_fields_operation")
         description : str
             Operation description (default: "Add or modify fields")
-
         field_name : str
             Field name to transform (default: "")
         mode : str
@@ -137,22 +131,24 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             Name for the output field if mode is "ENRICH" (default: None)
         column_prefix : str, optional
             Prefix for new column if mode is "ENRICH" (default: "_")
-
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
         chunk_size : int, optional
             Number of rows to process in each chunk (default: 10000).
         use_dask : bool, optional
             Whether to use Dask for processing (default: False).
         npartitions : int, optional
             Number of partitions use with Dask (default: 1).
-        meta : Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple], optional
-            Meta of output use with Dask.
         use_vectorization : bool, optional
             Whether to use vectorized (parallel) processing (default: False).
         parallel_processes : int, optional
             Number of processes use with vectorized (parallel) (default: 1).
-
-        batch_size : int
-            Batch size for processing large datasets (default: 10000)
         use_cache : bool
             Whether to use operation caching (default: True)
         use_encryption : bool
@@ -164,25 +160,22 @@ class AddOrModifyFieldsOperation(TransformationOperation):
         config = AddOrModifyFieldsConfig(
             field_operations=field_operations,
             lookup_tables=lookup_tables,
-
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
+            visualization_theme=visualization_theme,
+            visualization_backend=visualization_backend,
+            visualization_strict=visualization_strict,
+            visualization_timeout=visualization_timeout,
             chunk_size=chunk_size,
             use_dask=use_dask,
             npartitions=npartitions,
-            meta=meta,
             use_vectorization=use_vectorization,
             parallel_processes=parallel_processes,
-
-            batch_size=batch_size,
             use_cache=use_cache,
             use_encryption=use_encryption,
             encryption_key=encryption_key
@@ -191,26 +184,27 @@ class AddOrModifyFieldsOperation(TransformationOperation):
         # Initialize base class
         super().__init__(
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
-            batch_size=batch_size,
+            chunk_size=chunk_size,
             use_cache=use_cache,
             use_dask=use_dask,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
         )
 
+        self.visualization_theme = config.get("visualization_theme")
+        self.visualization_backend = config.get("visualization_backend")
+        self.visualization_strict = config.get("visualization_strict")
+        self.visualization_timeout = config.get("visualization_timeout")
         self.chunk_size = config.get("chunk_size")
         self.use_dask = config.get("use_dask")
         self.npartitions = config.get("npartitions")
-        self.meta = config.get("meta")
         self.use_vectorization = config.get("use_vectorization")
         self.parallel_processes = config.get("parallel_processes")
 
@@ -257,6 +251,10 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             - include_timestamp: bool - Include timestamp in filenames - True
             - save_output: bool - Save processed data to output directory - True
             - encrypt_output: bool - Override encryption setting for outputs - False
+            - visualization_theme: str - Override theme for visualizations - None
+            - visualization_backend: str - Override backend for visualizations - None
+            - visualization_strict: bool - Override strict mode for visualizations - False
+            - visualization_timeout: int - Override timeout for visualizations - 120
 
         Returns:
         --------
@@ -264,6 +262,8 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             Results of the operation
         """
         try:
+            # Config logger task for operatiions
+            self.logger = kwargs.get('logger', self.logger)
             # Initialize timing and result
             self.start_time = time.time()
             self.process_count = 0
@@ -292,6 +292,16 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             is_encryption_required = (kwargs.get("encrypt_output", False) or self.use_encryption)
             encryption_key = kwargs.get('encryption_key', None)
 
+            # Extract visualization parameters
+            vis_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            vis_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            vis_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            vis_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            self.logger.info(
+                f"Visualization settings: theme={vis_theme}, backend={vis_backend}, strict={vis_strict}, timeout={vis_timeout}s"
+            )
+
             self.use_dask = use_dask
             self.parallel_processes = parallel_processes
             self.include_timestamp = include_timestamp
@@ -312,7 +322,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                     progress_tracker.update(current_steps, {"step": "Checking Cache"})
 
                 self.logger.info("Checking operation cache...")
-                cache_result = self._check_cache(data_source, **kwargs)
+                cache_result = self._check_cache(data_source, reporter, **kwargs)
 
                 if cache_result:
                     self.logger.info("Cache hit! Using cached results.")
@@ -393,6 +403,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
 
             # Initialize metrics in scope
             metrics = {}
+            metrics_result = DataWriter
             self.end_time = time.time()
             if self.end_time and self.start_time:
                 self.execution_time = self.end_time - self.start_time
@@ -400,7 +411,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             try:
                 metrics = self._calculate_all_metrics(original_df, processed_df)
 
-                self._save_metrics(
+                metrics_result = self._save_metrics(
                     metrics=metrics,
                     task_dir=metrics_dir,
                     writer=writer,
@@ -418,19 +429,24 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                 current_steps += 1
                 progress_tracker.update(current_steps, {"step": "Finalization"})
 
+            visualizations = {}
             # Generate visualizations if required
-            if generate_visualization:
+            if generate_visualization and vis_backend is not None:
                 try:
                     kwargs_encryption = {
                         "use_encryption": kwargs.get('use_encryption', False),
                         "encryption_key": encryption_key
                     }
-                    self._handle_visualizations(
+                    visualizations = self._handle_visualizations(
                         original_df=original_df,
                         processed_df=processed_df,
                         task_dir=visualizations_dir,
                         result=result,
                         reporter=reporter,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        vis_timeout=vis_timeout,
                         progress_tracker=progress_tracker,
                         **kwargs_encryption
                     )
@@ -439,16 +455,18 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                     self.logger.warning(error_message)
                     # Continue execution - visualization failure is not critical
 
+            output_result = DataWriter
             # Save output data if required
             if save_output:
                 try:
-                    self._save_output_data(
+                    output_result = self._save_output_data(
                         processed_df=processed_df,
                         task_dir=output_dir,
                         writer=writer,
                         result=result,
                         reporter=reporter,
-                        progress_tracker=progress_tracker
+                        progress_tracker=progress_tracker,
+                        **kwargs
                     )
                 except Exception as e:
                     error_message = f"Error saving output data: {str(e)}"
@@ -462,6 +480,9 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                         original_df=original_df,
                         processed_df=processed_df,
                         metrics=metrics,
+                        metrics_result=metrics_result,
+                        output_result=output_result,
+                        visualizations=visualizations,
                         task_dir=task_dir
                     )
                 except Exception as e:
@@ -659,6 +680,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
     def _check_cache(
             self,
             data_source: DataSource,
+            reporter: Any,
             **kwargs
     ) -> Optional[OperationResult]:
         """
@@ -668,6 +690,8 @@ class AddOrModifyFieldsOperation(TransformationOperation):
         -----------
         data_source : DataSource
             Data source for the operation
+        reporter : Any
+            The reporter to log artifacts to
         task_dir : Path
             Task directory
         dataset_name: str
@@ -685,6 +709,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             # Import and get global cache manager
             from pamola_core.utils.ops.op_cache import operation_cache
 
+            # Get DataFrame from data source
             # Load data
             dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
@@ -717,10 +742,83 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                         if isinstance(value, (int, float, str, bool)):
                             cached_result.add_metric(key, value)
 
+                # Restore artifacts from cache
+                artifacts_restored = 0
+
+                # Add metrics artifact if exists
+                metrics_result_path = cached_data.get("metrics_result_path")
+                if metrics_result_path:
+                    metrics_path = Path(metrics_result_path)
+                    if metrics_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="json",
+                            path=metrics_path,
+                            description=f"Generalization metrics (cached)",
+                            category=Constants.Artifact_Category_Metrics
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalization metrics (cached)",
+                                details={
+                                    "artifact_type": "json",
+                                    "path": str(metrics_path)
+                                }
+                            )
+
+                # Add output artifact if file exists
+                output_result_path = cached_data.get("output_result_path")
+                if output_result_path:
+                    output_path = Path(output_result_path)
+                    if output_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type=self.output_format,
+                            path=output_path,
+                            description=f"Generalized data (cached)",
+                            category=Constants.Artifact_Category_Output
+                        )
+                        artifacts_restored += 1
+
+                        # Also report to reporter
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalized data (cached)",
+                                details={
+                                    "artifact_type": self.output_format,
+                                    "path": str(output_path)
+                                }
+                            )
+                    else:
+                        self.logger.warning(f"Cached output file not found: {output_path}")
+
+                # Add visualization artifacts
+                visualizations = cached_data.get("visualizations", {})
+                for viz_type, viz_path in visualizations.items():
+                    path = Path(viz_path)
+                    if path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="png",
+                            path=path,
+                            description=f"{viz_type} visualization (cached)",
+                            category=Constants.Artifact_Category_Visualization
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"{viz_type} visualization (cached)",
+                                details={
+                                    "artifact_type": "png",
+                                    "path": str(path)
+                                }
+                            )
+
                 # Add cache information to result
                 cached_result.add_metric("cached", True)
                 cached_result.add_metric("cache_key", cache_key)
                 cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+                cached_result.add_metric("artifacts_restored", artifacts_restored)
 
                 return cached_result
 
@@ -861,10 +959,11 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             chunk_size = self.chunk_size,
             use_dask = self.use_dask,
             npartitions = self.npartitions,
-            meta = self.meta,
+            meta = None,
             use_vectorization = self.use_vectorization,
             parallel_processes = self.parallel_processes,
-            progress_tracker = progress_tracker
+            progress_tracker = progress_tracker,
+            task_logger = self.logger
         )
 
         return processed_df
@@ -950,7 +1049,7 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             result: OperationResult,
             reporter: Any,
             progress_tracker: Optional[HierarchicalProgressTracker]
-    ) -> None:
+    ) -> WriterResult:
         """
         Save metrics.
 
@@ -968,6 +1067,11 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -1012,6 +1116,8 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                 description=f"Add/modify fields metrics"
             )
 
+        return metrics_result
+
     def _handle_visualizations(
             self,
             original_df: pd.DataFrame,
@@ -1019,9 +1125,13 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             task_dir: Path,
             result: OperationResult,
             reporter: Any,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            vis_timeout: int,
             progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
-    ) -> None:
+    ) -> Dict[str, Path]:
         """
         Generate and save visualizations.
 
@@ -1037,19 +1147,137 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             The operation result to add artifacts to
         reporter : Any
             The reporter to log artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
         """
         if progress_tracker:
             progress_tracker.update(0, {"step": "Generating visualizations"})
 
-        # Generate visualizations
-        visualization_paths = self._generate_visualizations(
-            original_df=original_df,
-            processed_df=processed_df,
-            task_dir=task_dir,
-            **kwargs
-        )
+        self.logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                self.logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        self.logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    visualization_paths = self._generate_visualizations(
+                        original_df=original_df,
+                        processed_df=processed_df,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                self.logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                self.logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                self.logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            self.logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
 
         # Register visualization artifacts
         for viz_type, path in visualization_paths.items():
@@ -1069,11 +1297,17 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                     description=f"{viz_type} visualization"
                 )
 
+        return visualization_paths
+
     def _generate_visualizations(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             task_dir: Path,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
     ) -> Dict[str, Path]:
         """
@@ -1087,6 +1321,14 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             The anonymized data after processing
         task_dir : Path
             Task directory for saving visualizations
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
 
         Returns:
         --------
@@ -1094,7 +1336,11 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             Dictionary with visualization types and paths
         """
         from pamola_core.transformations.commons.visualization_utils import (
-            generate_field_count_comparison_vis
+            generate_dataset_overview_vis,
+            generate_field_count_comparison_vis,
+            generate_record_count_comparison_vis,
+            generate_data_distribution_comparison_vis,
+            sample_large_dataset
         )
 
         visualization_paths = {}
@@ -1102,20 +1348,131 @@ class AddOrModifyFieldsOperation(TransformationOperation):
         # Create timestamp for filenames
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-        visualization_paths.update(
-            generate_field_count_comparison_vis(
-                original_df=original_df,
-                transformed_df=processed_df,
-                field_label="Add Or Modify fields",
-                operation_name=f"{self.__class__.__name__}",
-                task_dir=task_dir,
-                timestamp=timestamp,
-                visualization_paths=visualization_paths,
-                **kwargs
-            )
-        )
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(f"Skipping visualization (backend=None)")
+            return visualization_paths
 
-        return visualization_paths
+        self.logger.info(f"[VIZ] Starting visualization generation")
+        self.logger.debug(f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+        try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
+            # Sample large datasets for visualization
+            if len(original_df) > 10000:
+                self.logger.info(f"[VIZ] Sampling large dataset: {len(original_df)} -> 10000 samples")
+                original_for_viz = sample_large_dataset(original_df, max_samples=10000)
+                processed_for_viz = sample_large_dataset(processed_df, max_samples=10000)
+            else:
+                original_for_viz = original_df
+                processed_for_viz = processed_df
+
+            self.logger.debug(f"[VIZ] Data prepared for visualization: {len(original_for_viz)} samples")
+
+            # Step 2 & 3: Create visualization & Save visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Create visualization"})
+                progress_tracker.update(3, {"step": "Save visualization"})
+
+            # Generate visualization
+            field_names = set()
+            if self.field_operations:
+                field_names.update(self.field_operations.keys())
+            field_names = list(field_names)
+
+            output_field_names = field_names
+            if self.mode == "ENRICH" and self.column_prefix:
+                output_field_names = [f"{self.column_prefix}{field_name}" for field_name in field_names]
+
+            for field_name in field_names:
+                output_field_name = field_name
+                if self.mode == "ENRICH" and self.column_prefix:
+                    output_field_name = f"{self.column_prefix}{field_name}"
+
+                visualization_paths.update(
+                    generate_data_distribution_comparison_vis(
+                        original_data=original_for_viz[field_name],
+                        transformed_data=processed_for_viz[output_field_name],
+                        field_label=field_name,
+                        operation_name=f"{self.__class__.__name__}",
+                        task_dir=task_dir / "visualizations",
+                        timestamp=timestamp,
+                        theme=vis_theme,
+                        backend=vis_backend,
+                        strict=vis_strict,
+                        visualization_paths=None
+                    )
+                )
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=original_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="original",
+                    field_label=",".join(field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=processed_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="transformed",
+                    field_label=",".join(output_field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                 generate_record_count_comparison_vis(
+                     original_df=original_for_viz,
+                     transformed_dfs={"transformed": processed_for_viz},
+                     field_label= ",".join(field_names),
+                     operation_name=f"{self.__class__.__name__}",
+                     task_dir=task_dir / "visualizations",
+                     timestamp=timestamp,
+                     theme=vis_theme,
+                     backend=vis_backend,
+                     strict=vis_strict,
+                     visualization_paths=None
+                 )
+            )
+
+            visualization_paths.update(
+                 generate_field_count_comparison_vis(
+                     original_df=original_for_viz,
+                     transformed_df=processed_for_viz,
+                     field_label= ",".join(field_names),
+                     operation_name=f"{self.__class__.__name__}",
+                     task_dir=task_dir / "visualizations",
+                     timestamp=timestamp,
+                     theme=vis_theme,
+                     backend=vis_backend,
+                     strict=vis_strict,
+                     visualization_paths=None
+                 )
+            )
+
+            self.logger.info(f"[VIZ] Visualization generation completed. Created {len(visualization_paths)} visualizations")
+            return visualization_paths
+        except Exception as e:
+            self.logger.error(f"[VIZ] Error in visualization generation: {type(e).__name__}: {e}")
+            self.logger.debug(f"[VIZ] Stack trace:", exc_info=True)
+            return {}
 
     def _save_output_data(
             self,
@@ -1124,7 +1481,8 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             writer: DataWriter,
             result: OperationResult,
             reporter: Any,
-            progress_tracker: Optional[HierarchicalProgressTracker]
+            progress_tracker: Optional[HierarchicalProgressTracker],
+            **kwargs
     ) -> None:
         """
         Save the processed output data.
@@ -1143,6 +1501,11 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -1159,13 +1522,15 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             include_timestamp=self.include_timestamp
         )
 
+        encryption_mode = get_encryption_mode(processed_df, **kwargs)
         output_result = writer.write_dataframe(
             df=processed_df,
             name=output_filename.replace(".csv", ""),  # writer appends .csv
             format="csv",
             subdir="output",
             timestamp_in_name=False,  # Already included in the filename
-            encryption_key=self.encryption_key if self.is_encryption_required else None
+            encryption_key=self.encryption_key if self.is_encryption_required else None,
+            encryption_mode=encryption_mode
         )
 
         # Register output artifact with the result
@@ -1184,11 +1549,16 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                 description=f"Add/modify fields"
             )
 
+        return output_result
+
     def _save_to_cache(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             metrics: Dict[str, Any],
+            metrics_result: WriterResult,
+            output_result: WriterResult,
+            visualizations: Dict[str, Any],
             task_dir: Path
     ) -> bool:
         """
@@ -1202,6 +1572,12 @@ class AddOrModifyFieldsOperation(TransformationOperation):
             Processed DataFrame
         metrics : dict
             The metrics of operation
+        metrics_result : WriterResult
+            The result of metrics
+        output_result : WriterResult
+            The result of output
+        visualizations : dict
+            The visualizations of operation
         task_dir : Path
             Task directory
 
@@ -1227,6 +1603,9 @@ class AddOrModifyFieldsOperation(TransformationOperation):
                 "timestamp": datetime.now().isoformat(),
                 "parameters": operation_parameters,
                 "metrics": metrics,
+                "metrics_result_path": str(metrics_result.path),
+                "output_result_path": str(output_result.path),
+                "visualizations": visualizations,
                 "data_info": {
                     "original_df_length": len(original_df),
                     "processed_df_length": len(processed_df)

--- a/pamola_core/transformations/field_ops/remove_fields.py
+++ b/pamola_core/transformations/field_ops/remove_fields.py
@@ -32,13 +32,14 @@ import pandas as pd
 
 from pamola_core.utils.ops.op_config import OperationConfig
 from pamola_core.utils.ops.op_data_source import DataSource
-from pamola_core.utils.ops.op_data_writer import DataWriter
+from pamola_core.utils.ops.op_data_writer import DataWriter, WriterResult
 from pamola_core.utils.ops.op_registry import register
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
 from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.common.constants import Constants
 from pamola_core.utils.io import load_data_operation, load_settings_operation
 from pamola_core.transformations.base_transformation_op import TransformationOperation
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 
 # Configure module logger
 logger = logging.getLogger(__name__)
@@ -51,25 +52,23 @@ class RemoveFieldsConfig(OperationConfig):
         "properties": {
             "fields_to_remove": {"type": ["array", "null"]},
             "pattern": {"type": ["string", "null"]},
-
             "output_format": {"type": "string", "enum": ["csv", "json", "parquet"]},
-
-            "name": {"type": "string"},
-            "description": {"type": "string"},
-
-            "field_name": {"type": "string"},
+            "name": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "field_name": {"type": ["string", "null"]},
             "mode": {"type": "string", "enum": ["REPLACE", "ENRICH"]},
             "output_field_name": {"type": ["string", "null"]},
             "column_prefix": {"type": "string"},
-
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {"type": ["string", "null"], "enum": ["plotly", "matplotlib", None]},
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
             "chunk_size": {"type": "integer"},
             "use_dask": {"type": "boolean"},
             "npartitions": {"type": "integer"},
-            "meta": {"type": ["object", "null"]},
             "use_vectorization": {"type": "boolean"},
             "parallel_processes": {"type": "integer"},
-
-            "batch_size": {"type": "integer", "minimum": 1},
             "use_cache": {"type": "boolean"},
             "use_encryption": {"type": "boolean"},
             "encryption_key": {"type": ["string", "null"]}
@@ -88,28 +87,26 @@ class RemoveFieldsOperation(TransformationOperation):
             self,
             fields_to_remove: Optional[List[str]] = None,
             pattern: Optional[str] = None,
-
             output_format: str = "csv",
-
             name: str = "remove_fields_operation",
             description: str = "Remove fields from dataset",
-
             field_name: str = "",
             mode: str = "REPLACE",
             output_field_name: Optional[str] = None,
             column_prefix: str = "_",
-
+            visualization_theme: Optional[str] = None,
+            visualization_backend: Optional[str] = None,
+            visualization_strict: bool = False,
+            visualization_timeout: int = 120,
             chunk_size: int = 10000,
             use_dask: bool = False,
             npartitions: int = 2,
-            meta: Optional[Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple]] = None,
             use_vectorization: bool = False,
             parallel_processes: int = 2,
-
-            batch_size: int = 10000,
             use_cache: bool = True,
             use_encryption: bool = False,
-            encryption_key: Optional[Union[str, Path]] = None
+            encryption_key: Optional[Union[str, Path]] = None,
+            encryption_mode: Optional[str] = None,
     ):
         """
         Initialize operation.
@@ -120,15 +117,12 @@ class RemoveFieldsOperation(TransformationOperation):
             Fields to remove
         pattern : str, optional
             Pattern-based fields selection
-
         output_format : str
             Output format: "csv" or "json" or "parquet" (default: "csv")
-
         name : str
             Name of the operation (default: "remove_fields_operation")
         description : str
             Operation description (default: "Remove fields from dataset")
-
         field_name : str
             Field name to transform (default: "")
         mode : str
@@ -137,22 +131,24 @@ class RemoveFieldsOperation(TransformationOperation):
             Name for the output field if mode is "ENRICH" (default: None)
         column_prefix : str, optional
             Prefix for new column if mode is "ENRICH" (default: "_")
-
+        visualization_theme : str, optional
+            Theme to use for visualizations (default: None - uses system default)
+        visualization_backend : str, optional
+            Backend to use for visualizations: "plotly" or "matplotlib" (default: None - uses system default)
+        visualization_strict : bool, optional
+            If True, raise exceptions for visualization config errors (default: False)
+        visualization_timeout : int, optional
+            Timeout in seconds for visualization generation (default: 120)
         chunk_size : int, optional
             Number of rows to process in each chunk (default: 10000).
         use_dask : bool, optional
             Whether to use Dask for processing (default: False).
         npartitions : int, optional
             Number of partitions use with Dask (default: 1).
-        meta : Union[pd.DataFrame, pd.Series, Dict, Iterable, Tuple], optional
-            Meta of output use with Dask.
         use_vectorization : bool, optional
             Whether to use vectorized (parallel) processing (default: False).
         parallel_processes : int, optional
             Number of processes use with vectorized (parallel) (default: 1).
-
-        batch_size : int
-            Batch size for processing large datasets (default: 10000)
         use_cache : bool
             Whether to use operation caching (default: True)
         use_encryption : bool
@@ -164,25 +160,22 @@ class RemoveFieldsOperation(TransformationOperation):
         config = RemoveFieldsConfig(
             fields_to_remove=fields_to_remove,
             pattern=pattern,
-
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
+            visualization_theme=visualization_theme,
+            visualization_backend=visualization_backend,
+            visualization_strict=visualization_strict,
+            visualization_timeout=visualization_timeout,
             chunk_size=chunk_size,
             use_dask=use_dask,
             npartitions=npartitions,
-            meta=meta,
             use_vectorization=use_vectorization,
             parallel_processes=parallel_processes,
-
-            batch_size=batch_size,
             use_cache=use_cache,
             use_encryption=use_encryption,
             encryption_key=encryption_key
@@ -191,26 +184,27 @@ class RemoveFieldsOperation(TransformationOperation):
         # Initialize base class
         super().__init__(
             output_format=output_format,
-
             name=name,
             description=description,
-
             field_name=field_name,
             mode=mode,
             output_field_name=output_field_name,
             column_prefix=column_prefix,
-
-            batch_size=batch_size,
+            chunk_size=chunk_size,
             use_cache=use_cache,
             use_dask=use_dask,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
         )
 
+        self.visualization_theme = config.get("visualization_theme")
+        self.visualization_backend = config.get("visualization_backend")
+        self.visualization_strict = config.get("visualization_strict")
+        self.visualization_timeout = config.get("visualization_timeout")
         self.chunk_size = config.get("chunk_size")
         self.use_dask = config.get("use_dask")
         self.npartitions = config.get("npartitions")
-        self.meta = config.get("meta")
         self.use_vectorization = config.get("use_vectorization")
         self.parallel_processes = config.get("parallel_processes")
 
@@ -257,6 +251,10 @@ class RemoveFieldsOperation(TransformationOperation):
             - include_timestamp: bool - Include timestamp in filenames - True
             - save_output: bool - Save processed data to output directory - True
             - encrypt_output: bool - Override encryption setting for outputs - False
+            - visualization_theme: str - Override theme for visualizations - None
+            - visualization_backend: str - Override backend for visualizations - None
+            - visualization_strict: bool - Override strict mode for visualizations - False
+            - visualization_timeout: int - Override timeout for visualizations - 120
 
         Returns:
         --------
@@ -264,6 +262,8 @@ class RemoveFieldsOperation(TransformationOperation):
             Results of the operation
         """
         try:
+            # Config logger task for operatiions
+            self.logger = kwargs.get('logger', self.logger)
             # Initialize timing and result
             self.start_time = time.time()
             self.process_count = 0
@@ -292,6 +292,16 @@ class RemoveFieldsOperation(TransformationOperation):
             is_encryption_required = (kwargs.get("encrypt_output", False) or self.use_encryption)
             encryption_key = kwargs.get('encryption_key', None)
 
+            # Extract visualization parameters
+            vis_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            vis_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            vis_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            vis_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            self.logger.info(
+                f"Visualization settings: theme={vis_theme}, backend={vis_backend}, strict={vis_strict}, timeout={vis_timeout}s"
+            )
+
             self.use_dask = use_dask
             self.parallel_processes = parallel_processes
             self.include_timestamp = include_timestamp
@@ -312,7 +322,7 @@ class RemoveFieldsOperation(TransformationOperation):
                     progress_tracker.update(current_steps, {"step": "Checking Cache"})
 
                 self.logger.info("Checking operation cache...")
-                cache_result = self._check_cache(data_source, **kwargs)
+                cache_result = self._check_cache(data_source, reporter, **kwargs)
 
                 if cache_result:
                     self.logger.info("Cache hit! Using cached results.")
@@ -392,6 +402,7 @@ class RemoveFieldsOperation(TransformationOperation):
 
             # Initialize metrics in scope
             metrics = {}
+            metrics_result = DataWriter
             self.end_time = time.time()
             if self.end_time and self.start_time:
                 self.execution_time = self.end_time - self.start_time
@@ -399,7 +410,7 @@ class RemoveFieldsOperation(TransformationOperation):
             try:
                 metrics = self._calculate_all_metrics(original_df, processed_df)
 
-                self._save_metrics(
+                metrics_result = self._save_metrics(
                     metrics=metrics,
                     task_dir=metrics_dir,
                     writer=writer,
@@ -417,19 +428,24 @@ class RemoveFieldsOperation(TransformationOperation):
                 current_steps += 1
                 progress_tracker.update(current_steps, {"step": "Finalization"})
 
+            visualizations = {}
             # Generate visualizations if required
-            if generate_visualization:
+            if generate_visualization and vis_backend is not None:
                 try:
                     kwargs_encryption = {
                         "use_encryption": kwargs.get('use_encryption', False),
                         "encryption_key": encryption_key
                     }
-                    self._handle_visualizations(
+                    visualizations = self._handle_visualizations(
                         original_df=original_df,
                         processed_df=processed_df,
                         task_dir=visualizations_dir,
                         result=result,
                         reporter=reporter,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        vis_timeout=vis_timeout,
                         progress_tracker=progress_tracker,
                         **kwargs_encryption
                     )
@@ -438,16 +454,18 @@ class RemoveFieldsOperation(TransformationOperation):
                     self.logger.warning(error_message)
                     # Continue execution - visualization failure is not critical
 
+            output_result = DataWriter
             # Save output data if required
             if save_output:
                 try:
-                    self._save_output_data(
+                    output_result = self._save_output_data(
                         processed_df=processed_df,
                         task_dir=output_dir,
                         writer=writer,
                         result=result,
                         reporter=reporter,
-                        progress_tracker=progress_tracker
+                        progress_tracker=progress_tracker,
+                        **kwargs
                     )
                 except Exception as e:
                     error_message = f"Error saving output data: {str(e)}"
@@ -461,6 +479,9 @@ class RemoveFieldsOperation(TransformationOperation):
                         original_df=original_df,
                         processed_df=processed_df,
                         metrics=metrics,
+                        metrics_result=metrics_result,
+                        output_result=output_result,
+                        visualizations=visualizations,
                         task_dir=task_dir
                     )
                 except Exception as e:
@@ -590,6 +611,7 @@ class RemoveFieldsOperation(TransformationOperation):
     def _check_cache(
             self,
             data_source: DataSource,
+            reporter: Any,
             **kwargs
     ) -> Optional[OperationResult]:
         """
@@ -599,6 +621,8 @@ class RemoveFieldsOperation(TransformationOperation):
         -----------
         data_source : DataSource
             Data source for the operation
+        reporter : Any
+            The reporter to log artifacts to
         task_dir : Path
             Task directory
         dataset_name: str
@@ -616,6 +640,7 @@ class RemoveFieldsOperation(TransformationOperation):
             # Import and get global cache manager
             from pamola_core.utils.ops.op_cache import operation_cache
 
+            # Get DataFrame from data source
             # Load data
             dataset_name = kwargs.get('dataset_name', "main")
             settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
@@ -648,10 +673,83 @@ class RemoveFieldsOperation(TransformationOperation):
                         if isinstance(value, (int, float, str, bool)):
                             cached_result.add_metric(key, value)
 
+                # Restore artifacts from cache
+                artifacts_restored = 0
+
+                # Add metrics artifact if exists
+                metrics_result_path = cached_data.get("metrics_result_path")
+                if metrics_result_path:
+                    metrics_path = Path(metrics_result_path)
+                    if metrics_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="json",
+                            path=metrics_path,
+                            description=f"Generalization metrics (cached)",
+                            category=Constants.Artifact_Category_Metrics
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalization metrics (cached)",
+                                details={
+                                    "artifact_type": "json",
+                                    "path": str(metrics_path)
+                                }
+                            )
+
+                # Add output artifact if file exists
+                output_result_path = cached_data.get("output_result_path")
+                if output_result_path:
+                    output_path = Path(output_result_path)
+                    if output_path.exists():
+                        cached_result.add_artifact(
+                            artifact_type=self.output_format,
+                            path=output_path,
+                            description=f"Generalized data (cached)",
+                            category=Constants.Artifact_Category_Output
+                        )
+                        artifacts_restored += 1
+
+                        # Also report to reporter
+                        if reporter:
+                            reporter.add_operation(
+                                f"Generalized data (cached)",
+                                details={
+                                    "artifact_type": self.output_format,
+                                    "path": str(output_path)
+                                }
+                            )
+                    else:
+                        self.logger.warning(f"Cached output file not found: {output_path}")
+
+                # Add visualization artifacts
+                visualizations = cached_data.get("visualizations", {})
+                for viz_type, viz_path in visualizations.items():
+                    path = Path(viz_path)
+                    if path.exists():
+                        cached_result.add_artifact(
+                            artifact_type="png",
+                            path=path,
+                            description=f"{viz_type} visualization (cached)",
+                            category=Constants.Artifact_Category_Visualization
+                        )
+                        artifacts_restored += 1
+
+                        if reporter:
+                            reporter.add_operation(
+                                f"{viz_type} visualization (cached)",
+                                details={
+                                    "artifact_type": "png",
+                                    "path": str(path)
+                                }
+                            )
+
                 # Add cache information to result
                 cached_result.add_metric("cached", True)
                 cached_result.add_metric("cache_key", cache_key)
                 cached_result.add_metric("cache_timestamp", cached_data.get("timestamp", "unknown"))
+                cached_result.add_metric("artifacts_restored", artifacts_restored)
 
                 return cached_result
 
@@ -792,10 +890,11 @@ class RemoveFieldsOperation(TransformationOperation):
             chunk_size = self.chunk_size,
             use_dask = self.use_dask,
             npartitions = self.npartitions,
-            meta = self.meta,
+            meta = None,
             use_vectorization = self.use_vectorization,
             parallel_processes = self.parallel_processes,
-            progress_tracker = progress_tracker
+            progress_tracker = progress_tracker,
+            task_logger = self.logger
         )
 
         return processed_df
@@ -881,7 +980,7 @@ class RemoveFieldsOperation(TransformationOperation):
             result: OperationResult,
             reporter: Any,
             progress_tracker: Optional[HierarchicalProgressTracker]
-    ) -> None:
+    ) -> WriterResult:
         """
         Save metrics.
 
@@ -899,6 +998,11 @@ class RemoveFieldsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -943,6 +1047,8 @@ class RemoveFieldsOperation(TransformationOperation):
                 description=f"Remove fields metrics"
             )
 
+        return metrics_result
+
     def _handle_visualizations(
             self,
             original_df: pd.DataFrame,
@@ -950,9 +1056,13 @@ class RemoveFieldsOperation(TransformationOperation):
             task_dir: Path,
             result: OperationResult,
             reporter: Any,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            vis_timeout: int,
             progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
-    ) -> None:
+    ) -> Dict[str, Path]:
         """
         Generate and save visualizations.
 
@@ -968,19 +1078,137 @@ class RemoveFieldsOperation(TransformationOperation):
             The operation result to add artifacts to
         reporter : Any
             The reporter to log artifacts to
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        Dict[str, Path]
+            Dictionary with visualization types and paths
         """
         if progress_tracker:
             progress_tracker.update(0, {"step": "Generating visualizations"})
 
-        # Generate visualizations
-        visualization_paths = self._generate_visualizations(
-            original_df=original_df,
-            processed_df=processed_df,
-            task_dir=task_dir,
-            **kwargs
-        )
+        self.logger.info(f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s")
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}")
+                self.logger.info(f"[DIAG] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(f"[DIAG] Context vars count: {len(list(current_context))}")
+                    except Exception as ctx_e:
+                        self.logger.warning(f"[DIAG] Could not inspect context: {ctx_e}")
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                    # Generate visualizations
+                    visualization_paths = self._generate_visualizations(
+                        original_df=original_df,
+                        processed_df=processed_df,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend,
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        **kwargs
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}")
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(f"[DIAG] Starting visualization thread with timeout={vis_timeout}s")
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(f"[DIAG] Visualization thread still running after {elapsed:.1f}s...")
+
+            if viz_thread.is_alive():
+                self.logger.error(f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout")
+                self.logger.error(f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}")
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(f"[DIAG] Visualization failed with error: {visualization_error}")
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s")
+                self.logger.info(f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}")
+        except Exception as e:
+            self.logger.error(f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}")
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
 
         # Register visualization artifacts
         for viz_type, path in visualization_paths.items():
@@ -1000,11 +1228,17 @@ class RemoveFieldsOperation(TransformationOperation):
                     description=f"{viz_type} visualization"
                 )
 
+        return visualization_paths
+
     def _generate_visualizations(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             task_dir: Path,
+            vis_theme: Optional[str],
+            vis_backend: Optional[str],
+            vis_strict: bool,
+            progress_tracker: Optional[HierarchicalProgressTracker],
             **kwargs
     ) -> Dict[str, Path]:
         """
@@ -1018,6 +1252,14 @@ class RemoveFieldsOperation(TransformationOperation):
             The anonymized data after processing
         task_dir : Path
             Task directory for saving visualizations
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
 
         Returns:
         --------
@@ -1025,7 +1267,11 @@ class RemoveFieldsOperation(TransformationOperation):
             Dictionary with visualization types and paths
         """
         from pamola_core.transformations.commons.visualization_utils import (
-            generate_field_count_comparison_vis
+            generate_dataset_overview_vis,
+            generate_field_count_comparison_vis,
+            generate_record_count_comparison_vis,
+            generate_data_distribution_comparison_vis,
+            sample_large_dataset
         )
 
         visualization_paths = {}
@@ -1033,20 +1279,89 @@ class RemoveFieldsOperation(TransformationOperation):
         # Create timestamp for filenames
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-        visualization_paths.update(
-            generate_field_count_comparison_vis(
-                original_df=original_df,
-                transformed_df=processed_df,
-                field_label="Remove fields",
-                operation_name=f"{self.__class__.__name__}",
-                task_dir=task_dir,
-                timestamp=timestamp,
-                visualization_paths=visualization_paths,
-                **kwargs
-            )
-        )
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(f"Skipping visualization (backend=None)")
+            return visualization_paths
 
-        return visualization_paths
+        self.logger.info(f"[VIZ] Starting visualization generation")
+        self.logger.debug(f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}")
+
+        try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
+            # Sample large datasets for visualization
+            if len(original_df) > 10000:
+                self.logger.info(f"[VIZ] Sampling large dataset: {len(original_df)} -> 10000 samples")
+                original_for_viz = sample_large_dataset(original_df, max_samples=10000)
+                processed_for_viz = sample_large_dataset(processed_df, max_samples=10000)
+            else:
+                original_for_viz = original_df
+                processed_for_viz = processed_df
+
+            self.logger.debug(f"[VIZ] Data prepared for visualization: {len(original_for_viz)} samples")
+
+            # Step 2 & 3: Create visualization & Save visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Create visualization"})
+                progress_tracker.update(3, {"step": "Save visualization"})
+
+            # Generate visualization
+            field_names = self.fields_to_remove
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=original_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="original",
+                    field_label=",".join(field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                generate_dataset_overview_vis(
+                    df=processed_for_viz,
+                    operation_name=f"{self.__class__.__name__}",
+                    dataset_label="transformed",
+                    field_label=",".join(field_names),
+                    task_dir=task_dir / "visualizations",
+                    timestamp=timestamp,
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=None
+                )
+            )
+
+            visualization_paths.update(
+                 generate_field_count_comparison_vis(
+                     original_df=original_for_viz,
+                     transformed_df=processed_for_viz,
+                     field_label= ",".join(field_names),
+                     operation_name=f"{self.__class__.__name__}",
+                     task_dir=task_dir / "visualizations",
+                     timestamp=timestamp,
+                     theme=vis_theme,
+                     backend=vis_backend,
+                     strict=vis_strict,
+                     visualization_paths=None
+                 )
+            )
+
+            self.logger.info(f"[VIZ] Visualization generation completed. Created {len(visualization_paths)} visualizations")
+            return visualization_paths
+        except Exception as e:
+            self.logger.error(f"[VIZ] Error in visualization generation: {type(e).__name__}: {e}")
+            self.logger.debug(f"[VIZ] Stack trace:", exc_info=True)
+            return {}
 
     def _save_output_data(
             self,
@@ -1055,7 +1370,8 @@ class RemoveFieldsOperation(TransformationOperation):
             writer: DataWriter,
             result: OperationResult,
             reporter: Any,
-            progress_tracker: Optional[HierarchicalProgressTracker]
+            progress_tracker: Optional[HierarchicalProgressTracker],
+            **kwargs
     ) -> None:
         """
         Save the processed output data.
@@ -1074,6 +1390,11 @@ class RemoveFieldsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+
+        Returns:
+        --------
+        WriterResult
+            Result object with path and metadata
         """
         from pamola_core.transformations.commons.visualization_utils import (
             generate_visualization_filename
@@ -1090,13 +1411,15 @@ class RemoveFieldsOperation(TransformationOperation):
             include_timestamp=self.include_timestamp
         )
 
+        encryption_mode = get_encryption_mode(processed_df, **kwargs)
         output_result = writer.write_dataframe(
             df=processed_df,
             name=output_filename.replace(".csv", ""),  # writer appends .csv
             format="csv",
             subdir="output",
             timestamp_in_name=False,  # Already included in the filename
-            encryption_key=self.encryption_key if self.is_encryption_required else None
+            encryption_key=self.encryption_key if self.is_encryption_required else None,
+            encryption_mode=encryption_mode
         )
 
         # Register output artifact with the result
@@ -1115,11 +1438,16 @@ class RemoveFieldsOperation(TransformationOperation):
                 description=f"Remove fields"
             )
 
+        return output_result
+
     def _save_to_cache(
             self,
             original_df: pd.DataFrame,
             processed_df: pd.DataFrame,
             metrics: Dict[str, Any],
+            metrics_result: WriterResult,
+            output_result: WriterResult,
+            visualizations: Dict[str, Any],
             task_dir: Path
     ) -> bool:
         """
@@ -1133,6 +1461,12 @@ class RemoveFieldsOperation(TransformationOperation):
             Processed DataFrame
         metrics : dict
             The metrics of operation
+        metrics_result : WriterResult
+            The result of metrics
+        output_result : WriterResult
+            The result of output
+        visualizations : dict
+            The visualizations of operation
         task_dir : Path
             Task directory
 
@@ -1158,6 +1492,9 @@ class RemoveFieldsOperation(TransformationOperation):
                 "timestamp": datetime.now().isoformat(),
                 "parameters": operation_parameters,
                 "metrics": metrics,
+                "metrics_result_path": str(metrics_result.path),
+                "output_result_path": str(output_result.path),
+                "visualizations": visualizations,
                 "data_info": {
                     "original_df_length": len(original_df),
                     "processed_df_length": len(processed_df)

--- a/pamola_core/transformations/grouping/aggregate_records_op.py
+++ b/pamola_core/transformations/grouping/aggregate_records_op.py
@@ -29,6 +29,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
+import numpy as np
 import pandas as pd
 from pamola_core.common.helpers.custom_aggregations_helper import (
     CUSTOM_AGG_FUNCTIONS,
@@ -84,11 +85,26 @@ class AggregateRecordsOperationConfig(OperationConfig):
                     "items": {"type": "string"},
                 },
             },
-            "output_format": {"type": "string", "str": ["csv", "json", "parquet"]},
+            "chunk_size": {"type": "integer", "minimum": 1},
             "use_cache": {"type": "boolean"},
+            "use_dask": {"type": "boolean"},
+            "npartitions": {"type": ["integer", "null"]},
             "use_encryption": {"type": "boolean"},
             "encryption_key": {"type": ["string", "null"]},
-            "use_dask": {"type": "boolean"},
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {
+                "type": ["string", "null"],
+                "enum": ["plotly", "matplotlib", None],
+            },
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
+            # Output format properties
+            "output_format": {
+                "type": "string",
+                "enum": ["csv", "parquet", "json"],
+                "default": "csv",
+            },
         },
         "required": ["group_by_fields", "aggregations"],
     }
@@ -110,11 +126,18 @@ class AggregateRecordsOperation(TransformationOperation):
         group_by_fields: List[str] = None,
         aggregations: Dict[str, List[str]] = None,
         custom_aggregations: Optional[Dict[str, Callable]] = None,
-        output_format: str = "csv",
+        chunk_size: int = 10000,
+        use_dask: bool = False,
+        npartitions: Optional[int] = None,
         use_cache: bool = True,
         use_encryption: bool = False,
         encryption_key: Optional[Union[str, Path]] = None,
-        use_dask: bool = False,
+        visualization_theme: Optional[str] = None,
+        visualization_backend: Optional[str] = None,
+        visualization_strict: bool = False,
+        visualization_timeout: int = 120,
+        output_format: str = "csv",
+        encryption_mode: Optional[str] = None,
     ):
         """
         Initialize the group and aggregate records operation.
@@ -129,63 +152,97 @@ class AggregateRecordsOperation(TransformationOperation):
             Aggregation functions to apply to each field.
         custom_aggregations : Optional[Dict[str, Callable]]
             Custom aggregation functions.
+        chunk_size : int, optional
+            Chunk size for processing large datasets (default: 10000)
+        use_dask : bool, optional
+            Whether to use Dask for distributed processing (default: False)
+        npartitions : int, optional
+            Number of partitions for Dask processing (default: None)
+        use_cache : bool, optional
+            Whether to use operation caching (default: True)
+        use_encryption : bool, optional
+            Whether to encrypt output files (default: False)
+        encryption_key : str or Path, optional
+            The encryption key or path to a key file (default: None)
+        visualization_theme : str, optional
+            Theme for visualizations (default: None, uses PAMOLA default)
+        visualization_backend : str, optional
+            Backend for visualizations (default: None, uses PAMOLA default)
+        visualization_strict : bool, optional
+            Whether to enforce strict visualization rules (default: False)
+        visualization_timeout : int, optional
+            Timeout for visualization generation in seconds (default: 120)
         output_format : str
             Output format: "csv" or "parquet" or "json".
-        use_cache : bool
-            Enable or disable operation caching.
-        use_encryption : bool
-            Enable output encryption.
-        encryption_key : str or Path, optional
-            Key used for encryption.
-        use_dask : bool
-            Whether to use Dask for distributed computation.
         """
 
-        # Assign parameters to instance variables
-        self.name = name
-        self.description = description
-        self.group_by_fields = group_by_fields
-        self.aggregations = aggregations
-        self.custom_aggregations = custom_aggregations
-        self.output_format = output_format
-        self.use_cache = use_cache
-        self.use_encryption = use_encryption
-        self.output_format = output_format
-        self.use_cache = use_cache
-        self.use_encryption = use_encryption
-        self.encryption_key = encryption_key
-        self.use_dask = use_dask
+        # Use default description if not provided
+        if not description:
+            description = f"Aggregating records by {group_by_fields}."
+
+        # Build config parameters, excluding None values for optional fields
+        config_params = {
+            "name": name,
+            "group_by_fields": group_by_fields,
+            "aggregations": aggregations,
+            "custom_aggregations": custom_aggregations,
+            "chunk_size": chunk_size,
+            "use_dask": use_dask,
+            "npartitions": npartitions,
+            "use_cache": use_cache,
+            "use_encryption": use_encryption,
+            "encryption_key": encryption_key,
+            "visualization_theme": visualization_theme,
+            "visualization_backend": visualization_backend,
+            "visualization_strict": visualization_strict,
+            "visualization_timeout": visualization_timeout,
+            "output_format": output_format,
+        }
+
+        # Create configuration and validate parameters
+        config = AggregateRecordsOperationConfig(**config_params)
 
         # Call base class constructor
         super().__init__(
-            name=self.name,
-            use_cache=self.use_cache,
-            use_dask=self.use_dask,
-            use_encryption=self.use_encryption,
-            encryption_key=self.encryption_key,
-            description=self.description,
-            output_format=self.output_format,
+            name=config.get("name"),
+            chunk_size=config.get("chunk_size"),
+            use_dask=config.get("use_dask"),
+            npartitions=config.get("npartitions"),
+            use_cache=config.get("use_cache"),
+            use_encryption=config.get("use_encryption"),
+            encryption_key=config.get("encryption_key"),
+            visualization_backend=config.get("visualization_backend"),
+            visualization_theme=config.get("visualization_theme"),
+            visualization_strict=config.get("visualization_strict"),
+            visualization_timeout=config.get("visualization_timeout"),
+            output_format=config.get("output_format"),
+            description=description,
+            encryption_mode=encryption_mode,
         )
 
-        # Build and validate configuration
-        config = AggregateRecordsOperationConfig(
-            group_by_fields=self.group_by_fields,
-            aggregations=self.aggregations or {},
-            custom_aggregations=self.custom_aggregations or {},
-            output_format=self.output_format,
-            use_cache=self.use_cache,
-            use_encryption=self.use_encryption,
-            encryption_key=self.encryption_key,
-            use_dask=self.use_dask,
-        )
-        self.config = config  # Optionally store the config
+        # Assign instance properties from config
+        for key, value in config_params.items():
+            setattr(self, key, value)
 
-        # Use default description if not provided
-        if not self.description:
-            self.description = f"Aggregating records by {self.group_by_fields}."
+        # Optionally store the config
+        self.config = config
+
+        # Set up performance tracking variables
+        self.start_time = None
+        self.end_time = None
+        self.process_count = 0
+
+        # Set up common variables
+        self.force_recalculation = False  # Skip cache check
+        self.generate_visualization = True  # Create visualizations
+        self.encrypt_output = False  # Override encryption setting
+        self.save_output = True  # Save processed data to output directory
+
+        # Updated version for fixes
+        self.version = "1.4.1"
+        self.operation_name = self.__class__.__name__
 
         # Temporary storage for cleanup
-        self._temp_data = None
         self.operation_cache = None
 
     def execute(
@@ -212,19 +269,30 @@ class AggregateRecordsOperation(TransformationOperation):
         **kwargs : dict
             Additional parameters for the operation including:
             - force_recalculation: bool - Skip cache check
+            - generate_visualization: bool - Create visualizations
             - encrypt_output: bool - Override encryption setting
-
+            - save_output: bool - Save processed data to output directory
+            - visualization_theme: str - Override theme for visualizations
+            - visualization_backend: str - Override backend for visualizations
+            - visualization_strict: bool - Override strict mode for visualizations
+            - visualization_timeout: int - Override timeout for visualizations
         Returns:
         --------
         OperationResult
             Results of the operation
         """
         try:
+            # Config logger task for operatiions
+            self.logger = kwargs.get("logger", self.logger)
+
             # Initialize timing and result
             self.start_time = time.time()
+            self.logger.info(
+                f"Starting {self.operation_name} operation at {self.start_time}"
+            )
             self.process_count = 0
+            df = None
             result = OperationResult(status=OperationStatus.PENDING)
-            encryption_key = kwargs.get('encryption_key', None)
 
             # Prepare directories for artifacts
             directories = self._prepare_directories(task_dir)
@@ -236,39 +304,70 @@ class AggregateRecordsOperation(TransformationOperation):
 
             # Create DataWriter for consistent file operations
             writer = DataWriter(
-                task_dir=task_dir, logger=logger, progress_tracker=progress_tracker
+                task_dir=task_dir, logger=self.logger, progress_tracker=progress_tracker
             )
 
             # Save configuration to task directory
             self.save_config(task_dir)
 
-            # Set up progress tracking
-            # Preparation, Validation, Data Loading, Processing, Metrics, Finalization
-            force_recalculation = kwargs.get("force_recalculation", False)
-            total_steps = 6 + (1 if self.use_cache and not force_recalculation else 0)
-            current_steps = 0
-            # Step 1: Preparation progress tracker
-            if progress_tracker:
-                current_steps += 1
-                self._update_progress_tracker(
-                    total_steps, current_steps, "Preparation", progress_tracker
-                )
-
             # Decompose kwargs and introduce variables for clarity
-            is_encryption_required = (
+            self.encrypt_output = (
                 kwargs.get("encrypt_output", False) or self.use_encryption
             )
-            use_dask = kwargs.get("use_dask", self.use_dask)
-            generate_visualization = kwargs.get("generate_visualization", True)
-            include_timestamp_in_filenames = kwargs.get("include_timestamp", True)
-            save_output = kwargs.get("save_output", True)
+            self.generate_visualization = kwargs.get("generate_visualization", True)
+            self.save_output = kwargs.get("save_output", True)
+            self.force_recalculation = kwargs.get("force_recalculation", False)
+
+            # Extract visualization parameters
+            self.visualization_theme = kwargs.get(
+                "visualization_theme", self.visualization_theme
+            )
+            self.visualization_backend = kwargs.get(
+                "visualization_backend", self.visualization_backend
+            )
+            self.visualization_strict = kwargs.get(
+                "visualization_strict", self.visualization_strict
+            )
+            self.visualization_timeout = kwargs.get(
+                "visualization_timeout", self.visualization_timeout
+            )
+
+            # Dataset name
             dataset_name = kwargs.get("dataset_name", "main")
 
-            # Step 2: Validation progress tracker
-            if progress_tracker:
+            self.logger.info(
+                f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+            )
+
+            # Set up progress tracking with proper steps
+            # Main steps: 1. Validation, 2. Cache check, 3. Data loading, 4. Processing, 5. Metrics, 6. Visualization, 7. Save output
+            TOTAL_MAIN_STEPS = 6 + (
+                1 if self.use_cache and not self.force_recalculation else 0
+            )
+            main_progress = progress_tracker
+            current_steps = 0
+            if main_progress:
+                self.logger.info(
+                    f"Setting up progress tracker with {TOTAL_MAIN_STEPS} main steps"
+                )
+                try:
+                    main_progress.total = TOTAL_MAIN_STEPS
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS,
+                        current_steps,
+                        {
+                            "step": "Starting aggregation data",
+                        },
+                        main_progress,
+                    )
+                except Exception as e:
+                    self.logger.warning(f"Could not update progress tracker: {e}")
+
+            # Step 1: Validation progress tracker
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Validation", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Validation", main_progress
                 )
 
             # Validate input parameters
@@ -276,15 +375,17 @@ class AggregateRecordsOperation(TransformationOperation):
                 self.group_by_fields, self.aggregations, self.custom_aggregations
             )
 
-            # Step 3: Loading progress tracker
-            if progress_tracker:
+            # Step 2: Loading progress tracker
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Data Loading", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Data Loading", main_progress
                 )
 
             # Loading datasets
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+            settings_operation = load_settings_operation(
+                data_source, dataset_name, **kwargs
+            )
             df = load_data_operation(data_source, dataset_name, **settings_operation)
             if df is None:
                 return OperationResult(
@@ -293,49 +394,56 @@ class AggregateRecordsOperation(TransformationOperation):
                 )
 
             # Check Cache (if enabled and not forced to recalculate)
-            if self.use_cache and not force_recalculation:
-                if progress_tracker:
+            if self.use_cache and not self.force_recalculation:
+                # Step 3: Check if we have a cached result
+                if main_progress:
                     current_steps += 1
                     self._update_progress_tracker(
-                        total_steps, current_steps, "Checking cache", progress_tracker
+                        TOTAL_MAIN_STEPS, current_steps, "Checking cache", main_progress
                     )
 
                 self.logger.info("Checking operation cache...")
-                cache_result = self._check_cache(df)
+                cache_result = self._check_cache(df=df, reporter=reporter)
                 if cache_result:
                     self.logger.info("Cache hit! Using cached results.")
 
                     # Update progress
-                    if progress_tracker:
+                    if main_progress:
                         self._update_progress_tracker(
-                            total_steps,
+                            TOTAL_MAIN_STEPS,
                             current_steps,
                             "Complete (cached)",
-                            progress_tracker,
-                        )
-
-                    # Report cache hit to reporter
-                    if reporter:
-                        reporter.add_operation(
-                            f"Transformation of {self.name} (from cache)",
-                            details={
-                                "cached": True,
-                                "group_by": self.group_by_fields,
-                                "aggregations": self.aggregations,
-                                "custom_aggregations": self.custom_aggregations,
-                            },
+                            main_progress,
                         )
 
                     return cache_result
 
             # Step 4: Processing progress tracker
-            if progress_tracker:
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Processing", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Processing data", main_progress
                 )
 
             try:
+                self.logger.info(
+                    f"Processing with group_by_fields: {self.group_by_fields}"
+                )
+
+                # Create child progress tracker for chunk processing
+                data_tracker = None
+                if main_progress and hasattr(main_progress, "create_subtask"):
+                    try:
+                        data_tracker = main_progress.create_subtask(
+                            total=3,
+                            description="Aggregation processing",
+                            unit="steps",
+                        )
+                    except Exception as e:
+                        self.logger.debug(
+                            f"Could not create child progress tracker: {e}"
+                        )
+
                 # Process the data with the selected strategy
                 self.process_count = len(df)
                 processed_df = aggregate_dataframe(
@@ -343,8 +451,29 @@ class AggregateRecordsOperation(TransformationOperation):
                     group_by_fields=self.group_by_fields,
                     aggregations=self.aggregations,
                     custom_aggregations=self.custom_aggregations,
-                    use_dask=use_dask,
+                    chunk_size=self.chunk_size,
+                    use_dask=self.use_dask,
+                    npartitions=self.npartitions,
+                    progress_tracker=data_tracker,
+                    task_logger=self.logger,
                 )
+
+                # Close child progress tracker
+                if data_tracker:
+                    try:
+                        data_tracker.close()
+                    except:
+                        pass
+
+                self.logger.info(
+                    f"Processed data: {len(processed_df)} records, dtype: {processed_df.dtypes}"
+                )
+
+                # Log sample of processed data
+                if len(processed_df) > 0:
+                    self.logger.debug(
+                        f"Sample of processed data (first 5 rows): {processed_df.head(5).to_dict(orient='records')}"
+                    )
             except Exception as e:
                 error_message = f"Processing error: {str(e)}"
                 self.logger.error(error_message)
@@ -353,14 +482,20 @@ class AggregateRecordsOperation(TransformationOperation):
                 )
 
             # Step 5: Metrics Calculation
-            if progress_tracker:
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Metrics Calculation", progress_tracker
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Metrics Calculation",
+                    main_progress,
                 )
 
-            # Collect final metrics before using them
+            # Record end time after processing
             self.end_time = time.time()
+
+            # Generate single timestamp for all artifacts
+            operation_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
             # Initialize metrics in scope
             metrics = {}
@@ -368,96 +503,103 @@ class AggregateRecordsOperation(TransformationOperation):
             try:
                 metrics = self._collect_metrics(df=df, processed_df=processed_df)
 
-                # Save metrics using writer
+                # Generate metrics file name
+                metrics_file_name = f"{self.name}_metrics_{operation_timestamp}"
+
+                # Write metrics to persistent storage/artifact repository
                 metrics_result = writer.write_metrics(
                     metrics=metrics,
-                    name=f"{self.name}_metrics",
-                    timestamp_in_name=True,
+                    name=metrics_file_name,
+                    timestamp_in_name=False,
                     encryption_key=(
-                        self.encryption_key if is_encryption_required else None
+                        self.encryption_key if self.encrypt_output else None
                     ),
                 )
 
-                # Add metrics to result
+                # Add simple metrics (int, float, str, bool) to the result object
                 for key, value in metrics.items():
                     if isinstance(value, (int, float, str, bool)):
                         result.add_metric(key, value)
 
-                # Register metrics artifact
+                # Register the metrics artifact for tracking and visualization
                 result.add_artifact(
                     artifact_type="json",
                     path=metrics_result.path,
-                    description=f"{self.name} metrics",
-                    category=Constants.Artifact_Category_Metrics
+                    description=f"Aggregation on {self.group_by_fields} — datasets transformation metrics",
+                    category=Constants.Artifact_Category_Metrics,
                 )
 
-                # Report artifact
+                # Report the metrics artifact to the reporter if available
                 if reporter:
-                    reporter.add_artifact(
-                        "json",
-                        str(metrics_result.path),
-                        f"{self.name} metrics",
+                    reporter.add_operation(
+                        f"Aggregation on {self.group_by_fields} — datasets transformation metrics",
+                        details={"type": "json", "path": str(metrics_result.path)},
                     )
             except Exception as e:
                 error_message = f"Error calculating metrics: {str(e)}"
                 self.logger.warning(error_message)
                 # Continue execution - metrics failure is not critical
 
-            # Step 6: Finalization (Visualizations and Output Data)
-            if progress_tracker:
+            # Step 6: Visualizations
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Finalization", progress_tracker
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Generating Visualizations",
+                    main_progress,
                 )
-
             # Generate visualizations if required
-            if generate_visualization:
+            # Initialize visualization paths dictionary
+            visualization_paths = {}
+            if self.generate_visualization and self.visualization_backend is not None:
                 try:
                     kwargs_encryption = {
-                        "use_encryption": kwargs.get('use_encryption', False),
-                        "encryption_key": encryption_key
+                        "use_encryption": self.encrypt_output,
+                        "encryption_key": self.encryption_key,
                     }
-                    visualization_paths = self._generate_visualizations(
-                        df=df,
+                    visualization_paths = self._handle_visualizations(
+                        original_df=df,
                         processed_df=processed_df,
                         task_dir=task_dir,
                         result=result,
                         reporter=reporter,
-                        **kwargs_encryption
+                        progress_tracker=main_progress,
+                        vis_theme=self.visualization_theme,
+                        vis_backend=self.visualization_backend,
+                        vis_strict=self.visualization_strict,
+                        vis_timeout=self.visualization_timeout,
+                        operation_timestamp=operation_timestamp,
+                        **kwargs_encryption,
                     )
-
-                    # Register visualization artifacts and report
-                    for viz_type, path in visualization_paths.items():
-                        result.add_artifact(
-                            artifact_type="png",
-                            path=path,
-                            description=f"{self.name} {viz_type} visualization",
-                            category=Constants.Artifact_Category_Visualization
-                        )
-
-                        if reporter:
-                            reporter.add_operation(
-                                f"{self.name} {viz_type} visualization",
-                                details={"type": "png", "path": str(path)},
-                            )
-
                 except Exception as e:
                     error_message = f"Error generating visualizations: {str(e)}"
                     self.logger.warning(error_message)
                     # Continue execution - visualization failure is not critical
+            else:
+                self.logger.info(
+                    "Skipping visualizations as generate_visualization is False or backend is not set"
+                )
+
+            # Step 7: Save Output Data
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Save Output Data", main_progress
+                )
 
             # Save output data if required
-            if save_output:
+            if self.save_output:
                 try:
-                    self._save_output_data(
+                    output_result_path = self._save_output_data(
                         result_df=processed_df,
                         task_dir=task_dir,
-                        include_timestamp_in_filenames=include_timestamp_in_filenames,
-                        is_encryption_required=is_encryption_required,
+                        is_encryption_required=self.encrypt_output,
                         writer=writer,
                         result=result,
                         reporter=reporter,
-                        progress_tracker=progress_tracker,
+                        progress_tracker=main_progress,
+                        timestamp=operation_timestamp,
                         **kwargs,
                     )
                 except Exception as e:
@@ -473,12 +615,18 @@ class AggregateRecordsOperation(TransformationOperation):
                     self._save_to_cache(
                         original_data=df,
                         transformed_data=processed_df,
-                        task_dir=task_dir,
                         metrics=metrics,
+                        visualization_paths=visualization_paths,
+                        metrics_result_path=str(metrics_result.path),
+                        output_result_path=output_result_path,
+                        task_dir=task_dir,
                     )
                 except Exception as e:
                     # Failure to cache is non-critical
                     self.logger.warning(f"Failed to cache results: {str(e)}")
+
+            # Cleanup memory
+            self._cleanup_memory(processed_df, df)
 
             # Report completion
             if reporter:
@@ -498,8 +646,9 @@ class AggregateRecordsOperation(TransformationOperation):
                     details=details,
                 )
 
-            # Cleanup memory
-            self._cleanup_memory(processed_df, df)
+            self.logger.info(
+                f"Processing completed {self.operation_name} operation in {self.end_time - self.start_time:.2f} seconds"
+            )
 
             # Set success status
             result.status = OperationStatus.SUCCESS
@@ -517,7 +666,7 @@ class AggregateRecordsOperation(TransformationOperation):
         """
         Deprecated: No longer used for merging. All merging is now performed in a single step.
         """
-        logger.warning(
+        self.logger.warning(
             "process_batch is deprecated and not used for merging. All merging is performed in a single step."
         )
         return batch_df
@@ -526,7 +675,7 @@ class AggregateRecordsOperation(TransformationOperation):
         """
         Deprecated in batch mode. Not used in ML imputation anymore.
         """
-        logger.warning(
+        self.logger.warning(
             "_process_value is deprecated and not used in ML-based batch processing."
         )
         return value
@@ -543,8 +692,6 @@ class AggregateRecordsOperation(TransformationOperation):
         ----------
         df : pd.DataFrame
             The original DataFrame used in the transformation (e.g., the batch).
-        processed_df : pd.DataFrame
-            The original right DataFrame used for joining with the left_df.
         processed_df : pd.DataFrame
             The resulting DataFrame after processing (e.g., after merge/join operation).
 
@@ -678,52 +825,322 @@ class AggregateRecordsOperation(TransformationOperation):
             Strategy-specific parameters for cache key generation
         """
         params = {
-            "version": self.version,  # Include version for cache invalidation
+            "group_by_fields": self.group_by_fields,
+            "aggregations": self.aggregations,
+            "custom_aggregations": self.custom_aggregations,
+            "chunk_size": self.chunk_size,
+            "use_dask": self.use_dask,
+            "npartitions": self.npartitions,
+            "use_cache": self.use_cache,
+            "use_encryption": self.use_encryption,
+            "encryption_key": self.encryption_key,
+            "visualization_theme": self.visualization_theme,
+            "visualization_backend": self.visualization_backend,
+            "visualization_strict": self.visualization_strict,
+            "visualization_timeout": self.visualization_timeout,
+            "output_format": self.output_format,
+            "force_recalculation": self.force_recalculation,
+            "generate_visualization": self.generate_visualization,
+            "encrypt_output": self.encrypt_output,
+            "save_output": self.save_output,
         }
 
         return params
 
-    def _generate_visualizations(
+    def _handle_visualizations(
         self,
-        df: pd.DataFrame,
+        original_df: pd.DataFrame,
         processed_df: pd.DataFrame,
         task_dir: Path,
         result: OperationResult,
-        reporter: Any = None,
-        **kwargs
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        vis_timeout: int = 120,
+        operation_timestamp: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Generate and save visualizations with thread-safe context support.
+
+        Parameters:
+        -----------
+        original_df : pd.DataFrame
+            The original DataFrame before transformation
+        processed_df : pd.DataFrame
+            The transformed DataFrame after processing
+        task_dir : Path
+            The task directory
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        operation_timestamp : str, optional
+            Timestamp for the operation (default: current time)
+        **kwargs: Any
+            Additional keyword arguments for visualization functions.
+        """
+        self.logger.info(
+            f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s"
+        )
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(
+                    f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}"
+                )
+                self.logger.info(
+                    f"[DIAG] Field: {self.group_by_fields}, Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+                )
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(
+                            f"[DIAG] Context vars count: {len(list(current_context))}"
+                        )
+                    except Exception as ctx_e:
+                        self.logger.warning(
+                            f"[DIAG] Could not inspect context: {ctx_e}"
+                        )
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(
+                                f"Could not create child progress tracker: {e}"
+                            )
+
+                    # Generate visualizations with context parameters
+                    visualization_paths = self._generate_visualizations(
+                        original_df=original_df,
+                        processed_df=processed_df,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend or "plotly",
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        timestamp=operation_timestamp,  # Pass the same timestamp
+                        **kwargs,
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(
+                        f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}"
+                    )
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-{self.field_name}",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(
+                f"[DIAG] Starting visualization thread with timeout={vis_timeout}s"
+            )
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(
+                        f"[DIAG] Visualization thread still running after {elapsed:.1f}s..."
+                    )
+
+            if viz_thread.is_alive():
+                self.logger.error(
+                    f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout"
+                )
+                self.logger.error(
+                    f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}"
+                )
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(
+                    f"[DIAG] Visualization failed with error: {visualization_error}"
+                )
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(
+                    f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s"
+                )
+                self.logger.info(
+                    f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}"
+                )
+
+        except Exception as e:
+            self.logger.error(
+                f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}"
+            )
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{self.field_name} {viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization,
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_operation(
+                    f"{self.field_name} {viz_type} visualization",
+                    details={"artifact_type": "png", "path": str(path)},
+                )
+
+        return visualization_paths
+
+    def _generate_visualizations(
+        self,
+        original_df: pd.DataFrame,
+        processed_df: pd.DataFrame,
+        task_dir: Path,
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        timestamp: Optional[str] = None,
+        **kwargs,
     ) -> dict:
         """
-        Generate required visualizations for the merge operation using visualization utilities.
+        Generate required visualizations for the aggregation operation using visualization utilities.
 
         Parameters
         ----------
-        df : pd.DataFrame
-            The left input DataFrame used in the merge operation.
+        original_df : pd.DataFrame
+            The original DataFrame used in the aggregation operation.
         processed_df : pd.DataFrame
-            The right input DataFrame used in the merge operation.
+            The processed DataFrame used in the aggregation operation.
         task_dir : Path
             The base directory where all task-related outputs (including visualizations) will be saved.
-        result : OperationResult
-            An object representing the result of the merge operation, potentially containing metadata and statistics.
-        reporter : Any, optional
-            Optional reporter instance used for logging, tracking, or debugging the visualization process.
+        vis_theme : Optional[str]
+            The theme to use for visualizations.
+        vis_backend : Optional[str]
+            The backend to use for rendering visualizations.
+        vis_strict : bool
+            Whether to enforce strict visualization rules.
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Tracker for monitoring progress of the visualization generation.
+        timestamp : Optional[str]
+            Timestamp to include in visualization filenames.
+        **kwargs : Any
+            Additional keyword arguments for visualization functions.
 
         Returns
         -------
         """
         viz_dir = task_dir / "visualizations"
         viz_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         visualization_paths = {}
 
+        # Use provided timestamp or generate new one
+        if timestamp is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(
+                f"Skipping visualization for {self.group_by_fields} (backend=None)"
+            )
+            return visualization_paths
+
+        self.logger.info(
+            f"[VIZ] Starting visualization generation for {self.group_by_fields}"
+        )
+        self.logger.debug(
+            f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+        )
+
         try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
             # Sample large datasets for visualization
-            if len(df) > 10000:
-                df_viz = sample_large_dataset(df, max_samples=10000)
+            if len(original_df) > 10000:
+                self.logger.info(
+                    f"[VIZ] Sampling large dataset: {len(original_df)} -> 10000 samples"
+                )
+                original_viz = sample_large_dataset(original_df, max_samples=10000)
                 aggrega_viz = sample_large_dataset(processed_df, max_samples=10000)
             else:
-                df_viz = df
+                original_viz = original_df
                 aggrega_viz = processed_df
+
+            self.logger.debug(
+                f"[VIZ] Data prepared for visualization: {len(original_viz)} samples"
+            )
+
+            # Step 2: Create visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Creating visualization"})
 
             # Create visualizations
             # 1. Bar chart: record count per group
@@ -735,7 +1152,10 @@ class AggregateRecordsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    **kwargs,
                 )
             )
 
@@ -750,7 +1170,10 @@ class AggregateRecordsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    **kwargs,
                 )
             )
 
@@ -763,27 +1186,33 @@ class AggregateRecordsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    **kwargs,
                 )
             )
 
+            # Step 3: Finalize visualizations
+            if progress_tracker:
+                progress_tracker.update(3, {"step": "Finalizing visualizations"})
+
         except Exception as e:
-            logger.warning(f"Error creating visualizations: {e}")
+            self.logger.warning(f"Error creating visualizations: {e}")
 
         return visualization_paths
 
     def _save_output_data(
         self,
         result_df: pd.DataFrame,
-        task_dir: Path,
-        include_timestamp_in_filenames: bool,
         is_encryption_required: bool,
         writer: DataWriter,
         result: OperationResult,
         reporter: Any,
         progress_tracker: Optional[HierarchicalProgressTracker],
+        timestamp: Optional[str] = None,
         **kwargs,
-    ) -> None:
+    ) -> str:
         """
         Save the processed output data.
 
@@ -791,10 +1220,6 @@ class AggregateRecordsOperation(TransformationOperation):
         -----------
         result_df : pd.DataFrame
             The processed dataframe to save
-        task_dir : Path
-            Task directory for saving output
-        include_timestamp_in_filenames : bool
-            Whether to include a timestamp in the filename
         is_encryption_required : bool
             Whether to encrypt the output
         writer : DataWriter
@@ -805,19 +1230,24 @@ class AggregateRecordsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+        timestamp : Optional[str]
+            Optional timestamp for the output file
         **kwargs : dict
             Additional parameters for the operation
         """
         if progress_tracker:
             progress_tracker.update(0, {"step": "Saving output data"})
 
-        custom_kwargs = {k: v for k, v in kwargs.items() if k != 'encryption_key'}
+        # Generate standardized output filename with timestamp
+        field_name_output = f"{self.name}_output_{timestamp}"
+
+        custom_kwargs = self._get_custom_kwargs(result_df, **kwargs)
         output_result = writer.write_dataframe(
             df=result_df,
-            name=f"{self.name}_transformed",
+            name=field_name_output,
             format=self.output_format,
             subdir="output",
-            timestamp_in_name=include_timestamp_in_filenames,
+            timestamp_in_name=False,
             encryption_key=self.encryption_key if is_encryption_required else None,
             **custom_kwargs,
         )
@@ -827,7 +1257,7 @@ class AggregateRecordsOperation(TransformationOperation):
             artifact_type=self.output_format,
             path=output_result.path,
             description=f"{self.name} transformed data",
-            category=Constants.Artifact_Category_Output
+            category=Constants.Artifact_Category_Output,
         )
 
         # Report to reporter
@@ -837,6 +1267,8 @@ class AggregateRecordsOperation(TransformationOperation):
                 str(output_result.path),
                 f"{self.name} transformed data",
             )
+
+        return str(output_result.path)
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
@@ -886,8 +1318,6 @@ class AggregateRecordsOperation(TransformationOperation):
         df : pd.DataFrame, optional
             Original DataFrame to clear from memory
         """
-        import gc
-
         # Clear argument references
         if processed_df is not None:
             try:
@@ -901,10 +1331,6 @@ class AggregateRecordsOperation(TransformationOperation):
             except Exception:
                 pass
 
-        # Clear instance attribute references
-        if hasattr(self, "_temp_data"):
-            self._temp_data = None
-
         # Clear operation cache
         if hasattr(self, "operation_cache"):
             self.operation_cache = None
@@ -914,8 +1340,10 @@ class AggregateRecordsOperation(TransformationOperation):
             if attr_name.startswith("_temp_"):
                 setattr(self, attr_name, None)
 
-        # Force garbage collection
-        gc.collect()
+        # Optional: Force garbage collection for large datasets
+        # Uncomment if memory pressure is an issue
+        # import gc
+        # gc.collect()
 
     def _validate_input_params(
         self,
@@ -962,7 +1390,9 @@ class AggregateRecordsOperation(TransformationOperation):
                             f"Allowed: {sorted(allowed_aggs)}"
                         )
 
-    def _check_cache(self, df: pd.DataFrame) -> Optional[OperationResult]:
+    def _check_cache(
+        self, df: pd.DataFrame, reporter: Any
+    ) -> Optional[OperationResult]:
         """
         Check if a cached result exists for this operation.
 
@@ -970,67 +1400,188 @@ class AggregateRecordsOperation(TransformationOperation):
         -----------
         df : pd.DataFrame
             DataFrame to check in the cache
+        reporter : Any
+            Reporter to log cache hits/misses
 
         Returns:
         --------
         Optional[OperationResult]
-                Cached result if found, None otherwise
+            Cached result if found, None otherwise
         """
         if not self.use_cache:
             return None
 
         try:
-            if not self.group_by_fields:
-                # Use entire DataFrame or selected columns for cache key
-                cache_key = self._generate_cache_key(df)
-            else:
-                for field in self.group_by_fields:
-                    if field not in df.columns:
-                        logger.warning(
-                            f"Field '{field}' not found in DataFrame columns."
-                        )
-                        return None
-                cache_key = self._generate_cache_key(df[self.group_by_fields])
+            # Create cache key from entire dataframe or from group_by_fields if present
+            if self.group_by_fields and not all(
+                field in df.columns for field in self.group_by_fields
+            ):
+                missing = [f for f in self.group_by_fields if f not in df.columns]
+                self.logger.warning(f"Missing fields for cache key: {missing}")
+                return None
 
-            logger.debug(f"Checking cache for key: {cache_key}")
-            cached_data = self.operation_cache.get_cache(
-                cache_key=cache_key, operation_type=self.__class__.__name__
+            cache_df = df[self.group_by_fields] if self.group_by_fields else df
+            cache_key = self._generate_cache_key(cache_df)
+
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+            cached_result = self.operation_cache.get_cache(
+                cache_key=cache_key, operation_type=self.operation_name
             )
 
-            if cached_data:
-                logger.info(
-                    f"Cache hit for {self.group_by_fields} transformation operation"
+            if not cached_result:
+                self.logger.info("No cached result found, proceeding with operation")
+                return None
+
+            self.logger.info(
+                f"Using cached result for {self.group_by_fields} transformation"
+            )
+
+            result = OperationResult(status=OperationStatus.SUCCESS)
+            self._add_cached_metrics(result, cached_result)
+            artifacts_restored = self._restore_cached_artifacts(
+                result, cached_result, reporter
+            )
+
+            result.add_metric("cached", True)
+            result.add_metric("cache_key", cache_key)
+            result.add_metric(
+                "cache_timestamp", cached_result.get("timestamp", "unknown")
+            )
+            result.add_metric("artifacts_restored", artifacts_restored)
+
+            # Report cache hit to reporter
+            if reporter:
+                reporter.add_operation(
+                    f"Aggregate records transformation of {self.group_by_fields} (cached)",
+                    details={
+                        "cached": True,
+                        "group_by_fields": self.group_by_fields,
+                        "artifacts_restored": artifacts_restored,
+                    },
                 )
 
-                result = OperationResult(status=OperationStatus.SUCCESS)
-
-                metrics = cached_data.get("metrics", {})
-                if isinstance(metrics, dict):
-                    for key, value in metrics.items():
-                        if isinstance(value, (int, float, str, bool)):
-                            result.add_metric(key, value)
-
-                result.add_metric("cached", True)
-                result.add_metric("cache_key", cache_key)
-                result.add_metric(
-                    "cache_timestamp", cached_data.get("timestamp", "unknown")
-                )
-
-                return result
-
-            logger.debug(f"No cache found for key: {cache_key}")
-            return None
+            self.logger.info(
+                f"Cache hit successful: restored {artifacts_restored} artifacts"
+            )
+            return result
 
         except Exception as e:
-            logger.warning(f"Error checking cache: {str(e)}")
+            self.logger.warning(f"Error checking cache: {str(e)}")
             return None
+
+    def _add_cached_metrics(self, result: OperationResult, cached: dict):
+        """
+        Add cached scalar metrics (int, float, str, bool) to the OperationResult.
+
+        Parameters
+        ----------
+        result : OperationResult
+            The result object to update.
+        cached : dict
+            Cached result dictionary from cache manager.
+        """
+        for key, value in cached.get("metrics", {}).items():
+            if isinstance(value, (int, float, str, bool)):
+                result.add_metric(key, value)
+
+    def _restore_cached_artifacts(
+        self, result: OperationResult, cached: dict, reporter: Optional[Any]
+    ) -> int:
+        """
+        Restore artifacts (output, metrics, visualizations) from cached result if files exist.
+
+        Parameters
+        ----------
+        result : OperationResult
+            OperationResult object to update with restored artifacts.
+        cached : dict
+            Cached result dictionary from cache manager.
+        reporter : Optional[Any]
+            Optional reporter object for tracking operation-level artifacts.
+
+        Returns
+        -------
+        int
+            Number of artifacts successfully restored.
+        """
+        artifacts_restored = 0
+
+        def restore_file_artifact(
+            path: Union[str, Path], artifact_type: str, desc_suffix: str, category: str
+        ):
+            """
+            Restore a single artifact from a file path if it exists.
+
+            Parameters
+            ----------
+            path : Union[str, Path]
+                Path to the artifact file.
+            artifact_type : str
+                Type of the artifact (e.g., 'json', 'csv', 'png').
+            desc_suffix : str
+                Description suffix (e.g., 'visualization', 'metrics').
+            category : str
+                Artifact category (e.g., output, metrics, visualization).
+            """
+            nonlocal artifacts_restored
+            if not path:
+                return
+
+            artifact_path = Path(path)
+            if artifact_path.exists():
+                result.add_artifact(
+                    artifact_type=artifact_type,
+                    path=artifact_path,
+                    description=f"{self.name} {desc_suffix} (cached)",
+                    category=category,
+                )
+                artifacts_restored += 1
+
+                if reporter:
+                    reporter.add_operation(
+                        f"{self.name} {desc_suffix} (cached)",
+                        details={
+                            "artifact_type": artifact_type,
+                            "path": str(artifact_path),
+                        },
+                    )
+            else:
+                self.logger.warning(f"Cached file not found: {artifact_path}")
+
+        # Restore main output and metrics artifacts
+        restore_file_artifact(
+            cached.get("output_file"),
+            self.output_format,
+            "transformed data",
+            Constants.Artifact_Category_Output,
+        )
+        restore_file_artifact(
+            cached.get("metrics_file"),
+            "json",
+            "transformation metrics",
+            Constants.Artifact_Category_Metrics,
+        )
+
+        # Restore visualizations
+        for viz_type, path_str in cached.get("visualizations", {}).items():
+            restore_file_artifact(
+                path_str,
+                "png",
+                f"{viz_type} visualization",
+                Constants.Artifact_Category_Visualization,
+            )
+
+        return artifacts_restored
 
     def _save_to_cache(
         self,
         original_data: Union[pd.Series, pd.DataFrame],
         transformed_data: Union[pd.Series, pd.DataFrame],
+        metrics: Dict[str, Any],
+        visualization_paths: Dict[str, Path],
         task_dir: Path,
-        metrics: Dict[str, Any] = None,
+        metrics_result_path: Optional[str] = "",
+        output_result_path: Optional[str] = "",
     ) -> bool:
         """
         Save operation results to cache.
@@ -1041,10 +1592,18 @@ class AggregateRecordsOperation(TransformationOperation):
             Original input data
         transformed_data : pd.Series or pd.DataFrame
             Transformed output data
+        metrics : Dict[str, Any]
+            Metrics collected during the operation
+        visualization_paths : Dict[str, Path]
+            Paths to generated visualizations
         task_dir : Path
             Task directory
-        metrics : Dict[str, Any], optional
-            Metrics dictionary (default is None)
+        metrics_result_path : Optional[str]
+            Path to the metrics result file
+            If not provided, a default path will be used.
+        output_result_path : Optional[str]
+            Path to the output result file
+            If not provided, a default path will be used.
 
         Returns:
         --------
@@ -1072,21 +1631,16 @@ class AggregateRecordsOperation(TransformationOperation):
                 cache_key = self._generate_cache_key(original_data)
 
             # Prepare metadata for cache
-            operation_params = self._get_cache_parameters()
-            operation_params.update(
-                {
-                    "operation_class": self.__class__.__name__,
-                    "version": self.version,
-                    "group_by_fields": self.group_by_fields,
-                    "aggregations": self.aggregations,
-                    "custom_aggregations": self.custom_aggregations,
-                }
-            )
+            operation_params = self._get_basic_parameters()
+            operation_params.update(self._get_cache_parameters())
 
             # Prepare cache data
             cache_data = {
                 "timestamp": datetime.now().isoformat(),
-                "metrics": metrics,
+                "metrics": {
+                    k: float(v) if isinstance(v, (np.integer, np.floating)) else v
+                    for k, v in metrics.items()
+                },
                 "parameters": operation_params,
                 "data_info": {
                     "original_length": len(original_data),
@@ -1102,33 +1656,40 @@ class AggregateRecordsOperation(TransformationOperation):
                         else transformed_data.isna().sum()
                     ),
                 },
+                "output_file": output_result_path,  # Path to main output file
+                "metrics_file": metrics_result_path,  # Path to metrics file
+                "visualizations": {
+                    k: str(v) for k, v in visualization_paths.items()
+                },  # Paths to visualizations
             }
 
             # Save to cache
-            logger.debug(f"Saving to cache with key: {cache_key}")
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
             success = self.operation_cache.save_cache(
                 data=cache_data,
                 cache_key=cache_key,
-                operation_type=self.__class__.__name__,
+                operation_type=self.operation_name,
                 metadata={"task_dir": str(task_dir)},
             )
 
             if success:
-                logger.info(
+                self.logger.info(
                     f"Successfully saved {self.name} operation results to cache"
                 )
             else:
-                logger.warning(f"Failed to save {self.name} operation results to cache")
+                self.logger.warning(
+                    f"Failed to save {self.name} operation results to cache"
+                )
 
             return success
 
         except Exception as e:
-            logger.warning(f"Error saving to cache: {str(e)}")
+            self.logger.warning(f"Error saving to cache: {str(e)}")
             return False
 
     def _update_progress_tracker(
         self,
-        total_steps: int,
+        TOTAL_MAIN_STEPS: int,
         n: int,
         step_name: str,
         progress_tracker: Optional[HierarchicalProgressTracker],
@@ -1137,7 +1698,7 @@ class AggregateRecordsOperation(TransformationOperation):
         Helper to update progress tracker for the step.
         """
         if progress_tracker:
-            progress_tracker.total = total_steps  # Ensure total steps is set
+            progress_tracker.total = TOTAL_MAIN_STEPS  # Ensure total steps is set
             progress_tracker.update(
                 n,
                 {

--- a/pamola_core/transformations/merging/merge_datasets_op.py
+++ b/pamola_core/transformations/merging/merge_datasets_op.py
@@ -27,11 +27,11 @@ Implementation follows the PAMOLA.CORE operation framework with standardized int
 for input/output, progress tracking, and result reporting.
 """
 
-import logging
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
+import numpy as np
 import pandas as pd
 from pamola_core.common.enum.relationship_type import RelationshipType
 from pamola_core.transformations.commons.processing_utils import (
@@ -56,10 +56,6 @@ from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
 from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.utils.io import load_data_operation, load_settings_operation
 from pamola_core.common.constants import Constants
-
-# Configure module logger
-logger = logging.getLogger(__name__)
-
 
 class MergeDatasetsOperationConfig(OperationConfig):
     """Configuration for MergeDatasetsOperation."""
@@ -86,11 +82,26 @@ class MergeDatasetsOperationConfig(OperationConfig):
                 "type": "string",
                 "str": ["auto", "one-to-one", "one-to-many"],
             },
-            "output_format": {"type": "string", "str": ["csv", "json", "parquet"]},
+            "chunk_size": {"type": "integer", "minimum": 1},
             "use_cache": {"type": "boolean"},
+            "use_dask": {"type": "boolean"},
+            "npartitions": {"type": ["integer", "null"]},
             "use_encryption": {"type": "boolean"},
             "encryption_key": {"type": ["string", "null"]},
-            "use_dask": {"type": "boolean"},
+            # Visualization-related properties
+            "visualization_theme": {"type": ["string", "null"]},
+            "visualization_backend": {
+                "type": ["string", "null"],
+                "enum": ["plotly", "matplotlib", None],
+            },
+            "visualization_strict": {"type": "boolean"},
+            "visualization_timeout": {"type": "integer", "minimum": 1, "default": 120},
+            # Output format properties
+            "output_format": {
+                "type": "string",
+                "enum": ["csv", "parquet", "json"],
+                "default": "csv",
+            },
         },
         "required": [
             "left_dataset_name",
@@ -124,11 +135,18 @@ class MergeDatasetsOperation(TransformationOperation):
         join_type: str = "left",
         relationship_type: str = "auto",
         suffixes: Tuple[str, str] = ("_x", "_y"),
-        output_format: str = "csv",
+        chunk_size: int = 10000,
+        use_dask: bool = False,
+        npartitions: Optional[int] = None,
         use_cache: bool = True,
         use_encryption: bool = False,
         encryption_key: Optional[Union[str, Path]] = None,
-        use_dask: bool = False,
+        visualization_theme: Optional[str] = None,
+        visualization_backend: Optional[str] = None,
+        visualization_strict: bool = False,
+        visualization_timeout: int = 120,
+        output_format: str = "csv",
+        encryption_mode: Optional[str] = None,
     ):
         """
         Initialize the merge datasets operation.
@@ -151,75 +169,114 @@ class MergeDatasetsOperation(TransformationOperation):
             Join strategy: "inner", "left", "right", or "outer".
         suffixes : Tuple[str, str]
             Column suffixes for overlapping columns.
-        output_format : str
-            Output format: "csv" or "parquet" or "json".
-        use_cache : bool
-            Enable or disable operation caching.
-        use_encryption : bool
-            Enable output encryption.
-        encryption_key : str or Path, optional
-            Key used for encryption.
-        use_dask : bool
-            Whether to use Dask for distributed computation.
         relationship_type : str, optional
             Type of relationship between datasets ('auto', 'one-to-one', 'one-to-many').
             When 'auto', the function will detect the relationship type based on key uniqueness.
+        chunk_size : int, optional
+            Chunk size for processing large datasets (default: 10000)
+        use_dask : bool, optional
+            Whether to use Dask for distributed processing (default: False)
+        npartitions : int, optional
+            Number of partitions for Dask processing (default: None)
+        use_cache : bool, optional
+            Whether to use operation caching (default: True)
+        use_encryption : bool, optional
+            Whether to encrypt output files (default: False)
+        encryption_key : str or Path, optional
+            The encryption key or path to a key file (default: None)
+        visualization_theme : str, optional
+            Theme for visualizations (default: None, uses PAMOLA default)
+        visualization_backend : str, optional
+            Backend for visualizations (default: None, uses PAMOLA default)
+        visualization_strict : bool, optional
+            Whether to enforce strict visualization rules (default: False)
+        visualization_timeout : int, optional
+            Timeout for visualization generation in seconds (default: 120)
+        output_format : str
+            Output format: "csv" or "parquet" or "json".
         """
 
-        # Assign parameters to instance variables
-        self.name = name
-        self.description = description
-        self.left_dataset_name = left_dataset_name
-        self.right_dataset_name = right_dataset_name
-        self.right_dataset_path = right_dataset_path
-        self.left_key = left_key
-        self.right_key = right_key or left_key  # Default fallback
-        self.join_type = join_type
-        self.suffixes = suffixes
-        self.output_format = output_format
-        self.use_cache = use_cache
-        self.use_encryption = use_encryption
-        self.encryption_key = encryption_key
-        self.use_dask = use_dask
-        self.relationship_type = relationship_type
+        # Use default description if not provided
+        if not description:
+            self.description = (
+                f"Merging '{left_dataset_name}' with '{right_dataset_name}' using keys."
+            )
+
+        # Normalize suffixes if None
+        suffixes = list(suffixes) if suffixes else ["_x", "_y"]
+        # Normalize right_dataset_path if None
+        right_dataset_path = str(right_dataset_path) if right_dataset_path else None
+        # Normalize right_key if None
+        right_key = right_key if right_key else left_key
+
+        # Build config parameters, excluding None values for optional fields
+        config_params = {
+            "name": name,
+            "left_dataset_name": left_dataset_name,
+            "right_dataset_name": right_dataset_name,
+            "right_dataset_path": right_dataset_path,
+            "left_key": left_key,
+            "right_key": right_key,
+            "join_type": join_type,
+            "suffixes": suffixes,
+            "relationship_type": relationship_type,
+            "chunk_size": chunk_size,
+            "use_dask": use_dask,
+            "npartitions": npartitions,
+            "use_cache": use_cache,
+            "use_encryption": use_encryption,
+            "encryption_key": encryption_key,
+            "visualization_theme": visualization_theme,
+            "visualization_backend": visualization_backend,
+            "visualization_strict": visualization_strict,
+            "visualization_timeout": visualization_timeout,
+            "output_format": output_format,
+        }
+
+        # Create configuration and validate parameters
+        config = MergeDatasetsOperationConfig(**config_params)
 
         # Call base class constructor
         super().__init__(
-            name=self.name,
-            use_cache=self.use_cache,
-            use_dask=self.use_dask,
-            use_encryption=self.use_encryption,
-            encryption_key=self.encryption_key,
-            description=self.description,
-            output_format=self.output_format,
+            name=config.get("name"),
+            chunk_size=config.get("chunk_size"),
+            use_dask=config.get("use_dask"),
+            npartitions=config.get("npartitions"),
+            use_cache=config.get("use_cache"),
+            use_encryption=config.get("use_encryption"),
+            encryption_key=config.get("encryption_key"),
+            visualization_backend=config.get("visualization_backend"),
+            visualization_theme=config.get("visualization_theme"),
+            visualization_strict=config.get("visualization_strict"),
+            visualization_timeout=config.get("visualization_timeout"),
+            output_format=config.get("output_format"),
+            description=description,
+            encryption_mode=encryption_mode
         )
 
-        # Build and validate configuration
-        config = MergeDatasetsOperationConfig(
-            left_dataset_name=self.left_dataset_name,
-            right_dataset_name=self.right_dataset_name,
-            right_dataset_path=(
-                str(self.right_dataset_path) if self.right_dataset_path else None
-            ),
-            left_key=self.left_key,
-            right_key=self.right_key,
-            join_type=self.join_type,
-            suffixes=list(self.suffixes) if self.suffixes else ["_x", "_y"],
-            relationship_type=self.relationship_type,
-            output_format=self.output_format,
-            use_cache=self.use_cache,
-            use_encryption=self.use_encryption,
-            encryption_key=self.encryption_key,
-            use_dask=self.use_dask,
-        )
-        self.config = config  # Optionally store the config
+        # Assign instance properties from config
+        for key, value in config_params.items():
+            setattr(self, key, value)
 
-        # Use default description if not provided
-        if not self.description:
-            self.description = f"Merging '{self.left_dataset_name}' with '{self.right_dataset_name}' using keys."
+        # Optionally store the config
+        self.config = config
+
+        # Set up performance tracking variables
+        self.start_time = None
+        self.end_time = None
+        self.process_count = 0
+
+        # Set up common variables
+        self.force_recalculation = False  # Skip cache check
+        self.generate_visualization = True  # Create visualizations
+        self.encrypt_output = False  # Override encryption setting
+        self.save_output = True  # Save processed data to output directory
+
+        # Updated version for fixes
+        self.version = "1.4.1"
+        self.operation_name = self.__class__.__name__
 
         # Temporary storage for cleanup
-        self._temp_data = None
         self.right_df = None
         self.operation_cache = None
 
@@ -247,8 +304,13 @@ class MergeDatasetsOperation(TransformationOperation):
         **kwargs : dict
             Additional parameters for the operation including:
             - force_recalculation: bool - Skip cache check
+            - generate_visualization: bool - Create visualizations
             - encrypt_output: bool - Override encryption setting
-
+            - save_output: bool - Save processed data to output directory
+            - visualization_theme: str - Override theme for visualizations
+            - visualization_backend: str - Override backend for visualizations
+            - visualization_strict: bool - Override strict mode for visualizations
+            - visualization_timeout: int - Override timeout for visualizations
         Returns:
         --------
         OperationResult
@@ -257,51 +319,77 @@ class MergeDatasetsOperation(TransformationOperation):
         try:
             # Initialize timing and result
             self.start_time = time.time()
+            self.logger = kwargs.get("logger", self.logger)
+            self.logger.info(
+                f"Starting {self.operation_name} operation at {self.start_time}"
+            )
             self.process_count = 0
+            left_df = None
             result = OperationResult(status=OperationStatus.PENDING)
 
             # Prepare directories for artifacts
             directories = self._prepare_directories(task_dir)
 
+            # Initialize operation cache
             self.operation_cache = OperationCache(
                 cache_dir=task_dir / "cache",
             )
 
             # Create DataWriter for consistent file operations
             writer = DataWriter(
-                task_dir=task_dir, logger=logger, progress_tracker=progress_tracker
+                task_dir=task_dir, logger=self.logger, progress_tracker=progress_tracker
             )
 
             # Save configuration to task directory
             self.save_config(task_dir)
 
-            encryption_key = kwargs.get('encryption_key', None)
-            # Set up progress tracking
-            # Preparation, Validation, Data Loading, Processing, Metrics, Finalization
-            force_recalculation = kwargs.get("force_recalculation", False)
-            total_steps = 6 + (1 if self.use_cache and not force_recalculation else 0)
-            current_steps = 0
-            # Step 1: Preparation progress tracker
-            if progress_tracker:
-                current_steps += 1
-                self._update_progress_tracker(
-                    total_steps, current_steps, "Preparation", progress_tracker
-                )
-
             # Decompose kwargs and introduce variables for clarity
-            is_encryption_required = (
+            self.encrypt_output = (
                 kwargs.get("encrypt_output", False) or self.use_encryption
             )
-            use_dask = kwargs.get("use_dask", self.use_dask)
-            generate_visualization = kwargs.get("generate_visualization", True)
-            include_timestamp_in_filenames = kwargs.get("include_timestamp", True)
-            save_output = kwargs.get("save_output", True)
+            self.generate_visualization = kwargs.get("generate_visualization", True)
+            self.save_output = kwargs.get("save_output", True)
+            self.force_recalculation = kwargs.get("force_recalculation", False)
 
-            # Step 2: Validation progress tracker
-            if progress_tracker:
+            # Extract visualization parameters
+            self.visualization_theme = kwargs.get("visualization_theme", self.visualization_theme)
+            self.visualization_backend = kwargs.get("visualization_backend", self.visualization_backend)
+            self.visualization_strict = kwargs.get("visualization_strict", self.visualization_strict)
+            self.visualization_timeout = kwargs.get("visualization_timeout", self.visualization_timeout)
+
+            self.logger.info(
+                f"Visualization settings: theme={self.visualization_theme}, backend={self.visualization_backend}, strict={self.visualization_strict}, timeout={self.visualization_timeout}s"
+            )
+
+            # Set up progress tracking with proper steps
+            # Main steps: 1. Validation, 2. Cache check, 3. Data loading, 4. Processing, 5. Metrics, 6. Visualization, 7. Save output
+            TOTAL_MAIN_STEPS = 6 + (
+                1 if self.use_cache and not self.force_recalculation else 0
+            )
+            main_progress = progress_tracker
+            current_steps = 0
+            if main_progress:
+                self.logger.info(
+                    f"Setting up progress tracker with {TOTAL_MAIN_STEPS} main steps"
+                )
+                try:
+                    main_progress.total = TOTAL_MAIN_STEPS
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS,
+                        current_steps,
+                        {
+                            "step": "Starting merge datasets",
+                        },
+                        main_progress,
+                    )
+                except Exception as e:
+                    self.logger.warning(f"Could not update progress tracker: {e}")
+
+            # Step 1: Validation progress tracker
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Validation", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Validation", main_progress
                 )
 
             # Validate input parameters
@@ -313,15 +401,54 @@ class MergeDatasetsOperation(TransformationOperation):
                 right_dataset_path=self.right_dataset_path,
             )
 
-            # Step 3: Loading progress tracker
-            if progress_tracker:
-                current_steps += 1
-                self._update_progress_tracker(
-                    total_steps, current_steps, "Data Loading", progress_tracker
+            # Check Cache (if enabled and not forced to recalculate)
+            if self.use_cache and not self.force_recalculation:
+                # Step 2: Check if we have a cached result
+                if main_progress:
+                    current_steps += 1
+                    self._update_progress_tracker(
+                        TOTAL_MAIN_STEPS, current_steps, "Checking cache", main_progress
+                    )
+
+                # Load left dataset for check cache
+                self.logger.info("Load left dataset for check cache...")
+                left_df = self._get_dataset(
+                    data_source, self.left_dataset_name, **kwargs
+                )
+                self.logger.info(
+                    f"Left dataset '{self.left_dataset_name}' loaded with {len(left_df)} records."
                 )
 
-            # Loading datasets
-            left_df = self._get_dataset(data_source, self.left_dataset_name, **kwargs)
+                self.logger.info("Checking operation cache...")
+                cache_result = self._check_cache(df=left_df, reporter=reporter)
+                if cache_result:
+                    self.logger.info("Cache hit! Using cached results.")
+
+                    # Update progress
+                    if main_progress:
+                        self._update_progress_tracker(
+                            TOTAL_MAIN_STEPS,
+                            current_steps,
+                            "Complete (cached)",
+                            main_progress,
+                        )
+
+                    return cache_result
+
+            # Step 3: Loading progress tracker
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Data Loading", main_progress
+                )
+
+            # Loading left dataset
+            if left_df is None:
+                left_df = self._get_dataset(
+                    data_source, self.left_dataset_name, **kwargs
+                )
+
+            # Loading right dataset
             self.right_df = (
                 self._get_dataset(data_source, self.right_dataset_name, **kwargs)
                 if self.right_dataset_name is not None
@@ -340,50 +467,29 @@ class MergeDatasetsOperation(TransformationOperation):
             # Validate relationship on all left_df and right_df
             self._validate_relationship(left_df, self.right_df)
 
-            # Check Cache (if enabled and not forced to recalculate)
-            if self.use_cache and not force_recalculation:
-                if progress_tracker:
-                    current_steps += 1
-                    self._update_progress_tracker(
-                        total_steps, current_steps, "Checking cache", progress_tracker
-                    )
-
-                self.logger.info("Checking operation cache...")
-                cache_result = self._check_cache(df=left_df)
-                if cache_result:
-                    self.logger.info("Cache hit! Using cached results.")
-
-                    # Update progress
-                    if progress_tracker:
-                        self._update_progress_tracker(
-                            total_steps,
-                            current_steps,
-                            "Complete (cached)",
-                            progress_tracker,
-                        )
-
-                    # Report cache hit to reporter
-                    if reporter:
-                        reporter.add_operation(
-                            f"Transformation of {self.name} (from cache)",
-                            details={
-                                "cached": True,
-                                "left_key": f"{self.left_key}",
-                                "right_key": f"{self.right_key}",
-                            },
-                        )
-
-                    return cache_result
-
             # Step 4: Processing progress tracker
-            if progress_tracker:
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Processing", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Processing data", main_progress
                 )
 
             try:
-                # Process the data with the selected strategy
+                self.logger.info(f"Processing with left_key: {self.left_key}")
+
+                # Create child progress tracker for chunk processing
+                data_tracker = None
+                if main_progress and hasattr(main_progress, "create_subtask"):
+                    try:
+                        data_tracker = main_progress.create_subtask(
+                            total=3,
+                            description="Merging processing",
+                            unit="steps",
+                        )
+                    except Exception as e:
+                        self.logger.debug(f"Could not create child progress tracker: {e}")
+
+                # Process the data with the selected keys
                 self.process_count = len(left_df)
                 processed_df = merge_dataframes(
                     left_df=left_df,
@@ -392,8 +498,28 @@ class MergeDatasetsOperation(TransformationOperation):
                     right_key=self.right_key,
                     join_type=self.join_type,
                     suffixes=self.suffixes,
-                    use_dask=use_dask,
+                    chunk_size=self.chunk_size,
+                    use_dask=self.use_dask,
+                    progress_tracker=data_tracker,
+                    task_logger=self.logger
                 )
+
+                # Close child progress tracker
+                if data_tracker:
+                    try:
+                        data_tracker.close()
+                    except:
+                        pass
+
+                self.logger.info(
+                    f"Processed data: {len(processed_df)} records, dtype: {processed_df.dtypes}"
+                )
+
+                # Log sample of processed data
+                if len(processed_df) > 0:
+                    self.logger.debug(
+                        f"Sample of processed data (first 5 rows): {processed_df.head(5).to_dict(orient='records')}"
+                    )
             except Exception as e:
                 error_message = f"Processing error: {str(e)}"
                 self.logger.error(error_message)
@@ -402,14 +528,20 @@ class MergeDatasetsOperation(TransformationOperation):
                 )
 
             # Step 5: Metrics Calculation
-            if progress_tracker:
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Metrics Calculation", progress_tracker
+                    TOTAL_MAIN_STEPS,
+                    current_steps,
+                    "Metrics Calculation",
+                    main_progress,
                 )
 
-            # Collect final metrics before using them
+            # Record end time after processing
             self.end_time = time.time()
+
+            # Generate single timestamp for all artifacts
+            operation_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
             # Initialize metrics in scope
             metrics = {}
@@ -419,97 +551,101 @@ class MergeDatasetsOperation(TransformationOperation):
                     left_df=left_df, right_df=self.right_df, processed_df=processed_df
                 )
 
-                # Save metrics using writer
+                # Generate metrics file name (in self.name existed left_key)
+                metrics_file_name = f"{self.left_key}_{self.operation_name}_metrics_{operation_timestamp}"
+
+                # Write metrics to persistent storage/artifact repository
                 metrics_result = writer.write_metrics(
                     metrics=metrics,
-                    name=f"{self.name}_metrics",
-                    timestamp_in_name=True,
+                    name=metrics_file_name,
+                    timestamp_in_name=False,
                     encryption_key=(
-                        self.encryption_key if is_encryption_required else None
+                        self.encryption_key if self.encrypt_output else None
                     ),
                 )
 
-                # Add metrics to result
+                # Add simple metrics (int, float, str, bool) to the result object
                 for key, value in metrics.items():
                     if isinstance(value, (int, float, str, bool)):
                         result.add_metric(key, value)
 
-                # Register metrics artifact
+                # Register the metrics artifact for tracking and visualization
                 result.add_artifact(
                     artifact_type="json",
                     path=metrics_result.path,
-                    description=f"{self.name} metrics",
+                    description=f"Merging on {self.left_key} ↔ {self.right_key} — datasets transformation metrics",
                     category=Constants.Artifact_Category_Metrics,
                 )
 
-                # Report artifact
+                # Report the metrics artifact to the reporter if available
                 if reporter:
-                    reporter.add_artifact(
-                        "json",
-                        str(metrics_result.path),
-                        f"{self.name} metrics",
+                    reporter.add_operation(
+                        f"Merging on {self.left_key} ↔ {self.right_key} — datasets transformation metrics",
+                        details={"type": "json", "path": str(metrics_result.path)},
                     )
             except Exception as e:
                 error_message = f"Error calculating metrics: {str(e)}"
                 self.logger.warning(error_message)
                 # Continue execution - metrics failure is not critical
 
-            # Step 6: Finalization (Visualizations and Output Data)
-            if progress_tracker:
+            # Step 6: Visualizations
+            if main_progress:
                 current_steps += 1
                 self._update_progress_tracker(
-                    total_steps, current_steps, "Finalization", progress_tracker
+                    TOTAL_MAIN_STEPS, current_steps, "Generating Visualizations", main_progress
                 )
-
             # Generate visualizations if required
-            if generate_visualization:
+            # Initialize visualization paths dictionary
+            visualization_paths = {}
+            if self.generate_visualization and self.visualization_backend is not None:
                 try:
                     kwargs_encryption = {
-                        "use_encryption": kwargs.get('use_encryption', False),
-                        "encryption_key": encryption_key
+                        "use_encryption": self.encrypt_output,
+                        "encryption_key": self.encryption_key,
                     }
-                    visualization_paths = self._generate_visualizations(
-                        left_df,
-                        self.right_df,
-                        processed_df,
-                        task_dir,
-                        result,
-                        reporter,
-                        **kwargs_encryption
+                    visualization_paths = self._handle_visualizations(
+                        left_df=left_df,
+                        right_df=self.right_df,
+                        merged_df=processed_df,
+                        task_dir=task_dir,
+                        result=result,
+                        reporter=reporter,
+                        progress_tracker=main_progress,
+                        vis_theme=self.visualization_theme,
+                        vis_backend=self.visualization_backend,
+                        vis_strict=self.visualization_strict,
+                        vis_timeout=self.visualization_timeout,
+                        operation_timestamp=operation_timestamp,
+                        **kwargs_encryption,
                     )
-
-                    # Register visualization artifacts and report
-                    for viz_type, path in visualization_paths.items():
-                        result.add_artifact(
-                            artifact_type="png",
-                            path=path,
-                            description=f"{self.name} {viz_type} visualization",
-                            category=Constants.Artifact_Category_Visualization,
-                        )
-
-                        if reporter:
-                            reporter.add_operation(
-                                f"{self.name} {viz_type} visualization",
-                                details={"type": "png", "path": str(path)},
-                            )
-
                 except Exception as e:
                     error_message = f"Error generating visualizations: {str(e)}"
                     self.logger.warning(error_message)
                     # Continue execution - visualization failure is not critical
+            else:
+                self.logger.info(
+                    "Skipping visualizations as generate_visualization is False or backend is not set"
+                )
+
+            # Step 7: Save Output Data
+            if main_progress:
+                current_steps += 1
+                self._update_progress_tracker(
+                    TOTAL_MAIN_STEPS, current_steps, "Save Output Data", main_progress
+                )
 
             # Save output data if required
-            if save_output:
+            if self.save_output:
                 try:
-                    self._save_output_data(
+                    output_result_path = self._save_output_data(
                         result_df=processed_df,
                         task_dir=task_dir,
-                        include_timestamp_in_filenames=include_timestamp_in_filenames,
-                        is_encryption_required=is_encryption_required,
+                        is_encryption_required=self.encrypt_output,
                         writer=writer,
                         result=result,
                         reporter=reporter,
-                        progress_tracker=progress_tracker,
+                        progress_tracker=main_progress,
+                        timestamp=operation_timestamp,
                         **kwargs,
                     )
                 except Exception as e:
@@ -523,15 +659,21 @@ class MergeDatasetsOperation(TransformationOperation):
             if self.use_cache:
                 try:
                     self._save_to_cache(
-                        original_data=left_df,
+                        left_df=left_df,
                         transformed_data=processed_df,
-                        task_dir=task_dir,
                         metrics=metrics,
+                        visualization_paths=visualization_paths,
+                        metrics_result_path=str(metrics_result.path),
+                        output_result_path=output_result_path,
+                        task_dir=task_dir,
                     )
                 except Exception as e:
                     # Failure to cache is non-critical
                     self.logger.warning(f"Failed to cache results: {str(e)}")
 
+            # Cleanup memory
+            self._cleanup_memory(processed_df, left_df, self.right_df)
+            
             # Report completion
             if reporter:
                 # Create the details dictionary with checks for all values
@@ -550,8 +692,7 @@ class MergeDatasetsOperation(TransformationOperation):
                     details=details,
                 )
 
-            # Cleanup memory
-            self._cleanup_memory(processed_df, left_df, self.right_df)
+            self.logger.info(f"Processing completed {self.operation_name} operation in {self.end_time - self.start_time:.2f} seconds")
 
             # Set success status
             result.status = OperationStatus.SUCCESS
@@ -569,7 +710,7 @@ class MergeDatasetsOperation(TransformationOperation):
         """
         Deprecated: No longer used for merging. All merging is now performed in a single step.
         """
-        logger.warning(
+        self.logger.warning(
             "process_batch is deprecated and not used for merging. All merging is performed in a single step."
         )
         return batch_df
@@ -622,7 +763,7 @@ class MergeDatasetsOperation(TransformationOperation):
                 "Detected unsupported relationship (many-to-one or many-to-many)."
             )
 
-        logger.info(f"Auto-detected relationship type: {detected_relationship}")
+        self.logger.info(f"Auto-detected relationship type: {detected_relationship}")
         return detected_relationship
 
     def _validate_relationship(
@@ -643,7 +784,7 @@ class MergeDatasetsOperation(TransformationOperation):
                     f"Expected one-to-many relationship, but right key '{self.right_key}' is not unique."
                 )
             if not left_unique:
-                logger.warning(
+                self.logger.warning(
                     f"[Relationship Warning] Left key '{self.left_key}' is not unique (one-to-many). Possible data duplication."
                 )
         else:
@@ -655,7 +796,7 @@ class MergeDatasetsOperation(TransformationOperation):
         """
         Deprecated in batch mode. Not used in ML imputation anymore.
         """
-        logger.warning(
+        self.logger.warning(
             "_process_value is deprecated and not used in ML-based batch processing."
         )
         return value
@@ -705,7 +846,7 @@ class MergeDatasetsOperation(TransformationOperation):
             if execution_time and execution_time > 0
             else None
         )
-        transformation_type = self.__class__.__name__
+        transformation_type = self.operation_name
 
         metrics = {
             "total_input_records": total_input_records,
@@ -787,10 +928,244 @@ class MergeDatasetsOperation(TransformationOperation):
             Strategy-specific parameters for cache key generation
         """
         params = {
-            "version": self.version,  # Include version for cache invalidation
+            "left_dataset_name": self.left_dataset_name,
+            "right_dataset_name": self.right_dataset_name,
+            "right_dataset_path": self.right_dataset_path,
+            "left_key": self.left_key,
+            "right_key": self.right_key,
+            "join_type": self.join_type,
+            "relationship_type": self.relationship_type,
+            "suffixes": self.suffixes,
+            "chunk_size": self.chunk_size,
+            "use_dask": self.use_dask,
+            "npartitions": self.npartitions,
+            "use_cache": self.use_cache,
+            "use_encryption": self.use_encryption,
+            "encryption_key": self.encryption_key,
+            "visualization_theme": self.visualization_theme,
+            "visualization_backend": self.visualization_backend,
+            "visualization_strict": self.visualization_strict,
+            "visualization_timeout": self.visualization_timeout,
+            "output_format": self.output_format,
+            "force_recalculation": self.force_recalculation,
+            "generate_visualization": self.generate_visualization,
+            "encrypt_output": self.encrypt_output,
+            "save_output": self.save_output,
         }
 
         return params
+
+    def _handle_visualizations(
+        self,
+        left_df: pd.DataFrame,
+        right_df: pd.DataFrame,
+        merged_df: pd.DataFrame,
+        task_dir: Path,
+        result: OperationResult,
+        reporter: Any,
+        progress_tracker: Optional[HierarchicalProgressTracker],
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        vis_timeout: int = 120,
+        operation_timestamp: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Generate and save visualizations with thread-safe context support.
+
+        Parameters:
+        -----------
+        original_data : pd.Series
+            The original data before transformation
+        transformed_data : pd.Series
+            The transformed data after processing
+        task_dir : Path
+            The task directory
+        result : OperationResult
+            The operation result to add artifacts to
+        reporter : Any
+            The reporter to log artifacts to
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Optional progress tracker
+        vis_theme : str, optional
+            Theme to use for visualizations
+        vis_backend : str, optional
+            Backend to use: "plotly" or "matplotlib"
+        vis_strict : bool, optional
+            If True, raise exceptions for configuration errors
+        vis_timeout : int, optional
+            Timeout for visualization generation (default: 120 seconds)
+        operation_timestamp : str, optional
+            Timestamp for the operation (default: current time)
+        **kwargs: Any
+            Additional keyword arguments for visualization functions.
+        """
+        self.logger.info(
+            f"Generating visualizations with backend: {vis_backend}, timeout: {vis_timeout}s"
+        )
+
+        try:
+            import threading
+            import contextvars
+
+            visualization_paths = {}
+            visualization_error = None
+
+            def generate_viz_with_diagnostics():
+                nonlocal visualization_paths, visualization_error
+                thread_id = threading.current_thread().ident
+                thread_name = threading.current_thread().name
+
+                self.logger.info(
+                    f"[DIAG] Visualization thread started - Thread ID: {thread_id}, Name: {thread_name}"
+                )
+                self.logger.info(
+                    f"[DIAG] Field: {self.left_key}, Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+                )
+
+                start_time = time.time()
+
+                try:
+                    # Log context variables
+                    self.logger.info(f"[DIAG] Checking context variables...")
+                    try:
+                        current_context = contextvars.copy_context()
+                        self.logger.info(
+                            f"[DIAG] Context vars count: {len(list(current_context))}"
+                        )
+                    except Exception as ctx_e:
+                        self.logger.warning(
+                            f"[DIAG] Could not inspect context: {ctx_e}"
+                        )
+
+                    # Generate visualizations with visualization context parameters
+                    self.logger.info(f"[DIAG] Calling _generate_visualizations...")
+                    # Create child progress tracker for visualization if available
+                    total_steps = 3  # prepare data, create viz, save
+                    viz_progress = None
+                    if progress_tracker and hasattr(progress_tracker, "create_subtask"):
+                        try:
+                            viz_progress = progress_tracker.create_subtask(
+                                total=total_steps,
+                                description="Generating visualizations",
+                                unit="steps",
+                            )
+                        except Exception as e:
+                            self.logger.debug(
+                                f"Could not create child progress tracker: {e}"
+                            )
+
+                    # Generate visualizations with context parameters
+                    visualization_paths = self._generate_visualizations(
+                        left_df=left_df,
+                        right_df=right_df,
+                        merged_df=merged_df,
+                        task_dir=task_dir,
+                        vis_theme=vis_theme,
+                        vis_backend=vis_backend or "plotly",
+                        vis_strict=vis_strict,
+                        progress_tracker=viz_progress,
+                        timestamp=operation_timestamp,  # Pass the same timestamp
+                        **kwargs,
+                    )
+
+                    # Close visualization progress tracker
+                    if viz_progress:
+                        try:
+                            viz_progress.close()
+                        except:
+                            pass
+
+                    elapsed = time.time() - start_time
+                    self.logger.info(
+                        f"[DIAG] Visualization completed in {elapsed:.2f}s, generated {len(visualization_paths)} files"
+                    )
+
+                except Exception as e:
+                    elapsed = time.time() - start_time
+                    visualization_error = e
+                    self.logger.error(
+                        f"[DIAG] Visualization failed after {elapsed:.2f}s: {type(e).__name__}: {e}"
+                    )
+                    self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+
+            # Copy context for the thread
+            self.logger.info(f"[DIAG] Preparing to launch visualization thread...")
+            ctx = contextvars.copy_context()
+
+            # Create thread with context
+            viz_thread = threading.Thread(
+                target=ctx.run,
+                args=(generate_viz_with_diagnostics,),
+                name=f"VizThread-{self.field_name}",
+                daemon=False,  # Changed from True to ensure proper cleanup
+            )
+
+            self.logger.info(
+                f"[DIAG] Starting visualization thread with timeout={vis_timeout}s"
+            )
+            thread_start_time = time.time()
+            viz_thread.start()
+
+            # Log periodic status while waiting
+            check_interval = 5  # seconds
+            elapsed = 0
+            while viz_thread.is_alive() and elapsed < vis_timeout:
+                viz_thread.join(timeout=check_interval)
+                elapsed = time.time() - thread_start_time
+                if viz_thread.is_alive():
+                    self.logger.info(
+                        f"[DIAG] Visualization thread still running after {elapsed:.1f}s..."
+                    )
+
+            if viz_thread.is_alive():
+                self.logger.error(
+                    f"[DIAG] Visualization thread still alive after {vis_timeout}s timeout"
+                )
+                self.logger.error(
+                    f"[DIAG] Thread state: alive={viz_thread.is_alive()}, daemon={viz_thread.daemon}"
+                )
+                visualization_paths = {}
+            elif visualization_error:
+                self.logger.error(
+                    f"[DIAG] Visualization failed with error: {visualization_error}"
+                )
+                visualization_paths = {}
+            else:
+                total_time = time.time() - thread_start_time
+                self.logger.info(
+                    f"[DIAG] Visualization thread completed successfully in {total_time:.2f}s"
+                )
+                self.logger.info(
+                    f"[DIAG] Generated visualizations: {list(visualization_paths.keys())}"
+                )
+
+        except Exception as e:
+            self.logger.error(
+                f"[DIAG] Error in visualization thread setup: {type(e).__name__}: {e}"
+            )
+            self.logger.error(f"[DIAG] Stack trace:", exc_info=True)
+            visualization_paths = {}
+
+        # Register visualization artifacts
+        for viz_type, path in visualization_paths.items():
+            # Add to result
+            result.add_artifact(
+                artifact_type="png",
+                path=path,
+                description=f"{self.field_name} {viz_type} visualization",
+                category=Constants.Artifact_Category_Visualization,
+            )
+
+            # Report to reporter
+            if reporter:
+                reporter.add_operation(
+                    f"{self.field_name} {viz_type} visualization",
+                    details={"artifact_type": "png", "path": str(path)},
+                )
+
+        return visualization_paths
 
     def _generate_visualizations(
         self,
@@ -798,9 +1173,12 @@ class MergeDatasetsOperation(TransformationOperation):
         right_df: pd.DataFrame,
         merged_df: pd.DataFrame,
         task_dir: Path,
-        result: OperationResult,
-        reporter: Any = None,
-        **kwargs
+        vis_theme: Optional[str] = None,
+        vis_backend: Optional[str] = None,
+        vis_strict: bool = False,
+        progress_tracker: Optional[HierarchicalProgressTracker] = None,
+        timestamp: Optional[str] = None,
+        **kwargs,
     ) -> dict:
         """
         Generate required visualizations for the merge operation using visualization utilities.
@@ -815,10 +1193,18 @@ class MergeDatasetsOperation(TransformationOperation):
             The resulting DataFrame after performing the merge.
         task_dir : Path
             The base directory where all task-related outputs (including visualizations) will be saved.
-        result : OperationResult
-            An object representing the result of the merge operation, potentially containing metadata and statistics.
-        reporter : Any, optional
-            Optional reporter instance used for logging, tracking, or debugging the visualization process.
+        vis_theme : Optional[str]
+            The theme to use for visualizations.
+        vis_backend : Optional[str]
+            The backend to use for rendering visualizations.
+        vis_strict : bool
+            Whether to enforce strict visualization rules.
+        progress_tracker : Optional[HierarchicalProgressTracker]
+            Tracker for monitoring progress of the visualization generation.
+        timestamp : Optional[str]
+            Timestamp to include in visualization filenames.
+        **kwargs : Any
+            Additional keyword arguments for visualization functions.
 
         Returns
         -------
@@ -833,12 +1219,36 @@ class MergeDatasetsOperation(TransformationOperation):
         """
         viz_dir = task_dir / "visualizations"
         viz_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         visualization_paths = {}
 
+        # Use provided timestamp or generate new one
+        if timestamp is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # Check if visualization should be skipped
+        if vis_backend is None:
+            self.logger.info(
+                f"Skipping visualization for {self.left_key} (backend=None)"
+            )
+            return visualization_paths
+
+        self.logger.info(
+            f"[VIZ] Starting visualization generation for {self.left_key}"
+        )
+        self.logger.debug(
+            f"[VIZ] Backend: {vis_backend}, Theme: {vis_theme}, Strict: {vis_strict}"
+        )
+
         try:
+            # Step 1: Prepare data
+            if progress_tracker:
+                progress_tracker.update(1, {"step": "Preparing visualization data"})
+
             # Sample large datasets for visualization
             if len(left_df) > 10000:
+                self.logger.info(
+                    f"[VIZ] Sampling large dataset: {len(left_df)} -> 10000 samples"
+                )
                 left_viz = sample_large_dataset(left_df, max_samples=10000)
                 right_viz = sample_large_dataset(right_df, max_samples=10000)
                 merged_viz = sample_large_dataset(merged_df, max_samples=10000)
@@ -846,6 +1256,14 @@ class MergeDatasetsOperation(TransformationOperation):
                 left_viz = left_df
                 right_viz = right_df
                 merged_viz = merged_df
+
+            self.logger.debug(
+                f"[VIZ] Data prepared for visualization: {len(left_viz)} samples"
+            )
+
+            # Step 2: Create visualization
+            if progress_tracker:
+                progress_tracker.update(2, {"step": "Creating visualization"})
 
             # 1. Record overlap (Venn or bar chart)
             visualization_paths.update(
@@ -858,7 +1276,11 @@ class MergeDatasetsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=visualization_paths,
+                    **kwargs,
                 )
             )
 
@@ -872,7 +1294,11 @@ class MergeDatasetsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=visualization_paths,
+                    **kwargs,
                 )
             )
 
@@ -885,7 +1311,11 @@ class MergeDatasetsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=visualization_paths,
+                    **kwargs,
                 )
             )
 
@@ -907,27 +1337,34 @@ class MergeDatasetsOperation(TransformationOperation):
                     operation_name=self.name,
                     task_dir=viz_dir,
                     timestamp=timestamp,
-                    **kwargs
+                    theme=vis_theme,
+                    backend=vis_backend,
+                    strict=vis_strict,
+                    visualization_paths=visualization_paths,
+                    **kwargs,
                 )
             )
 
+            # Step 3: Finalize visualizations
+            if progress_tracker:
+                progress_tracker.update(3, {"step": "Finalizing visualizations"})
+
         except Exception as e:
-            logger.warning(f"Error creating visualizations: {e}")
+            self.logger.warning(f"Error creating visualizations: {e}")
 
         return visualization_paths
 
     def _save_output_data(
         self,
         result_df: pd.DataFrame,
-        task_dir: Path,
-        include_timestamp_in_filenames: bool,
         is_encryption_required: bool,
         writer: DataWriter,
         result: OperationResult,
         reporter: Any,
         progress_tracker: Optional[HierarchicalProgressTracker],
+        timestamp: Optional[str] = None,
         **kwargs,
-    ) -> None:
+    ) -> str:
         """
         Save the processed output data.
 
@@ -935,10 +1372,6 @@ class MergeDatasetsOperation(TransformationOperation):
         -----------
         result_df : pd.DataFrame
             The processed dataframe to save
-        task_dir : Path
-            Task directory for saving output
-        include_timestamp_in_filenames : bool
-            Whether to include a timestamp in the filename
         is_encryption_required : bool
             Whether to encrypt the output
         writer : DataWriter
@@ -949,19 +1382,27 @@ class MergeDatasetsOperation(TransformationOperation):
             The reporter to log artifacts to
         progress_tracker : Optional[HierarchicalProgressTracker]
             Optional progress tracker
+        timestamp : Optional[str]
+            Optional timestamp for the output file
         **kwargs : dict
             Additional parameters for the operation
         """
         if progress_tracker:
             progress_tracker.update(0, {"step": "Saving output data"})
 
-        custom_kwargs = {k: v for k, v in kwargs.items() if k != 'encryption_key'}
+        custom_kwargs = self._get_custom_kwargs(result_df, **kwargs)
+        
+        # Generate standardized output filename with timestamp
+        field_name_output = (
+            f"{self.left_key}_{self.operation_name}_output_{timestamp}"
+        )
+
         output_result = writer.write_dataframe(
             df=result_df,
-            name=f"{self.name}_transformed",
+            name=field_name_output,
             format=self.output_format,
             subdir="output",
-            timestamp_in_name=include_timestamp_in_filenames,
+            timestamp_in_name=False,
             encryption_key=self.encryption_key if is_encryption_required else None,
             **custom_kwargs,
         )
@@ -981,6 +1422,8 @@ class MergeDatasetsOperation(TransformationOperation):
                 str(output_result.path),
                 f"{self.name} transformed data",
             )
+
+        return str(output_result.path)
 
     def _prepare_directories(self, task_dir: Path) -> Dict[str, Path]:
         """
@@ -1034,8 +1477,6 @@ class MergeDatasetsOperation(TransformationOperation):
         right_df : pd.DataFrame, optional
             Right DataFrame to clear from memory
         """
-        import gc
-
         # Clear argument references
         if processed_df is not None:
             try:
@@ -1055,10 +1496,6 @@ class MergeDatasetsOperation(TransformationOperation):
             except Exception:
                 pass
 
-        # Clear instance attribute references
-        if hasattr(self, "_temp_data"):
-            self._temp_data = None
-
         # Clear right DataFrame
         if hasattr(self, "right_df"):
             self.right_df = None
@@ -1072,8 +1509,10 @@ class MergeDatasetsOperation(TransformationOperation):
             if attr_name.startswith("_temp_"):
                 setattr(self, attr_name, None)
 
-        # Force garbage collection
-        gc.collect()
+        # Optional: Force garbage collection for large datasets
+        # Uncomment if memory pressure is an issue
+        # import gc
+        # gc.collect()
 
     def _get_dataset(
         self, source: Any, dataset_name_or_path: Optional[str], **kwargs
@@ -1099,8 +1538,11 @@ class MergeDatasetsOperation(TransformationOperation):
             return None
         if isinstance(source, pd.DataFrame):
             return source.get(dataset_name_or_path)
-        
-        settings_operation = load_settings_operation(source, dataset_name_or_path, **kwargs)
+
+        # Load settings operation
+        settings_operation = load_settings_operation(
+            source, dataset_name_or_path, **kwargs
+        )
         return load_data_operation(source, dataset_name_or_path, **settings_operation)
 
     def _validate_input_params(
@@ -1152,7 +1594,9 @@ class MergeDatasetsOperation(TransformationOperation):
                 "Either right_dataset_name or right_dataset_path must be provided"
             )
 
-    def _check_cache(self, df: pd.DataFrame) -> Optional[OperationResult]:
+    def _check_cache(
+        self, df: pd.DataFrame, reporter: Any
+    ) -> Optional[OperationResult]:
         """
         Check if a cached result exists for this operation.
 
@@ -1160,78 +1604,208 @@ class MergeDatasetsOperation(TransformationOperation):
         -----------
         df : pd.DataFrame
             DataFrame to check in the cache
+        reporter : Any
+            Reporter to log cache hits/misses
 
         Returns:
         --------
         Optional[OperationResult]
-                Cached result if found, None otherwise
+            Cached result if found, None otherwise
         """
         if not self.use_cache:
             return None
 
         try:
-            if not self.left_key:
-                # Use entire DataFrame or selected columns for cache key
-                cache_key = self._generate_cache_key(df)
-            else:
-                if self.left_key not in df.columns:
-                    logger.warning(
-                        f"Field '{self.left_key}' not found in DataFrame columns."
-                    )
-                    return None
-                cache_key = self._generate_cache_key(df[self.left_key])
+            if self.left_key and self.left_key not in df.columns:
+                self.logger.warning(
+                    f"Field '{self.left_key}' not found in DataFrame columns."
+                )
+                return None
 
-            logger.debug(f"Checking cache for key: {cache_key}")
-            cached_data = self.operation_cache.get_cache(
-                cache_key=cache_key, operation_type=self.__class__.__name__
+            target_df = df[self.left_key] if self.left_key else df
+            cache_key = self._generate_cache_key(target_df)
+
+            self.logger.debug(f"Checking cache for key: {cache_key}")
+
+            cached_result = self.operation_cache.get_cache(
+                cache_key=cache_key, operation_type=self.operation_name
             )
 
-            if cached_data:
-                logger.info(f"Cache hit for {self.left_key} transformation operation")
+            if not cached_result:
+                self.logger.info("No cached result found, proceeding with operation")
+                return None
 
-                result = OperationResult(status=OperationStatus.SUCCESS)
+            self.logger.info(f"Using cached result for {self.left_key} transformation")
 
-                metrics = cached_data.get("metrics", {})
-                if isinstance(metrics, dict):
-                    for key, value in metrics.items():
-                        if isinstance(value, (int, float, str, bool)):
-                            result.add_metric(key, value)
+            result = OperationResult(status=OperationStatus.SUCCESS)
+            # Restore cached data
+            self._add_cached_metrics(result, cached_result)
+            artifacts_restored = self._restore_cached_artifacts(
+                result, cached_result, reporter
+            )
 
-                result.add_metric("cached", True)
-                result.add_metric("cache_key", cache_key)
-                result.add_metric(
-                    "cache_timestamp", cached_data.get("timestamp", "unknown")
+            # Add cache metadata
+            result.add_metric("cached", True)
+            result.add_metric("cache_key", cache_key)
+            result.add_metric(
+                "cache_timestamp", cached_result.get("timestamp", "unknown")
+            )
+            result.add_metric("artifacts_restored", artifacts_restored)
+
+            if reporter:
+                reporter.add_operation(
+                    f"Merge datasets transformation of {self.left_key} (cached)",
+                    details={
+                        "left_key": self.left_key,
+                        "cached": True,
+                        "artifacts_restored": artifacts_restored,
+                    },
                 )
 
-                return result
-
-            logger.debug(f"No cache found for key: {cache_key}")
-            return None
+            self.logger.info(
+                f"Cache hit successful: restored {artifacts_restored} artifacts"
+            )
+            return result
 
         except Exception as e:
-            logger.warning(f"Error checking cache: {str(e)}")
+            self.logger.warning(f"Error checking cache: {str(e)}")
             return None
+
+    def _add_cached_metrics(self, result: OperationResult, cached: dict):
+        """
+        Add cached scalar metrics (int, float, str, bool) to the OperationResult.
+
+        Parameters
+        ----------
+        result : OperationResult
+            The result object to update.
+        cached : dict
+            Cached result dictionary from cache manager.
+        """
+        for key, value in cached.get("metrics", {}).items():
+            if isinstance(value, (int, float, str, bool)):
+                result.add_metric(key, value)
+
+    def _restore_cached_artifacts(
+        self, result: OperationResult, cached: dict, reporter: Optional[Any]
+    ) -> int:
+        """
+        Restore artifacts (output, metrics, visualizations) from cached result if files exist.
+
+        Parameters
+        ----------
+        result : OperationResult
+            OperationResult object to update with restored artifacts.
+        cached : dict
+            Cached result dictionary from cache manager.
+        reporter : Optional[Any]
+            Optional reporter object for tracking operation-level artifacts.
+
+        Returns
+        -------
+        int
+            Number of artifacts successfully restored.
+        """
+        artifacts_restored = 0
+
+        def restore_file_artifact(
+            path: Union[str, Path], artifact_type: str, desc_suffix: str, category: str
+        ):
+            """
+            Restore a single artifact from a file path if it exists.
+
+            Parameters
+            ----------
+            path : Union[str, Path]
+                Path to the artifact file.
+            artifact_type : str
+                Type of the artifact (e.g., 'json', 'csv', 'png').
+            desc_suffix : str
+                Description suffix (e.g., 'visualization', 'metrics').
+            category : str
+                Artifact category (e.g., output, metrics, visualization).
+            """
+            nonlocal artifacts_restored
+            if not path:
+                return
+
+            artifact_path = Path(path)
+            if artifact_path.exists():
+                result.add_artifact(
+                    artifact_type=artifact_type,
+                    path=artifact_path,
+                    description=f"{self.left_key} {desc_suffix} (cached)",
+                    category=category,
+                )
+                artifacts_restored += 1
+
+                if reporter:
+                    reporter.add_operation(
+                        f"{self.left_key} {desc_suffix} (cached)",
+                        details={
+                            "artifact_type": artifact_type,
+                            "path": str(artifact_path),
+                        },
+                    )
+            else:
+                self.logger.warning(f"Cached file not found: {artifact_path}")
+
+        # Restore main output and metrics artifacts
+        restore_file_artifact(
+            cached.get("output_file"),
+            self.output_format,
+            "transformed data",
+            Constants.Artifact_Category_Output,
+        )
+        restore_file_artifact(
+            cached.get("metrics_file"),
+            "json",
+            "transformation metrics",
+            Constants.Artifact_Category_Metrics,
+        )
+
+        # Restore visualizations
+        for viz_type, path_str in cached.get("visualizations", {}).items():
+            restore_file_artifact(
+                path_str,
+                "png",
+                f"{viz_type} visualization",
+                Constants.Artifact_Category_Visualization,
+            )
+
+        return artifacts_restored
 
     def _save_to_cache(
         self,
-        original_data: Union[pd.Series, pd.DataFrame],
+        left_df: Union[pd.Series, pd.DataFrame],
         transformed_data: Union[pd.Series, pd.DataFrame],
+        metrics: Dict[str, Any],
+        visualization_paths: Dict[str, Path],
         task_dir: Path,
-        metrics: Dict[str, Any] = None,
+        metrics_result_path: Optional[str] = "",
+        output_result_path: Optional[str] = "",
     ) -> bool:
         """
         Save operation results to cache.
 
         Parameters:
         -----------
-        original_data : pd.Series or pd.DataFrame
+        left_df : pd.Series or pd.DataFrame
             Original input data
         transformed_data : pd.Series or pd.DataFrame
             Transformed output data
+        metrics : Dict[str, Any]
+            Metrics collected during the operation
+        visualization_paths : Dict[str, Path]
+            Paths to generated visualizations
         task_dir : Path
             Task directory
-        metrics : Dict[str, Any], optional
-            Metrics dictionary (default is None)
+        metrics_result_path : Optional[str]
+            Path to the metrics result file
+            If not provided, a default path will be used.
+        output_result_path : Optional[str]
+            Path to the output result file
+            If not provided, a default path will be used.
 
         Returns:
         --------
@@ -1246,38 +1820,33 @@ class MergeDatasetsOperation(TransformationOperation):
 
         try:
             # Generate cache key (same logic as _check_cache)
-            if isinstance(original_data, pd.DataFrame) and self.left_key:
-                if self.left_key in original_data.columns:
-                    cache_key = self._generate_cache_key(original_data[self.left_key])
+            if isinstance(left_df, pd.DataFrame) and self.left_key:
+                if self.left_key in left_df.columns:
+                    cache_key = self._generate_cache_key(left_df[self.left_key])
                 else:
-                    cache_key = self._generate_cache_key(original_data)
+                    cache_key = self._generate_cache_key(left_df)
             else:
-                cache_key = self._generate_cache_key(original_data)
+                cache_key = self._generate_cache_key(left_df)
 
             # Prepare metadata for cache
-            operation_params = self._get_cache_parameters()
-            operation_params.update(
-                {
-                    "operation_class": self.__class__.__name__,
-                    "version": self.version,
-                    "left_key": self.left_key,
-                    "right_key": self.right_key,
-                    "join_type": self.join_type,
-                }
-            )
+            operation_params = self._get_basic_parameters()
+            operation_params.update(self._get_cache_parameters())
 
             # Prepare cache data
             cache_data = {
                 "timestamp": datetime.now().isoformat(),
-                "metrics": metrics,
+                "metrics": {
+                    k: float(v) if isinstance(v, (np.integer, np.floating)) else v
+                    for k, v in metrics.items()
+                },
                 "parameters": operation_params,
                 "data_info": {
-                    "original_length": len(original_data),
+                    "original_length": len(left_df),
                     "transformed_length": len(transformed_data),
                     "original_null_count": int(
-                        original_data.isna().sum().sum()
-                        if isinstance(original_data, pd.DataFrame)
-                        else original_data.isna().sum()
+                        left_df.isna().sum().sum()
+                        if isinstance(left_df, pd.DataFrame)
+                        else left_df.isna().sum()
                     ),
                     "transformed_null_count": int(
                         transformed_data.isna().sum().sum()
@@ -1285,28 +1854,33 @@ class MergeDatasetsOperation(TransformationOperation):
                         else transformed_data.isna().sum()
                     ),
                 },
+                "output_file": output_result_path,  # Path to main output file
+                "metrics_file": metrics_result_path,  # Path to metrics file
+                "visualizations": {
+                    k: str(v) for k, v in visualization_paths.items()
+                },  # Paths to visualizations
             }
 
             # Save to cache
-            logger.debug(f"Saving to cache with key: {cache_key}")
+            self.logger.debug(f"Saving to cache with key: {cache_key}")
             success = self.operation_cache.save_cache(
                 data=cache_data,
                 cache_key=cache_key,
-                operation_type=self.__class__.__name__,
+                operation_type=self.operation_name,
                 metadata={"task_dir": str(task_dir)},
             )
 
             if success:
-                logger.info(
+                self.logger.info(
                     f"Successfully saved {self.name} operation results to cache"
                 )
             else:
-                logger.warning(f"Failed to save {self.name} operation results to cache")
+                self.logger.warning(f"Failed to save {self.name} operation results to cache")
 
             return success
 
         except Exception as e:
-            logger.warning(f"Error saving to cache: {str(e)}")
+            self.logger.warning(f"Error saving to cache: {str(e)}")
             return False
 
     def _detect_relationship_type_auto(
@@ -1357,7 +1931,7 @@ class MergeDatasetsOperation(TransformationOperation):
                 "Detected unsupported relationship (many-to-one or many-to-many)."
             )
 
-        logger.info(f"Auto-detected relationship type: {detected_relationship}")
+        self.logger.info(f"Auto-detected relationship type: {detected_relationship}")
         return detected_relationship
 
     def _get_processed_key_columns(
@@ -1391,7 +1965,7 @@ class MergeDatasetsOperation(TransformationOperation):
         if right_key_col not in processed_df.columns:
             missing_keys.append(f"processed_df['{right_key_col}']")
         if missing_keys:
-            logger.warning(
+            self.logger.warning(
                 f"Cannot find key columns in processed_df: {', '.join(missing_keys)}"
             )
             return None

--- a/pamola_core/transformations/splitting/split_fields_op.py
+++ b/pamola_core/transformations/splitting/split_fields_op.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Union, Tuple
 import pandas as pd
 from pamola_core.transformations.base_transformation_op import TransformationOperation
 from pamola_core.utils.io import load_data_operation, ensure_directory, load_settings_operation, write_json, write_dataframe_to_csv
@@ -11,19 +11,14 @@ from pamola_core.utils.logging import configure_task_logging
 from pamola_core.utils.ops.op_cache import operation_cache
 from pamola_core.utils.ops.op_data_source import DataSource
 from pamola_core.utils.ops.op_result import OperationResult, OperationStatus, OperationArtifact
-from pamola_core.utils.progress import ProgressTracker
+from pamola_core.utils.progress import HierarchicalProgressTracker
 from pamola_core.common.constants import Constants
-from pamola_core.utils.visualization import _save_figure
+from pamola_core.utils.visualization import create_bar_plot, plot_field_subset_network
 from pamola_core.utils.io_helpers import crypto_utils, directory_utils
-
+from pamola_core.utils.io_helpers.crypto_utils import get_encryption_mode
 import matplotlib
-
 # Set the backend to 'Agg' to avoid GUI issues
 matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-import seaborn as sns
-from matplotlib.ticker import MaxNLocator
-import plotly.graph_objects as go
 import hashlib
 from pamola_core.utils.ops.op_registry import register
 
@@ -43,8 +38,19 @@ class SplitFieldsOperation(TransformationOperation):
                  field_groups: Optional[Dict[str, List[str]]] = None,
                  include_id_field: bool = True,
                  output_format: str = OutputFormat.CSV.value,
+                 save_output: bool = True,
+                 use_cache: bool = True,
+                 force_recalculation: bool = False,
+                 use_dask: bool = False,
+                 npartitions: int = 1,
+                 use_vectorization: bool = False,
+                 parallel_processes: int = 1,
+                 visualization_backend: Optional[str] = None,
+                 visualization_theme: Optional[str] = None,
+                 visualization_strict: bool = False,
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
+                 encryption_mode: Optional[str] = None,
                  **kwargs):
         """
         Initialize a SplitFieldsOperation instance.
@@ -73,18 +79,29 @@ class SplitFieldsOperation(TransformationOperation):
         super().__init__(
             name=name,
             description=description,
+            use_cache=use_cache,
+            use_dask=use_dask,
+            npartitions=npartitions,
+            use_vectorization=use_vectorization,
+            parallel_processes=parallel_processes,
+            visualization_backend=visualization_backend,
+            visualization_theme=visualization_theme,
+            visualization_strict=visualization_strict,
             use_encryption=use_encryption,
-            encryption_key=encryption_key
-            )
+            encryption_key=encryption_key,
+            encryption_mode=encryption_mode
+        )
 
         # Initialize attributes specific to SplitFieldsOperation
         self.id_field = id_field
         self.field_groups = field_groups or {}
         self.include_id_field = include_id_field
         self.output_format = output_format
+        self.save_output = save_output
+        self.force_recalculation = force_recalculation
 
     def execute(self, data_source: DataSource, task_dir: Path, reporter: Any,
-                progress_tracker: Optional[ProgressTracker] = None, **kwargs):
+                progress_tracker: Optional[HierarchicalProgressTracker] = None, **kwargs):
         """
         Execute the SplitFieldsOperation.
 
@@ -95,13 +112,13 @@ class SplitFieldsOperation(TransformationOperation):
         Parameters
         ----------
         data_source : DataSource
-            The input data source from which the dataset will be loaded.
+            The data source object used to load the input dataset.
         task_dir : Path
-            The directory where output files, logs, visualizations, and other artifacts will be saved.
+            Directory path where outputs, logs, visualizations, and other artifacts are stored.
         reporter : Any
-            A reporter or logger object used to report status, messages, or errors.
+            Reporting or logging object to record execution status and messages.
         progress_tracker : ProgressTracker, optional
-            An optional object to track and update progress step-by-step, typically for UI or monitoring purposes.
+            An optional progress tracker to update stepwise progress status.
         **kwargs : dict, optional
             Optional overrides for instance attributes and execution parameters:
                 - id_field (str): Field name used to uniquely identify records.
@@ -111,88 +128,107 @@ class SplitFieldsOperation(TransformationOperation):
                 - force_recalculation (bool): If True, bypass cached results and force full reprocessing.
                 - generate_visualization (bool): Whether to generate visualizations for the output data.
                 - include_timestamp (bool): Whether to append a timestamp to output filenames.
-                - save_output (bool): Whether to save the resulting split datasets to disk.
-                - parallel_processes (int): Number of parallel processes to use for output saving.
-                - use_cache (bool): Whether to use cached results when available.
-                - dataset_name (str): Optional name of the dataset to load from the data source.
-                - use_dask (bool): Whether to use Dask for parallel/distributed processing.
-                - use_encryption (bool): Whether to encrypt output files.
-                - encryption_key (str or Path): Key or path to key file used for encryption.
-                - batch_size (int): Number of records to process per batch during operation.
+                - save_output (bool): Whether to save partitioned outputs to disk.
+                - parallel_processes (int): Number of processes to use for saving output.
+                - use_cache (bool): Enable caching of intermediate results.
+                - dataset_name (str): Name of the dataset to load from the data source.
+                - use_dask (bool): If True, enable Dask for parallel/distributed processing.
+                - use_encryption (bool): If True, encrypt output files.
+                - encryption_key (str or Path): Encryption key or path for encrypting outputs.
+                - batch_size (int): Number of records processed per batch during processing.
 
         Returns
         -------
         OperationResult
-            An object summarizing the outcome of the operation, including:
-                - Execution status (success or failure)
-                - Execution time duration
-                - Paths to saved output files and visualizations
-                - Collected metrics and logs
-                - Any errors encountered during processing
+            An object summarizing the execution outcome, including:
+                - Status (success/failure)
+                - Execution duration
+                - Paths to saved files and visualizations
+                - Collected metrics
+                - Error messages, if any
         """
 
+        self.start_time = time.time()
+
+        caller_operation = self.__class__.__name__
+        self.logger = kwargs.get('logger', self.logger)
+
         try:
-            self.logger = kwargs.get('logger', self.logger)
-            self.logger.info("Starting SplitFieldsOperation execution")
-
-            step_count = 0
+            # Start operation
+            self.logger.info(f"Operation: {caller_operation}, Start operation")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Preparation", "operation": self.name})
-                step_count += 1
+                progress_tracker.total = self._compute_total_steps(**kwargs)
+                progress_tracker.update(1, {"step": "Start operation - Preparation", "operation": caller_operation})
 
-            self.start_time = time.time()
+            dirs = self._prepare_directories(task_dir)
 
-            self._set_common_operation_parameters(**kwargs)
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Preparation",
+                                                "message": "Preparation successfully",
+                                                "directories": {k: str(v) for k, v in dirs.items()}
+                                                })
 
-            directories = self._prepare_directories(task_dir)
-            self.logger.info(f"Output directories prepared: {directories}")
-
-            self.save_config(task_dir)
-            self.logger.info("Configuration file saved")
-
+            # Load data and validate input parameters
+            self.logger.info(f"Operation: {caller_operation}, Load data and validate input parameters")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Loading dataset", "operation": self.name})
-                step_count += 1
+                progress_tracker.update(1, {"step": "Load data and validate input parameters",
+                                            "operation": caller_operation})
 
-            # Load data
-            dataset_name = kwargs.get('dataset_name', "main")
-            self.logger.info(f"Loading dataset '{dataset_name}' from data source")
-            settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
-            df = load_data_operation(data_source, dataset_name, **settings_operation)
+            df, is_valid = self._load_data_and_validate_input_parameters(data_source, **kwargs)
 
-            if df is None or df.empty:
-                self.logger.error("Loaded DataFrame is None or empty — aborting")
-                return OperationResult(status=OperationStatus.ERROR, error_message="Input data frame is None or empty")
+            if is_valid:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters successfully",
+                                                    "shape": df.shape
+                                                    })
+            else:
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Load data and validate input parameters",
+                                                    "message": "Load data and validate input parameters failed"
+                                                    })
+                    return OperationResult(status=OperationStatus.ERROR,
+                                           error_message="Load data and validate input parameters failed")
 
-            self.logger.info(f"Loaded dataset '{dataset_name}' with shape {df.shape}")
-
-            self.input_dataset = dataset_name
-            self.original_df = df.copy(deep=True)
-
-            # Handle caching
+            # Handle cache if required
             if self.use_cache and not self.force_recalculation:
+                self.logger.info(f"Operation: {caller_operation}, Load result from cache")
                 if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Use cache", "operation": self.name})
-                    step_count += 1
+                    progress_tracker.update(1, {"step": "Load result from cache", "operation": caller_operation})
 
-                cached_result = self._get_cache(df.copy())  # _get_cache now returns OperationResult or None
+                cached_result = self._get_cache(df.copy(), **kwargs)  # _get_cache now returns OperationResult or None
                 if cached_result is not None and isinstance(cached_result, OperationResult):
-                    self.logger.info("Loaded result from cache — skipping execution.")
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache successfully"
+                                                        })
                     return cached_result
                 else:
-                    self.logger.info("No valid cached result found — proceeding with execution.")
+                    self.logger.info(
+                        f"Operation: {caller_operation}, Load result from cache failed — proceeding with execution.")
+                    if reporter:
+                        reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                               details={"step": "Load result from cache",
+                                                        "message": "Load result from cache failed - proceeding with execution"
+                                                        })
 
+            # Process data
+            self.logger.info(f"Operation: {caller_operation}, Process data")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Validating parameters", "operation": self.name})
-                step_count += 1
+                progress_tracker.update(1, {"step": "Process data", "operation": caller_operation})
 
-            if not self._validate_parameters(df):
-                self.logger.error("Validation failed: Input parameters are invalid")
-                return OperationResult(status=OperationStatus.ERROR, error_message="Input parameters are invalid")
+            transformed_df = self._process_data(df, **kwargs)
 
-            if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Processing data", "operation": self.name})
-                step_count += 1
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Process data",
+                                                "message": "Process data successfully",
+                                                "num_subsets": len(transformed_df)
+                                                })
 
             result = OperationResult(status=OperationStatus.SUCCESS,
                                      artifacts=[],
@@ -200,71 +236,110 @@ class SplitFieldsOperation(TransformationOperation):
                                      error_message=None, execution_time=0,
                                      error_trace=None)
 
-            self.logger.info("Processing data into field-based subsets")
-            transformed_df = self._process_data(df, **kwargs)
-            self.logger.info(f"Data split into {len(transformed_df)} subset(s)")
-
             self.end_time = time.time()
             result.execution_time = self.end_time - self.start_time
 
+            # Collect metric
+            self.logger.info(f"Operation: {caller_operation}, Collect metric")
             if progress_tracker:
-                progress_tracker.update(step_count, {"step": "Collecting metrics", "operation": self.name})
-                step_count += 1
+                progress_tracker.update(1, {"step": "Collect metric", "operation": caller_operation})
 
             metrics = self._collect_metrics(df, transformed_df)
             result.metrics = metrics
             self._save_metrics(metrics, task_dir, result, **kwargs)
 
-            if self.save_output:
-                if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Saving output", "operation": self.name})
-                    step_count += 1
-
-                self.logger.info("Saving output subsets to disk")
-                self._save_output(transformed_df, task_dir, result, **kwargs)
-                self.logger.info("Output files saved")
-
-            if self.generate_visualization:
-                if progress_tracker:
-                    progress_tracker.update(step_count, {"step": "Generating visualizations", "operation": self.name})
-                    step_count += 1
-
-                self.logger.info("Generating visualizations")
-                self._generate_visualizations(df, transformed_df, task_dir, result, **kwargs)
-                self.logger.info("Visualizations completed")
-
-            self.logger.info("SplitFieldsOperation completed successfully")
-
             if reporter:
-                reporter.add_operation("SplitFieldsOperation", status="info",
-                                       details={"message": "SplitFieldsOperation completed successfully"})
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Collect metric",
+                                                "message": "Collect metric successfully",
+                                                "summary": {
+                                                    "input_dataset": metrics.get("input_dataset"),
+                                                    "input_records": metrics.get("total_input_records"),
+                                                    "input_fields": metrics.get("total_input_fields"),
+                                                    "output_records": metrics.get("total_output_records"),
+                                                    "output_fields": metrics.get("total_output_fields"),
+                                                    "id_field": metrics.get("id_field"),
+                                                    "splits": metrics.get("number_of_splits"),
+                                                    "execution_time_seconds": metrics.get("execution_time_seconds")
+                                                }
+                                                })
 
+            # Save output if required
+            if self.save_output:
+                self.logger.info(f"Operation: {caller_operation}, Save output")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Save output", "operation": caller_operation})
+
+                self._save_output(transformed_df, task_dir, result, **kwargs)
+
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Save output",
+                                                    "message": "Save output successfully",
+                                                    "files_saved": len(result.artifacts)
+                                                    })
+
+            # Generate visualizations if required
+            if self.generate_visualization:
+                self.logger.info(f"Operation: {caller_operation}, Generate visualizations")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Generate visualizations", "operation": caller_operation})
+
+                self._generate_visualizations(df, transformed_df, task_dir, result, **kwargs)
+
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Generate visualizations",
+                                                    "message": "Generate visualizations successfully",
+                                                    "num_images": len([a for a in result.artifacts if
+                                                                       a.get("artifact_type") == "png"])
+                                                    })
+
+            # Save cache if required
             if self.use_cache:
-                self._save_cache(task_dir, result)
-                self.logger.info("Cached result saved successfully in task directory.")
+                self.logger.info(f"Operation: {caller_operation}, Save cache")
+                if progress_tracker:
+                    progress_tracker.update(1, {"step": "Save cache", "operation": caller_operation})
+
+                self._save_cache(task_dir, result, **kwargs)
+
+                if reporter:
+                    reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                           details={"step": "Save cache",
+                                                    "message": "Save cache successfully"
+                                                    })
+
+            # Operation completed successfully
+            self.logger.info(f"Operation: {caller_operation}, Operation completed successfully.")
+            if reporter:
+                reporter.add_operation(f"Operation {caller_operation}", status="info",
+                                       details={"step": "Return result",
+                                                "message": "Operation completed successfully"
+                                                })
 
             return result
 
         except Exception as e:
-            error_msg = f"Error in SplitFieldsOperation: {e}"
-            self.logger.exception(error_msg)
-
-            if progress_tracker:
-                progress_tracker.update(0, {"step": "Error", "error": str(e)})
-
+            self.logger.error(f"Operation: {caller_operation}, error occurred: {e}")
             if reporter:
-                reporter.add_operation("SplitFieldsOperation", status="error", details={"error": str(e)})
+                reporter.add_operation(f"Operation {caller_operation}", status="error",
+                                       details={
+                                           "step": "Exception",
+                                           "message": "Operation failed due to an exception",
+                                           "error": str(e)
+                                       })
 
-            return OperationResult(
-                status=OperationStatus.ERROR,
-                error_message=error_msg
-            )
+            return OperationResult(status=OperationStatus.ERROR, error_message=str(e))
 
     def _process_data(self, df: pd.DataFrame, **kwargs) -> Union[pd.DataFrame, Dict[str, pd.DataFrame]]:
         """
         Process data according to operation-specific logic.
         Split the dataset into multiple subsets based on field_groups.
         Each subset contains its specified columns, and optionally the ID field.
+
+        Dask and Joblib are not used here because we are only splitting the DataFrame by column groups,
+        which is a lightweight operation. Pandas handles column selection efficiently even with millions of rows,
+        so adding parallelism would introduce unnecessary overhead without performance benefits.
 
         Parameters:
         -----------
@@ -320,7 +395,7 @@ class SplitFieldsOperation(TransformationOperation):
 
         return {
             "operation_type": self.__class__.__name__,
-            "input_dataset": self.input_dataset or "unknown.csv",
+            "input_dataset": self._input_dataset or "unknown.csv",
             "total_input_records": input_rows,
             "total_input_fields": input_fields,
             "total_output_records": total_output_records,
@@ -344,10 +419,10 @@ class SplitFieldsOperation(TransformationOperation):
         metrics_path = metrics_dir / metrics_filename
 
         try:
-            
+
             # Save metrics to file
             use_encryption = kwargs.get('use_encryption', False)
-            encryption_key= kwargs.get('encryption_key', None) if use_encryption else None
+            encryption_key = kwargs.get('encryption_key', None) if use_encryption else None
             write_json(metrics, metrics_path, encryption_key=encryption_key)
 
             result.add_artifact(
@@ -386,22 +461,25 @@ class SplitFieldsOperation(TransformationOperation):
 
             try:
                 use_encryption = kwargs.get('use_encryption', False)
-                encryption_key= kwargs.get('encryption_key', None) if use_encryption else None
+                encryption_key = kwargs.get('encryption_key', None)
+                encryption_mode = get_encryption_mode(df, **kwargs)
                 if self.output_format == OutputFormat.CSV.value:
-                    write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key)
+                    write_dataframe_to_csv(df=df, file_path=output_path, encryption_key=encryption_key,
+                                           use_encryption=use_encryption, encryption_mode=encryption_mode)
                 elif self.output_format == OutputFormat.JSON.value:
                     if encryption_key:
                         file_path = Path(output_path)
                         temp_dir = file_path.parent / "temp"
                         temp_dir.mkdir(parents=True, exist_ok=True)
                         temp_destination_path = temp_dir / f"decrypted_{file_path.name}"
-                        
+
                         df.to_json(temp_destination_path, orient="records", lines=True)
-                        
+
                         crypto_utils.encrypt_file(
                             source_path=temp_destination_path,
                             destination_path=output_path,
-                            key=encryption_key
+                            key=encryption_key,
+                            mode=encryption_mode
                         )
                         directory_utils.safe_remove_temp_file(temp_destination_path)
                     else:
@@ -427,7 +505,7 @@ class SplitFieldsOperation(TransformationOperation):
                                  task_dir: Path,
                                  result: OperationResult,
                                  **kwargs) -> None:
-        """Generate visualizations specific to this operation."""
+        """Generate visualizations specific to this operation using standard visualization module."""
         if not isinstance(output_data, dict) or not output_data:
             self.logger.warning("Skipping visualization: output_data is not a non-empty dictionary of DataFrames.")
             return
@@ -438,137 +516,81 @@ class SplitFieldsOperation(TransformationOperation):
         suffix = f"_{self.timestamp}" if self.timestamp else ""
         operation = self.__class__.__name__
 
-        bar_chart_path = self._plot_fields_per_subset_bar_chart(output_data, vis_dir, suffix, operation, **kwargs)
-        if bar_chart_path:
-            result.add_artifact(
-                artifact_type="png",
-                path=bar_chart_path,
-                description="Bar chart showing number of fields in each subset",
-                category=Constants.Artifact_Category_Visualization
-            )
+        kwargs["backend"] = kwargs.pop("visualization_backend", self.visualization_backend)
+        kwargs["theme"] = kwargs.pop("visualization_theme", self.visualization_theme)
+        kwargs["strict"] = kwargs.pop("visualization_strict", self.visualization_strict)
 
-        network_path = self._plot_field_subset_network(output_data, vis_dir, suffix, operation, **kwargs)
-        if network_path:
-            result.add_artifact(
-                artifact_type="png",
-                path=network_path,
-                description="Network diagram showing field distribution across subsets (Plotly)",
-                category=Constants.Artifact_Category_Visualization
+        # 1. Bar chart: number of fields per subset
+        try:
+            subset_field_counts = {k: len(df.columns) for k, df in output_data.items()}
+            bar_chart_path = vis_dir / f"{operation}_viz_fields_per_subset{suffix}.png"
+            bar_result = create_bar_plot(
+                data=subset_field_counts,
+                output_path=bar_chart_path,
+                title="Number of Fields per Subset",
+                orientation="v",
+                x_label="Subset",
+                y_label="Number of Fields",
+                sort_by="key",
+                **kwargs
             )
-
-        if isinstance(input_data, pd.DataFrame):
-            schema_path = self._plot_schema_comparison(input_data, output_data, vis_dir, suffix, operation, **kwargs)
-            if schema_path:
+            if not bar_result.startswith("Error"):
                 result.add_artifact(
                     artifact_type="png",
-                    path=schema_path,
-                    description="Schema visualization of original vs. split datasets",
+                    path=bar_result,
+                    description="Bar chart showing number of fields in each subset",
                     category=Constants.Artifact_Category_Visualization
                 )
+        except Exception as e:
+            self.logger.error(f"Failed to create fields-per-subset bar chart: {e}")
 
-    def _plot_fields_per_subset_bar_chart(self, output_data: Dict[str, pd.DataFrame], vis_dir: Path, suffix: str, operation: str, **kwargs) -> Path:
-        """Create a bar chart showing the number of fields in each subset."""
-        subset_field_counts = {k: len(df.columns) for k, df in output_data.items()}
+        # 2. Network diagram: field distribution across subsets
+        try:
+            network_path = vis_dir / f"{operation}_viz_field_subset_network{suffix}.png"
+            network_result = plot_field_subset_network(
+                output_data=output_data,
+                output_path=network_path,
+                title="Field Distribution Across Subsets (Network Diagram)",
+                **kwargs
+            )
+            if not network_result.startswith("Error"):
+                result.add_artifact(
+                    artifact_type="png",
+                    path=network_result,
+                    description="Network diagram showing field distribution across subsets (Plotly)",
+                    category=Constants.Artifact_Category_Visualization
+                )
+        except Exception as e:
+            self.logger.error(f"Failed to create field-subset network diagram: {e}")
 
-        fig, ax = plt.subplots(figsize=(10, 6))
-        sns.barplot(x=list(subset_field_counts.keys()), y=list(subset_field_counts.values()), ax=ax)
-        ax.set_title("Number of Fields per Subset")
-        ax.set_xlabel("Subset")
-        ax.set_ylabel("Number of Fields")
-        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
-        plt.xticks(rotation=45)
+        # 3. Bar chart: schema comparison (optional)
+        if isinstance(input_data, pd.DataFrame):
+            try:
+                schema_data = {"Original": len(input_data.columns)}
+                schema_data.update({k: len(df.columns) for k, df in output_data.items()})
 
-        bar_chart_path = vis_dir / f"{operation}_viz_fields_per_subset{suffix}.png"
-        plt.tight_layout()
-        
-        _save_figure(fig, bar_chart_path, **kwargs)
-        return bar_chart_path
+                schema_path = vis_dir / f"{operation}_viz_schema_comparison{suffix}.png"
+                schema_result = create_bar_plot(
+                    data=schema_data,
+                    output_path=schema_path,
+                    title="Schema Comparison: Original vs. Split Datasets",
+                    orientation="v",
+                    x_label="Dataset",
+                    y_label="Number of Fields",
+                    sort_by="key",
+                    **kwargs
+                )
+                if not schema_result.startswith("Error"):
+                    result.add_artifact(
+                        artifact_type="png",
+                        path=schema_result,
+                        description="Schema visualization of original vs. split datasets",
+                        category=Constants.Artifact_Category_Visualization
+                    )
+            except Exception as e:
+                self.logger.error(f"Failed to create schema comparison chart: {e}")
 
-    def _plot_field_subset_network(self, output_data: Dict[str, pd.DataFrame], vis_dir: Path, suffix: str, operation: str, **kwargs) -> Path:
-        """Create a network diagram showing how fields are distributed across subsets using Plotly."""
-        nodes = set()
-        edges = []
-        node_types = {}
-
-        for subset_name, df in output_data.items():
-            nodes.add(subset_name)
-            node_types[subset_name] = "subset"
-            for col in df.columns:
-                nodes.add(col)
-                node_types[col] = "field"
-                edges.append((subset_name, col))
-
-        subset_nodes = [n for n in nodes if node_types[n] == "subset"]
-        field_nodes = [n for n in nodes if node_types[n] == "field"]
-
-        positions = {n: (0, i * -1.5) for i, n in enumerate(subset_nodes)}
-        positions.update({n: (3, i * -1.2) for i, n in enumerate(field_nodes)})
-
-        edge_x, edge_y = [], []
-        for src, tgt in edges:
-            x0, y0 = positions[src]
-            x1, y1 = positions[tgt]
-            edge_x += [x0, x1, None]
-            edge_y += [y0, y1, None]
-
-        edge_trace = go.Scatter(
-            x=edge_x, y=edge_y,
-            line=dict(width=1, color='gray'),
-            hoverinfo='none',
-            mode='lines'
-        )
-
-        node_x, node_y, node_text, node_color = [], [], [], []
-        for node in nodes:
-            x, y = positions[node]
-            node_x.append(x)
-            node_y.append(y)
-            node_text.append(node)
-            node_color.append("skyblue" if node_types[node] == "subset" else "lightgreen")
-
-        node_trace = go.Scatter(
-            x=node_x, y=node_y,
-            mode='markers+text',
-            marker=dict(size=20, color=node_color, line=dict(width=1, color='black')),
-            text=node_text,
-            textposition="top center",
-            hoverinfo='text'
-        )
-
-        fig = go.Figure(data=[edge_trace, node_trace],
-                        layout=go.Layout(
-                            title=dict(text='Field Distribution Across Subsets (Network Diagram)', font=dict(size=16)),
-                            showlegend=False,
-                            hovermode='closest',
-                            margin=dict(b=20, l=20, r=20, t=40),
-                            xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
-                            yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
-                            plot_bgcolor='white'
-                        ))
-
-        network_path = vis_dir / f"{operation}_viz_field_subset_network{suffix}.png"
-        _save_figure(fig, network_path, **kwargs)
-        return network_path
-
-    def _plot_schema_comparison(self, input_data: pd.DataFrame, output_data: Dict[str, pd.DataFrame], vis_dir: Path, suffix: str, operation: str, **kwargs) -> Path:
-        """Create a bar chart comparing the schema of the original dataset to the split subsets."""
-        fig, ax = plt.subplots(figsize=(10, 6))
-        original_columns = input_data.columns
-        sns.barplot(x=["Original"] + list(output_data.keys()),
-                    y=[len(original_columns)] + [len(df.columns) for df in output_data.values()],
-                    palette="pastel", ax=ax)
-        ax.set_title("Schema Comparison: Original vs. Split Datasets")
-        ax.set_ylabel("Number of Fields")
-        ax.set_xlabel("Dataset")
-        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
-
-        schema_path = vis_dir / f"{operation}_viz_schema_comparison{suffix}.png"
-        plt.tight_layout()
-        _save_figure(fig, schema_path, **kwargs)
-
-        return schema_path
-
-    def _save_cache(self, task_dir: Path, result: OperationResult) -> None:
+    def _save_cache(self, task_dir: Path, result: OperationResult, **kwargs) -> None:
         """
         Save the operation result to cache.
 
@@ -591,13 +613,13 @@ class SplitFieldsOperation(TransformationOperation):
 
             cache_data = {
                 "result": result_data,
-                "parameters": self._get_cache_parameters(),
+                "parameters": self._get_cache_parameters(**kwargs),
             }
 
             cache_key = operation_cache.generate_cache_key(
                 operation_name=self.__class__.__name__,
-                parameters=self._get_cache_parameters(),
-                data_hash=self._generate_data_hash(self.original_df.copy())
+                parameters=self._get_cache_parameters(**kwargs),
+                data_hash=self._generate_data_hash(self._original_df.copy())
             )
 
             operation_cache.save_cache(
@@ -611,7 +633,7 @@ class SplitFieldsOperation(TransformationOperation):
         except Exception as e:
             self.logger.warning(f"Failed to save cache: {e}")
 
-    def _get_cache(self, df: pd.DataFrame) -> Optional[OperationResult]:
+    def _get_cache(self, df: pd.DataFrame, **kwargs) -> Optional[OperationResult]:
         """
         Retrieve cached result if available and valid.
 
@@ -628,7 +650,7 @@ class SplitFieldsOperation(TransformationOperation):
         try:
             cache_key = operation_cache.generate_cache_key(
                 operation_name=self.__class__.__name__,
-                parameters=self._get_cache_parameters(),
+                parameters=self._get_cache_parameters(**kwargs),
                 data_hash=self._generate_data_hash(df)
             )
 
@@ -674,26 +696,41 @@ class SplitFieldsOperation(TransformationOperation):
             self.logger.warning(f"Failed to load cache: {e}")
             return None
 
-    def _get_cache_parameters(self) -> Dict[str, Any]:
+    def _get_cache_parameters(self, **kwargs) -> Dict[str, Any]:
         """
-        Get operation-specific parameters required for generating a cache key.
+        Get operation-specific parameters for SplitFieldsOperation using external kwargs.
 
-        These parameters define the behavior of the transformation and are used
-        to determine cache uniqueness.
+        Parameters
+        ----------
+        **kwargs : dict
+            Dictionary of parameters that may override instance attributes.
 
         Returns
         -------
         Dict[str, Any]
             Dictionary of relevant parameters to identify the operation configuration.
         """
-        params = {
+
+        return {
             "operation": self.__class__.__name__,
-            "version": self.version,  # To support invalidation on version changes
-            "field_groups": self.field_groups,
-            "include_id_field": self.include_id_field,
-            "id_field": self.id_field,
+            "version": self.version,
+            "id_field": kwargs.get("id_field"),
+            "field_groups": kwargs.get("field_groups"),
+            "include_id_field": kwargs.get("include_id_field"),
+            "output_format": kwargs.get("output_format"),
+            "save_output": kwargs.get("save_output"),
+            "use_cache": kwargs.get("use_cache"),
+            "force_recalculation": kwargs.get("force_recalculation"),
+            "use_dask": kwargs.get("use_dask"),
+            "npartitions": kwargs.get("npartitions"),
+            "use_vectorization": kwargs.get("use_vectorization"),
+            "parallel_processes": kwargs.get("parallel_processes"),
+            "visualization_backend": kwargs.get("visualization_backend"),
+            "visualization_theme": kwargs.get("visualization_theme"),
+            "visualization_strict": kwargs.get("visualization_strict"),
+            "use_encryption": kwargs.get("use_encryption"),
+            "encryption_key": str(kwargs.get("encryption_key")) if kwargs.get("encryption_key") else None
         }
-        return params
 
     def _generate_data_hash(self, data: pd.DataFrame) -> str:
         """
@@ -751,7 +788,40 @@ class SplitFieldsOperation(TransformationOperation):
             fallback = f"{data.shape}_{list(data.dtypes)}"
             return hashlib.md5(fallback.encode()).hexdigest()
 
-    def _validate_parameters(self, df: pd.DataFrame) -> bool:
+    def _set_input_parameters(self, **kwargs):
+        """
+        Set common configurable operation parameters from keyword arguments.
+        """
+
+        self.id_field = kwargs.get("id_field", getattr(self, "id_field", None))
+        self.field_groups = kwargs.get("field_groups", getattr(self, "field_groups", None))
+        self.include_id_field = kwargs.get("include_id_field", getattr(self, "include_id_field", True))
+
+        self.generate_visualization = kwargs.get("generate_visualization", getattr(self, "generate_visualization", True))
+        self.save_output = kwargs.get("save_output", getattr(self, "save_output", True))
+        self.output_format = kwargs.get("output_format", getattr(self, "output_format", OutputFormat.CSV.value))
+        self.include_timestamp = kwargs.get("include_timestamp", getattr(self, "include_timestamp", True))
+
+        self.use_cache = kwargs.get("use_cache", getattr(self, "use_cache", True))
+        self.force_recalculation = kwargs.get("force_recalculation", getattr(self, "force_recalculation", False))
+
+        self.use_dask = kwargs.get("use_dask", getattr(self, "use_dask", False))
+        self.npartitions = kwargs.get("npartitions", getattr(self, "npartitions", 1))
+
+        self.use_vectorization = kwargs.get("use_vectorization", getattr(self, "use_vectorization", False))
+        self.parallel_processes = kwargs.get("parallel_processes", getattr(self, "parallel_processes", 1))
+
+        self.visualization_backend = kwargs.get("visualization_backend", getattr(self, "visualization_backend", False))
+        self.visualization_theme = kwargs.get("visualization_theme", getattr(self, "visualization_theme", None))
+        self.visualization_strict = kwargs.get("visualization_strict", getattr(self, "visualization_strict", None))
+
+        self.use_encryption = kwargs.get("use_encryption", getattr(self, "use_encryption", False))
+        self.encryption_key = kwargs.get("encryption_key",
+                                         getattr(self, "encryption_key", None)) if self.use_encryption else None
+
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S") if self.include_timestamp else ""
+
+    def _validate_input_parameters(self, df: pd.DataFrame) -> bool:
         """
         Validate that all specified fields in field_groups exist in the DataFrame.
         Optionally check if the ID field exists.
@@ -789,46 +859,46 @@ class SplitFieldsOperation(TransformationOperation):
         # All validations passed
         return True
 
-    def _initialize_logger(self, task_dir: Path):
-        """
-        Initialize the logger for the operation using the class name as task_id.
+    def _load_data_and_validate_input_parameters(self, data_source: DataSource, **kwargs) -> Tuple[Optional[pd.DataFrame], bool]:
+        dataset_name = kwargs.get('dataset_name', "main")
+        settings_operation = load_settings_operation(data_source, dataset_name, **kwargs)
+        df = load_data_operation(data_source, dataset_name, **settings_operation)
 
-        Parameters
-        ----------
-        task_dir : Path
-            The base directory for the task, used to determine log directory.
-        """
-        task_id = self.__class__.__name__
-        log_dir = task_dir / "logs"
+        if df is None or df.empty:
+            self.logger.error("Error data frame is None or empty")
+            return None, False
 
-        self.logger = configure_task_logging(
-            task_id=task_id,
-            log_level="INFO",
-            log_dir=log_dir,
-        )
+        self._input_dataset = dataset_name
+        self._original_df = df.copy(deep=True)
 
-    def _set_common_operation_parameters(self, **kwargs):
-        """
-        Set common configurable operation parameters from keyword arguments.
-        """
+        self._set_input_parameters(**kwargs)
 
-        self.id_field = kwargs.get("id_field", getattr(self, "id_field", None))
-        self.field_groups = kwargs.get("field_groups", getattr(self, "field_groups", None))
-        self.include_id_field = kwargs.get("include_id_field", getattr(self, "include_id_field", True))
-        self.output_format = kwargs.get("output_format", getattr(self, "output_format", OutputFormat.CSV.value))
+        return df, self._validate_input_parameters(df)
 
-        self.force_recalculation = kwargs.get("force_recalculation", getattr(self, "force_recalculation", False))
-        self.generate_visualization = kwargs.get("generate_visualization",
-                                                 getattr(self, "generate_visualization", True))
-        self.include_timestamp = kwargs.get("include_timestamp", getattr(self, "include_timestamp", True))
-        self.save_output = kwargs.get("save_output", getattr(self, "save_output", True))
+    def _compute_total_steps(self, **kwargs) -> int:
+        use_cache = kwargs.get("use_cache", self.use_cache)
+        force_recalculation = kwargs.get("force_recalculation", self.force_recalculation)
+        save_output = kwargs.get("save_output", self.save_output)
+        generate_visualization = kwargs.get("save_output", self.generate_visualization)
 
-        self.parallel_processes = kwargs.get("parallel_processes", getattr(self, "parallel_processes", 1))
-        self.batch_size = kwargs.get("batch_size", getattr(self, "batch_size", 10000))
-        self.use_cache = kwargs.get("use_cache", getattr(self, "use_cache", False))
-        self.use_dask = kwargs.get("use_dask", getattr(self, "use_dask", False))
+        steps = 0
 
-        self.use_encryption = kwargs.get("use_encryption", getattr(self, "use_encryption", False))
-        self.encryption_key = kwargs.get("encryption_key", getattr(self, "encryption_key", None))
+        steps += 1  # Step 1: Preparation
+        steps += 1  # Step 2: Load data and validate input
 
-        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S") if self.include_timestamp else ""
+        if use_cache and not force_recalculation:
+            steps += 1  # Step 3: Try to load from cache
+
+        steps += 1  # Step 4: Process data
+        steps += 1  # Step 5: Collect metrics
+
+        if save_output:
+            steps += 1  # Step 6: Save output
+
+        if generate_visualization:
+            steps += 1  # Step 7: Generate visualizations
+
+        if use_cache:
+            steps += 1  # Step 8: Save cache
+
+        return steps

--- a/pamola_core/utils/crypto_helpers/providers/age_provider.py
+++ b/pamola_core/utils/crypto_helpers/providers/age_provider.py
@@ -20,10 +20,12 @@ from pamola_core.utils.crypto_helpers.errors import (
     AgeToolError
 )
 from pamola_core.utils.io_helpers.provider_interface import CryptoProvider
+from dotenv import load_dotenv
+load_dotenv()
 
 # Constants - only keep constant values at module level
 AGE_HEADER = b"age-encryption.org/"
-AGE_BINARY = os.environ.get("PAMOLA_AGE_BINARY", "age")
+AGE_BINARY = os.environ.get("PAMOLA_AGE_BINARY", "pamola_datasets/age_binary/age")
 
 
 class AgeProvider(CryptoProvider):
@@ -115,9 +117,8 @@ class AgeProvider(CryptoProvider):
             If no recipients are available
         """
         # Read environment variables at method call time, not module import time
-        age_recipients = os.environ.get("PAMOLA_AGE_RECIPIENTS", "").split(',')
-        age_recipients_file = os.environ.get("PAMOLA_AGE_RECIPIENTS_FILE", "")
-
+        age_recipients = os.environ.get("PAMOLA_AGE_RECIPIENTS", "age1zz3p45xsyk569u6k4mqhryuppjmhcgn4rfjnnac40gjhaes354sqfq2s9z").split(',')
+        age_recipients_file = os.environ.get("PAMOLA_AGE_RECIPIENTS_FILE", "pamola_datasets/age_binary/recipient.txt")
         recipients = []
 
         # Add recipients from environment
@@ -153,7 +154,7 @@ class AgeProvider(CryptoProvider):
             If no identity file is available
         """
         # Read environment variable at method call time
-        age_identity_file = os.environ.get("PAMOLA_AGE_IDENTITY_FILE", "")
+        age_identity_file = os.environ.get("PAMOLA_AGE_IDENTITY_FILE", "pamola_datasets/age_binary/age.key")
 
         # Use identity file
         if not age_identity_file:

--- a/pamola_core/utils/ops/op_base.py
+++ b/pamola_core/utils/ops/op_base.py
@@ -138,7 +138,8 @@ class BaseOperation(ABC):
                  config: Optional[OperationConfig] = None,
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
-                 use_vectorization: bool = False):
+                 use_vectorization: bool = False,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize the operation.
 
@@ -165,6 +166,7 @@ class BaseOperation(ABC):
         self.config = config or OperationConfig()
         self.use_encryption = use_encryption
         self.encryption_key = encryption_key
+        self.encryption_mode = encryption_mode
         self.use_vectorization = use_vectorization
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
@@ -220,7 +222,7 @@ class BaseOperation(ABC):
 
             # Atomic replace
             os.replace(temp_path, config_path)
-            self.logger.info(f"Saved operation configuration to {config_path}")
+            self.logger.info(f"Saved operation configuration to {Path(config_path).name}")
         except Exception as e:
             self.logger.error(f"Failed to save configuration: {str(e)}")
             raise ConfigSaveError(f"Failed to save configuration: {str(e)}") from e
@@ -528,7 +530,8 @@ class FieldOperation(BaseOperation):
                  config: Optional[OperationConfig] = None,
                  use_encryption: bool = False,
                  encryption_key: Optional[Union[str, Path]] = None,
-                 use_vectorization: bool = False):
+                 use_vectorization: bool = False,
+                 encryption_mode: Optional[str] = None):
         """
         Initialize a field-specific operation.
 
@@ -557,7 +560,8 @@ class FieldOperation(BaseOperation):
             config=config,
             use_encryption=use_encryption,
             encryption_key=encryption_key,
-            use_vectorization=use_vectorization
+            use_vectorization=use_vectorization,
+            encryption_mode=encryption_mode
         )
         self.field_name = field_name
 

--- a/pamola_core/utils/ops/op_data_reader.py
+++ b/pamola_core/utils/ops/op_data_reader.py
@@ -82,6 +82,8 @@ class DataReader:
                        auto_optimize: bool = True,
                        show_progress: bool = True,
                        detect_parameters: bool = True,
+                       use_encryption: bool = False,
+                       encryption_mode: Optional[str] = None,
                        **kwargs) -> ResultWithError:
         """
         Read a DataFrame from various sources with comprehensive options.
@@ -218,22 +220,22 @@ class DataReader:
                     source, file_format, encoding, delimiter, quotechar,
                     columns, nrows, skiprows, use_dask,
                     encryption_key, show_progress,
-                    progress_tracker, **kwargs
+                    progress_tracker, use_encryption, encryption_mode, **kwargs
                 )
             elif file_format in ('parquet', 'pq'):
                 df, error_info = self._read_parquet_format(
                     source, columns, nrows, skiprows,
-                    encryption_key, **kwargs
+                    encryption_key, use_encryption, encryption_mode, **kwargs
                 )
             elif file_format in ('xls', 'xlsx', 'xlsm'):
                 df, error_info = self._read_excel_format(
                     source, sheet_name, columns, nrows, skiprows,
-                    encryption_key, show_progress, **kwargs
+                    encryption_key, show_progress, use_encryption, encryption_mode, **kwargs
                 )
             elif file_format == 'json':
                 df, error_info = self._read_json_format(
                     source, encoding, columns, nrows, skiprows,
-                    encryption_key, **kwargs
+                    encryption_key, use_encryption, encryption_mode, **kwargs
                 )
             else:
                 # For other formats, use generic read_dataframe from io.py
@@ -303,7 +305,10 @@ class DataReader:
     def _read_csv_format(self, source, file_format, encoding, delimiter, quotechar,
                          columns, nrows, skiprows, use_dask,
                          encryption_key, show_progress,
-                         progress_tracker=None, **kwargs) -> ResultWithError:
+                         progress_tracker=None,
+                         use_encryption: bool = False,
+                         encryption_mode: Optional[str] = None,
+                         **kwargs) -> ResultWithError:
         """Read data from CSV-like formats using io.py functions."""
         try:
             # For TSV format, override delimiter
@@ -321,7 +326,9 @@ class DataReader:
                 skiprows=skiprows,
                 use_dask=use_dask,
                 encryption_key=encryption_key,
-                show_progress=show_progress
+                show_progress=show_progress,
+                use_encryption=use_encryption,
+                encryption_mode=encryption_mode
             )
             return df, None
         except Exception as e:
@@ -333,7 +340,10 @@ class DataReader:
             return None, error_info
 
     def _read_parquet_format(self, source, columns, nrows, skiprows,
-                             encryption_key, **kwargs) -> ResultWithError:
+                             encryption_key,
+                             use_encryption: bool = False,
+                             encryption_mode: Optional[str] = None,
+                             **kwargs) -> ResultWithError:
         """Read data from Parquet format using io.py functions."""
         try:
             # Use io.py's read_parquet
@@ -341,6 +351,8 @@ class DataReader:
                 file_path=source,
                 columns=columns,
                 encryption_key=encryption_key,
+                use_encryption=use_encryption,
+                encryption_mode=encryption_mode,
                 **kwargs
             )
 
@@ -365,7 +377,10 @@ class DataReader:
             return None, error_info
 
     def _read_excel_format(self, source, sheet_name, columns, nrows, skiprows,
-                           encryption_key, show_progress, **kwargs) -> ResultWithError:
+                           encryption_key, show_progress,
+                           use_encryption: bool = False,
+                           encryption_mode: Optional[str] = None,
+                           **kwargs) -> ResultWithError:
         """Read data from Excel format using io.py functions."""
         try:
             # Use io.py's read_excel
@@ -377,6 +392,8 @@ class DataReader:
                 skiprows=skiprows,
                 encryption_key=encryption_key,
                 show_progress=show_progress,
+                use_encryption=use_encryption,
+                encryption_mode=encryption_mode,
                 **kwargs
             )
             return df, None
@@ -389,7 +406,10 @@ class DataReader:
             return None, error_info
 
     def _read_json_format(self, source, encoding, columns, nrows, skiprows,
-                          encryption_key, **kwargs) -> ResultWithError:
+                          encryption_key,
+                          use_encryption: bool = False,
+                          encryption_mode: Optional[str] = None,
+                          **kwargs) -> ResultWithError:
         """Read data from JSON format using io.py functions."""
         try:
             # Use io.py's read_json
@@ -397,6 +417,8 @@ class DataReader:
                 file_path=source,
                 encoding=encoding,
                 encryption_key=encryption_key,
+                use_encryption=use_encryption,
+                encryption_mode=encryption_mode,
                 **kwargs
             )
 

--- a/pamola_core/utils/ops/op_data_writer.py
+++ b/pamola_core/utils/ops/op_data_writer.py
@@ -258,7 +258,7 @@ class DataWriter:
                 raise DataWriteError(f"File {output_path} already exists and overwrite=False")
 
             # Log writing operation
-            self.logger.info(f"Writing {format.upper()} data to {output_path}")
+            self.logger.info(f"Writing {format.upper()} data to {Path(output_path).name}")
 
             # Handle Dask DataFrames specially
             if isinstance(df, dd.DataFrame):
@@ -507,7 +507,7 @@ class DataWriter:
                 raise DataWriteError(f"File {output_path} already exists and overwrite=False")
 
             # Log writing operation
-            self.logger.info(f"Writing JSON data to {output_path}")
+            self.logger.info(f"Writing JSON data to {Path(output_path).name}")
 
             # Set indent if pretty-printing
             if "indent" not in kwargs and pretty:

--- a/pamola_core/utils/tasks/context_manager.py
+++ b/pamola_core/utils/tasks/context_manager.py
@@ -278,7 +278,7 @@ class TaskContextManager:
 
                 # Log successful completion
                 self.logger.info(
-                    f"Successfully cleared checkpoints from {checkpoint_dir}. Initially found {existing_count}.")
+                    f"Successfully cleared checkpoints. Initially found {existing_count}.")
 
                 # Log through progress manager if available
                 if self.progress_manager:
@@ -552,7 +552,7 @@ class TaskContextManager:
                 if self.progress_manager:
                     self.progress_manager.log_info(f"Saved checkpoint: {checkpoint_name}")
                 else:
-                    self.logger.info(f"Saved execution state to checkpoint: {checkpoint_path}")
+                    self.logger.info(f"Saved execution state to checkpoint: {Path(checkpoint_path).name}")
 
                 return checkpoint_path
 

--- a/pamola_core/utils/tasks/directory_manager.py
+++ b/pamola_core/utils/tasks/directory_manager.py
@@ -584,7 +584,7 @@ class TaskDirectoryManager:
                     return False
                 else:
                     self.progress_manager.log_info(
-                        f"Successfully cleaned {items_removed} items from temp directory: {temp_dir}")
+                        f"Successfully cleaned {items_removed} items from temp directory: {Path(temp_dir).name}")
                     return True
 
         except Exception as e:
@@ -622,7 +622,7 @@ class TaskDirectoryManager:
                 f"Cleaned {items_removed} items from temp directory with {errors} errors: {temp_dir}")
             return False
         else:
-            self.logger.info(f"Successfully cleaned {items_removed} items from temp directory: {temp_dir}")
+            self.logger.info(f"Successfully cleaned {items_removed} items from temp directory: {Path(temp_dir).name}")
             return True
 
     def get_timestamped_filename(self, base_name: str, extension: str = "json") -> str:

--- a/pamola_core/utils/tasks/encryption_manager.py
+++ b/pamola_core/utils/tasks/encryption_manager.py
@@ -23,7 +23,6 @@ Key features:
 import base64
 import logging
 import secrets
-from enum import Enum
 from pathlib import Path
 from typing import Dict, Any, Optional, Union, List, TYPE_CHECKING
 
@@ -92,34 +91,12 @@ except ImportError:  # pragma: no cover
         pass
 
 # Import path security validation
+from pamola_core.common.enum.encryption_mode import EncryptionMode
 from pamola_core.utils.tasks.path_security import validate_path_security, PathSecurityError
 
 # Set up logger with a null handler (will be replaced by proper handler)
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-
-
-class EncryptionMode(Enum):
-    """
-    Encryption modes supported by the task framework.
-
-    - NONE: No encryption
-    - SIMPLE: Simple symmetric encryption using Fernet
-    - AGE: Age encryption (more secure, supports key rotation)
-    """
-    NONE = "none"
-    SIMPLE = "simple"
-    AGE = "age"
-
-    @classmethod
-    def from_string(cls, value: str) -> 'EncryptionMode':
-        """Convert string to EncryptionMode enum value."""
-        try:
-            return cls(value.lower())
-        except (ValueError, AttributeError):
-            logger.warning(f"Invalid encryption mode '{value}', defaulting to 'simple'")
-            return cls.SIMPLE
-
 
 class EncryptionContext:
     """

--- a/pamola_core/utils/tasks/templates/secure_task_template.py
+++ b/pamola_core/utils/tasks/templates/secure_task_template.py
@@ -31,8 +31,8 @@ from pathlib import Path
 from typing import Dict, Any, Optional
 
 # Import PAMOLA Core modules
+from pamola_core.common.enum.encryption_mode import EncryptionMode
 from pamola_core.utils.tasks.base_task import BaseTask
-from pamola_core.utils.tasks.task_config import EncryptionMode
 from pamola_core.utils.tasks.task_utils import ensure_secure_directory
 
 # Safe import of utility functions - moved to module level

--- a/tests/fake_data/commons/test_dict_helpers.py
+++ b/tests/fake_data/commons/test_dict_helpers.py
@@ -337,8 +337,7 @@ class TestLoadMultiDictionary(unittest.TestCase):
         result = dict_helpers.load_multi_dictionary("domain", {}, fallback_to_embedded=True)
         self.assertEqual(result, ["gmail.com", "yahoo.com"])
 
-    # Error #
-    @patch("pamola_core.fake_data.commons.dict_helpers.phones.get_area_codes")
+    @patch("pamola_core.fake_data.commons.dict_helpers.phones.get_country_codes")
     def test_fallback_phone(self, mock_phones):
         mock_phones.return_value = ["212", "646"]
         result = dict_helpers.load_multi_dictionary("phone", {"country": "US"})

--- a/tests/fake_data/commons/test_operations.py
+++ b/tests/fake_data/commons/test_operations.py
@@ -1,0 +1,480 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch, call, ANY
+import pandas as pd
+from pamola_core.common.constants import Constants
+from pamola_core.fake_data.commons.base import BaseGenerator, NullStrategy, ValidationError
+from pamola_core.fake_data.commons.mapping_store import MappingStore
+from pamola_core.fake_data.commons.operations import GeneratorOperation, FieldOperation
+from pamola_core.utils.ops.op_result import OperationResult, OperationStatus
+
+
+class TestGeneratorOperationInit(unittest.TestCase):
+
+    def test_initialization_with_defaults(self):
+        mock_generator = Mock(spec=BaseGenerator)
+
+        op = GeneratorOperation(
+            field_name="test_field",
+            generator=mock_generator
+        )
+
+        self.assertEqual(op.field_name, "test_field")
+        self.assertEqual(op.generator, mock_generator)
+        self.assertEqual(op.mode, "REPLACE")
+        self.assertEqual(op.chunk_size, 10000)
+        self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
+        self.assertEqual(op.consistency_mechanism, "prgn")
+        self.assertIsInstance(op.mapping_store, MappingStore)
+        self.assertEqual(op.generator_params, {})
+        self.assertTrue(op.use_cache)
+        self.assertFalse(op.force_recalculation)
+        self.assertFalse(op.use_dask)
+        self.assertEqual(op.npartitions, 1)
+        self.assertFalse(op.use_vectorization)
+        self.assertEqual(op.parallel_processes, 1)
+        self.assertFalse(op.use_encryption)
+        self.assertIsNone(op.encryption_key)
+        self.assertIsNone(op.visualization_backend)
+        self.assertIsNone(op.visualization_theme)
+        self.assertFalse(op.visualization_strict)
+        self.assertIn("Operation for generating fake", op.description)
+
+    def test_initialization_with_parameters(self):
+        mock_generator = Mock(spec=BaseGenerator)
+        custom_mapping_store = MappingStore()
+        custom_params = {"locale": "en_US"}
+
+        op = GeneratorOperation(
+            field_name="email",
+            generator=mock_generator,
+            mode="ENRICH",
+            output_field_name="synthetic_email",
+            chunk_size=5000,
+            null_strategy=NullStrategy.EXCLUDE,
+            consistency_mechanism="mapping",
+            mapping_store=custom_mapping_store,
+            generator_params=custom_params,
+            use_cache=False,
+            force_recalculation=True,
+            use_dask=True,
+            npartitions=4,
+            use_vectorization=True,
+            parallel_processes=2,
+            use_encryption=True,
+            encryption_key="secret",
+            visualization_backend="plotly",
+            visualization_theme="dark",
+            visualization_strict=True
+        )
+
+        self.assertEqual(op.field_name, "email")
+        self.assertEqual(op.generator, mock_generator)
+        self.assertEqual(op.mode, "ENRICH")
+        self.assertEqual(op.output_field_name, "synthetic_email")
+        self.assertEqual(op.chunk_size, 5000)
+        self.assertEqual(op.null_strategy, NullStrategy.EXCLUDE)
+        self.assertEqual(op.consistency_mechanism, "mapping")
+        self.assertEqual(op.mapping_store, custom_mapping_store)
+        self.assertEqual(op.generator_params, custom_params)
+        self.assertFalse(op.use_cache)
+        self.assertTrue(op.force_recalculation)
+        self.assertTrue(op.use_dask)
+        self.assertEqual(op.npartitions, 4)
+        self.assertTrue(op.use_vectorization)
+        self.assertEqual(op.parallel_processes, 2)
+        self.assertTrue(op.use_encryption)
+        self.assertEqual(op.encryption_key, "secret")
+        self.assertEqual(op.visualization_backend, "plotly")
+        self.assertEqual(op.visualization_theme, "dark")
+        self.assertTrue(op.visualization_strict)
+
+
+class TestGeneratorOperationProcessBatch(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_generator = Mock(spec=BaseGenerator)
+        self.mock_generator.generate_like.return_value = "synthetic"
+
+    def create_operation(self, mode="REPLACE", null_strategy=NullStrategy.PRESERVE):
+        op = GeneratorOperation(
+            field_name="name",
+            generator=self.mock_generator,
+            mode=mode,
+            null_strategy=null_strategy
+        )
+        op._process_value = Mock(side_effect=lambda x: f"synthetic_{x}" if x else "synthetic_NULL")
+        return op
+
+    def test_replace_mode_with_valid_values(self):
+        df = pd.DataFrame({"name": ["Alice", "Bob"]})
+        op = self.create_operation(mode="REPLACE")
+        result = op.process_batch(df)
+        self.assertListEqual(result["name"].tolist(), ["synthetic_Alice", "synthetic_Bob"])
+
+    def test_enrich_mode_with_valid_values(self):
+        df = pd.DataFrame({"name": ["Alice", "Bob"]})
+        op = self.create_operation(mode="ENRICH")
+        op.output_field_name = "synthetic_name"
+        result = op.process_batch(df)
+        self.assertListEqual(result["synthetic_name"].tolist(), ["synthetic_Alice", "synthetic_Bob"])
+        self.assertListEqual(result["name"].tolist(), ["Alice", "Bob"])  # original unchanged
+
+    def test_null_preserve(self):
+        df = pd.DataFrame({"name": ["Alice", None, "Bob"]})
+        op = self.create_operation(mode="REPLACE", null_strategy=NullStrategy.PRESERVE)
+        result = op.process_batch(df)
+        self.assertListEqual(result["name"].tolist(), ["synthetic_Alice", None, "synthetic_Bob"])
+
+    def test_null_replace(self):
+        df = pd.DataFrame({"name": [None, "Charlie"]})
+        op = self.create_operation(mode="REPLACE", null_strategy=NullStrategy.REPLACE)
+        result = op.process_batch(df)
+        self.assertListEqual(result["name"].tolist(), ["synthetic_NULL", "synthetic_Charlie"])
+
+    def test_all_nulls_returns_same_batch(self):
+        df = pd.DataFrame({"name": [None, None]})
+        op = self.create_operation(mode="ENRICH", null_strategy=NullStrategy.PRESERVE)
+        op.output_field_name = "synthetic_name"
+        result = op.process_batch(df)
+        self.assertTrue((result["synthetic_name"].isna()).all())
+
+    def test_output_structure_is_preserved(self):
+        df = pd.DataFrame({"name": ["X"], "other": [123]})
+        op = self.create_operation(mode="ENRICH")
+        op.output_field_name = "synthetic_name"
+        result = op.process_batch(df)
+        self.assertIn("name", result.columns)
+        self.assertIn("other", result.columns)
+        self.assertIn("synthetic_name", result.columns)
+
+
+class TestGeneratorOperationHandleNullValues(unittest.TestCase):
+
+    def setUp(self):
+        self.data = pd.DataFrame({
+            "name": ["Alice", None, "Bob", None]
+        })
+        self.mock_generator = Mock(spec=BaseGenerator)
+
+    def create_op(self, null_strategy):
+        return GeneratorOperation(
+            field_name="name",
+            generator=self.mock_generator,
+            null_strategy=null_strategy
+        )
+
+    def test_error_strategy_raises_validation_error(self):
+        op = self.create_op(NullStrategy.ERROR)
+        with self.assertRaises(ValidationError) as context:
+            op.handle_null_values(self.data)
+
+        self.assertIn("NULL values", str(context.exception))
+
+    def test_exclude_strategy_filters_nulls(self):
+        op = self.create_op(NullStrategy.EXCLUDE)
+        result = op.handle_null_values(self.data)
+        self.assertEqual(len(result), 2)
+        self.assertListEqual(result["name"].tolist(), ["Alice", "Bob"])
+
+    def test_preserve_strategy_returns_as_is(self):
+        op = self.create_op(NullStrategy.PRESERVE)
+        result = op.handle_null_values(self.data)
+        pd.testing.assert_frame_equal(result, self.data)
+
+    def test_replace_strategy_returns_as_is(self):
+        op = self.create_op(NullStrategy.REPLACE)
+        result = op.handle_null_values(self.data)
+        pd.testing.assert_frame_equal(result, self.data)
+
+
+class TestGeneratorOperationExecute(unittest.TestCase):
+    def setUp(self):
+        self.generator = Mock(spec=BaseGenerator)
+        self.mapping_store = Mock(spec=MappingStore)
+        self.mapping_store.get_field_mappings.return_value = {
+            "Alice": "SyntheticAlice",
+            "Bob": "SyntheticBob"
+        }
+
+        self.op = GeneratorOperation(
+            field_name="name",
+            generator=self.generator,
+            consistency_mechanism="mapping",
+            mapping_store=self.mapping_store
+        )
+
+        self.task_dir = Path("/fake/task_dir")
+        self.reporter = Mock()
+        self.progress_tracker = Mock()
+
+    @patch("pamola_core.fake_data.commons.operations.write_json")
+    @patch("pamola_core.fake_data.commons.operations.ensure_directory")
+    @patch("pamola_core.fake_data.commons.operations.FieldOperation.execute")
+    def test_execute_saves_mappings_on_success(self, mock_super_execute, mock_ensure_dir, mock_write_json):
+        # Mock super().execute() return value
+        mock_result = Mock(spec=OperationResult)
+        mock_result.status = OperationStatus.SUCCESS
+        mock_result.add_artifact = Mock()
+        mock_super_execute.return_value = mock_result
+
+        # Mock map dir
+        mock_ensure_dir.return_value = self.task_dir / "maps"
+
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=self.progress_tracker
+        )
+
+        # Ensure write_json was called twice
+        self.assertEqual(mock_write_json.call_count, 2)
+
+        # Build expected filenames using actual `self.op.name`
+        expected_serialized = [
+            {"original": "Alice", "synthetic": "SyntheticAlice", "field": "name"},
+            {"original": "Bob", "synthetic": "SyntheticBob", "field": "name"},
+        ]
+        expected_main_file = self.task_dir / f"{self.op.name}_{self.op.field_name}_mappings.json"
+        expected_detail_file = self.task_dir / "maps" / f"{self.op.field_name}_mappings.json"
+
+        mock_write_json.assert_any_call(expected_serialized, expected_main_file)
+        mock_write_json.assert_any_call(expected_serialized, expected_detail_file)
+
+        # Assert artifact was added with correct metadata
+        mock_result.add_artifact.assert_called_once()
+        _, kwargs = mock_result.add_artifact.call_args
+        self.assertEqual(kwargs["artifact_type"], "json")
+        self.assertEqual(kwargs["category"], Constants.Artifact_Category_Mapping)
+
+        self.assertEqual(result, mock_result)
+
+    @patch("pamola_core.fake_data.commons.operations.write_json")
+    @patch("pamola_core.fake_data.commons.operations.ensure_directory")
+    @patch("pamola_core.fake_data.commons.operations.FieldOperation.execute")
+    def test_execute_skips_mapping_if_not_success(self, mock_super_execute, mock_ensure_dir, mock_write_json):
+        # Simulate a failed operation result
+        mock_result = Mock(spec=OperationResult)
+        mock_result.status = OperationStatus.ERROR
+        mock_result.add_artifact = Mock()
+        mock_super_execute.return_value = mock_result
+
+        # Call execute method
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=self.progress_tracker
+        )
+
+        # Ensure no mapping file is written
+        mock_write_json.assert_not_called()
+        mock_result.add_artifact.assert_not_called()
+
+        # Ensure the result is returned correctly
+        self.assertEqual(result, mock_result)
+
+
+class TestFieldOperationInit(unittest.TestCase):
+
+    def test_init_with_valid_params(self):
+        op = FieldOperation(
+            field_name="test_field",
+            mode="ENRICH",
+            output_field_name="test_output",
+            chunk_size=5000,
+            null_strategy="replace",
+            use_cache=False,
+            force_recalculation=True,
+            use_dask=True,
+            npartitions=4,
+            use_vectorization=True,
+            parallel_processes=2,
+            use_encryption=True,
+            encryption_key="secret_key",
+            visualization_backend="plotly",
+            visualization_theme="dark",
+            visualization_strict=True
+        )
+
+        self.assertEqual(op.field_name, "test_field")
+        self.assertEqual(op.mode, "ENRICH")
+        self.assertEqual(op.output_field_name, "test_output")
+        self.assertEqual(op.chunk_size, 5000)
+        self.assertEqual(op.null_strategy, NullStrategy.REPLACE)
+        self.assertFalse(op.use_cache)
+        self.assertTrue(op.force_recalculation)
+        self.assertTrue(op.use_dask)
+        self.assertEqual(op.npartitions, 4)
+        self.assertTrue(op.use_vectorization)
+        self.assertEqual(op.parallel_processes, 2)
+        self.assertTrue(op.use_encryption)
+        self.assertEqual(op.encryption_key, "secret_key")
+        self.assertEqual(op.visualization_backend, "plotly")
+        self.assertEqual(op.visualization_theme, "dark")
+        self.assertTrue(op.visualization_strict)
+
+    def test_init_with_invalid_null_strategy_defaults_to_preserve(self):
+        with patch("pamola_core.fake_data.commons.operations.logger") as mock_logger:
+            op = FieldOperation(field_name="test", null_strategy="invalid_strategy")
+
+            # Should fall back to PRESERVE
+            self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
+            mock_logger.warning.assert_called_once_with("Unknown NULL strategy: invalid_strategy. Using PRESERVE.")
+
+    def test_init_with_enum_null_strategy(self):
+        op = FieldOperation(field_name="test", null_strategy=NullStrategy.EXCLUDE)
+        self.assertEqual(op.null_strategy, NullStrategy.EXCLUDE)
+
+    def test_metrics_collector_initialized(self):
+        op = FieldOperation(field_name="some_field")
+        self.assertIsNotNone(op._metrics_collector)
+        self.assertIsNone(op._original_df)
+
+
+class TestFieldOperationExecute(unittest.TestCase):
+    def setUp(self):
+        self.op = FieldOperation(field_name="test_field")
+        self.op.force_recalculation = True  # Force execution even if cache exists
+        self.task_dir = Path("/fake/task_dir")
+        self.reporter = Mock()
+        self.progress_tracker = Mock()
+
+        # Patch the instance method 'process_batch' with a simple lambda
+        patcher = patch.object(self.op, "process_batch", side_effect=lambda batch: batch)
+        self.mock_process_batch = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch("pamola_core.fake_data.commons.operations.generate_metrics_report")
+    @patch("pamola_core.fake_data.commons.operations.ensure_directory")
+    @patch.object(FieldOperation, "_save_metrics", return_value=Path("/fake/task_dir/metrics.json"))
+    @patch.object(FieldOperation, "_save_result", return_value=Path("/fake/task_dir/output.csv"))
+    @patch.object(FieldOperation, "_collect_metrics", return_value={"performance": {}})
+    @patch.object(FieldOperation, "handle_null_values")
+    @patch.object(FieldOperation, "preprocess_data")
+    @patch.object(FieldOperation, "_prepare_directories")
+    @patch("pamola_core.fake_data.commons.operations.load_data_operation")
+    def test_execute_success(self, mock_load_data, mock_prepare_dirs, mock_preprocess, mock_handle_null,
+                             mock_collect_metrics, mock_save_result, mock_save_metrics,
+                             mock_ensure_dir, mock_generate_report):
+        # Set up mocks to return the input dataframe unchanged
+        mock_handle_null.side_effect = lambda df: df
+        mock_preprocess.side_effect = lambda df: df
+
+        # Return fake output and visualization directory paths
+        mock_prepare_dirs.return_value = {
+            "output": self.task_dir / "output",
+            "visualizations": self.task_dir / "visualizations"
+        }
+
+        # Create simulated input data
+        df = pd.DataFrame({
+            self.op.field_name: [1, 2, 3],
+            "other_field": [4, 5, 6]
+        })
+        mock_load_data.return_value = df
+
+        # Execute the operation
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=self.progress_tracker
+        )
+
+        # Verify that dummy_process_batch was called
+        self.assertTrue(self.mock_process_batch.called, "Expected process_batch to be called")
+
+        # Verify result status and structure
+        self.assertEqual(result.status, OperationStatus.SUCCESS)
+        self.assertTrue(hasattr(result, "metrics"))
+        self.assertIsInstance(result.metrics, dict)
+
+        # Confirm all mocks were called correctly
+        mock_prepare_dirs.assert_called_once_with(self.task_dir)
+        mock_load_data.assert_called_once()
+        mock_save_result.assert_called_once()
+        mock_save_metrics.assert_called_once()
+        mock_ensure_dir.assert_called_once()
+        mock_generate_report.assert_called_once()
+
+    @patch("pamola_core.fake_data.commons.operations.load_data_operation")
+    @patch.object(FieldOperation, "_prepare_directories")
+    def test_execute_field_missing_returns_error(self, mock_prepare_dirs, mock_load_data):
+        mock_prepare_dirs.return_value = {
+            "output": self.task_dir / "output",
+            "visualizations": self.task_dir / "visualizations"
+        }
+
+        # DataFrame missing the required field
+        df = pd.DataFrame({"other_field": [1, 2, 3]})
+        mock_load_data.return_value = df
+
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=None
+        )
+
+        self.assertEqual(result.status, OperationStatus.ERROR)
+        self.assertIn("not found in the data", result.error_message)
+        self.reporter.add_operation.assert_any_call(
+            f"Operation {self.op.name}", status="info", details=ANY
+        )
+
+    @patch("pamola_core.fake_data.commons.operations.load_data_operation")
+    @patch.object(FieldOperation, "_prepare_directories")
+    @patch.object(FieldOperation, "_get_cache")
+    def test_execute_uses_cache(self, mock_get_cache, mock_prepare_dirs, mock_load_data):
+        mock_prepare_dirs.return_value = {
+            "output": self.task_dir / "output",
+            "visualizations": self.task_dir / "visualizations"
+        }
+
+        df = pd.DataFrame({self.op.field_name: [1, 2, 3]})
+        mock_load_data.return_value = df
+
+        cached_result = Mock(spec=OperationResult)
+        cached_result.status = OperationStatus.SUCCESS
+        mock_get_cache.return_value = cached_result
+
+        self.op.use_cache = True
+        self.op.force_recalculation = False
+
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=self.progress_tracker
+        )
+
+        # It should return cached result and skip processing
+        self.assertEqual(result, cached_result)
+        self.reporter.add_operation.assert_any_call(
+            f"Operation {self.op.name}", status="info",
+            details={"message": "Result loaded from cache – execution skipped"}
+        )
+
+    def test_execute_catches_exception_and_reports_error(self):
+        # Patch method to raise error
+        self.op._prepare_directories = Mock(side_effect=Exception("fail prepare dirs"))
+
+        result = self.op.execute(
+            data_source=Mock(),
+            task_dir=self.task_dir,
+            reporter=self.reporter,
+            progress_tracker=None
+        )
+
+        self.assertEqual(result.status, OperationStatus.ERROR)
+        self.assertIn("fail prepare dirs", result.error_message)
+        self.reporter.add_operation.assert_called_with(
+            f"Operation {self.op.name}", status="error",
+            details={"message": "fail prepare dirs"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fake_data/generators/test_phone.py
+++ b/tests/fake_data/generators/test_phone.py
@@ -395,6 +395,7 @@ class TestPhoneGeneratorFormatPhone(unittest.TestCase):
             number='3456',
             format_template=template
         )
+        # Expect padded operator_code -> "1200"
         self.assertEqual(formatted, "+44-1200-3456")
 
     def test_format_with_long_operator_code_truncating(self):

--- a/tests/fake_data/operations/test_email_op.py
+++ b/tests/fake_data/operations/test_email_op.py
@@ -22,7 +22,7 @@ class TestFakeEmailOperationInit(unittest.TestCase):
         # Check default attributes of FakeEmailOperation
         self.assertEqual(op.field_name, "email")
         self.assertEqual(op.mode, "ENRICH")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
         self.assertFalse(op.save_mapping)
@@ -71,7 +71,7 @@ class TestFakeEmailOperationInit(unittest.TestCase):
             "handle_invalid_email": "generate_new",
             "nicknames_dict": None,
             "max_length": 254,
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "abcd",
             "mapping_store_path": "C:/fake_data/email_operation/mappings.json",
@@ -95,7 +95,7 @@ class TestFakeEmailOperationInit(unittest.TestCase):
         self.assertEqual(op.field_name, "email")
         self.assertEqual(op.mode, "ENRICH")
         self.assertEqual(op.output_field_name, "email_enriched")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "abcd")
         self.assertTrue(op.save_mapping)
@@ -335,10 +335,10 @@ class PrepareData:
             "handle_invalid_email": "generate_new",
             "nicknames_dict": None,
             "max_length": 254,
-            "batch_size": 10000,
+            "chunk_size": 3,
             "null_strategy": "PRESERVE",
-            "consistency_mechanism": "abcd",
-            "mapping_store_path": "C:/fake_data/email_operation/mappings.json",
+            "consistency_mechanism": "prgn",   # "prgn", "mapping"
+            "mapping_store_path": "C:/operation/fake_data/email/maps/mappings.json",
             "id_field": "id",
             "key": None,
             "context_salt": "email-context-001",
@@ -350,7 +350,18 @@ class PrepareData:
             "business_domain_ratio": 0.2,
             "detailed_metrics": True,
             "error_logging_level": "WARNING",
-            "max_retries": 3
+            "max_retries": 3,
+            "use_cache": True,
+            "force_recalculation": True,
+            "use_dask": False,
+            "npartitions": 2,
+            "use_vectorization": False,
+            "parallel_processes": 2,
+            "use_encryption": False,
+            "encryption_key":  None,
+            "visualization_backend": "plotly",
+            "visualization_theme": None,
+            "visualization_strict": False
         }
 
     def create_task_dir(self):
@@ -407,7 +418,7 @@ class TestFakeEmailOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)
@@ -461,7 +472,7 @@ class TestFakeEmailOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)

--- a/tests/fake_data/operations/test_name_op.py
+++ b/tests/fake_data/operations/test_name_op.py
@@ -20,7 +20,7 @@ class TestFakeNameOperationInit(unittest.TestCase):
         # Check basic configuration attributes
         self.assertEqual(op.field_name, "full_name")
         self.assertEqual(op.mode, "ENRICH")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
 
@@ -66,7 +66,7 @@ class TestFakeNameOperationInit(unittest.TestCase):
             "use_faker": False,
             "case": "title",
             "dictionaries": None,
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "prgn",
             "mapping_store_path": "C:/fake_data/name_operation/mappings.json",
@@ -83,7 +83,7 @@ class TestFakeNameOperationInit(unittest.TestCase):
         self.assertEqual(op.field_name, "full_name")
         self.assertEqual(op.mode, "ENRICH")
         self.assertEqual(op.output_field_name, "full_name_enriched")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
         self.assertTrue(op.save_mapping)
@@ -148,7 +148,7 @@ class TestFakeNameOperationProcessValue(unittest.TestCase):
             "full_name", "Jane Doe", "synthetic_name"
         )
 
-    @patch("pamola_core.fake_data.commons.prgn.PRNGenerator")
+    @patch("pamola_core.fake_data.operations.name_op.PRNGenerator")
     def test_process_value_with_prgn_consistency(self, MockPRGN):
         self.op.consistency_mechanism = "prgn"
         self.op.generator.prgn_generator = None
@@ -308,7 +308,7 @@ class PrepareData:
             "use_faker": False,
             "case": "title",
             "dictionaries": None,
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "prgn",
             "mapping_store_path": "C:/fake_data/name_operation/mappings.json",
@@ -373,7 +373,7 @@ class TestFakeNameOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)
@@ -427,7 +427,7 @@ class TestFakeNameOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)

--- a/tests/fake_data/operations/test_organization_op.py
+++ b/tests/fake_data/operations/test_organization_op.py
@@ -21,7 +21,7 @@ class TestFakeOrganizationOperationInit(unittest.TestCase):
         # Check default attributes
         self.assertEqual(op.field_name, "organization")
         self.assertEqual(op.mode, "ENRICH")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
         self.assertFalse(op.save_mapping)
@@ -83,7 +83,7 @@ class TestFakeOrganizationOperationInit(unittest.TestCase):
             "region": "en",
             "preserve_type": True,
             "industry": "technology",
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "abcd",
             "mapping_store_path": "C:/fake_data/operation/mappings.json",
@@ -106,7 +106,7 @@ class TestFakeOrganizationOperationInit(unittest.TestCase):
         self.assertEqual(op.field_name, "organization_name")
         self.assertEqual(op.mode, "ENRICH")
         self.assertEqual(op.output_field_name, "organization_enriched")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "abcd")
         self.assertEqual(op.mapping_store_path, "C:/fake_data/operation/mappings.json")
@@ -347,7 +347,7 @@ class PrepareData:
             "region": "en",
             "preserve_type": True,
             "industry": None,
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "abcd",
             "mapping_store_path": "C:/fake_data/operation/mappings.json",
@@ -418,7 +418,7 @@ class TestFakeOrganzationOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)
@@ -472,7 +472,7 @@ class TestFakeOrganzationOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)

--- a/tests/fake_data/operations/test_phone_op.py
+++ b/tests/fake_data/operations/test_phone_op.py
@@ -21,7 +21,7 @@ class TestFakePhoneOperationInit(unittest.TestCase):
         # Basic attributes
         self.assertEqual(op.field_name, "phone_number")
         self.assertEqual(op.mode, "ENRICH")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
         self.assertFalse(op.save_mapping)
@@ -82,7 +82,7 @@ class TestFakePhoneOperationInit(unittest.TestCase):
             "preserve_country_code": True,
             "preserve_operator_code": False,
             "region": "us",
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": NullStrategy.PRESERVE,
             "consistency_mechanism": "prgn",
             "mapping_store_path": "C:/fake_data/phone_operation/mappings.json",
@@ -105,7 +105,7 @@ class TestFakePhoneOperationInit(unittest.TestCase):
         self.assertEqual(op.field_name, "phone_number")
         self.assertEqual(op.mode, "ENRICH")
         self.assertEqual(op.output_field_name, "phone_number_enriched")
-        self.assertEqual(op.batch_size, 10000)
+        self.assertEqual(op.chunk_size, 10000)
         self.assertEqual(op.null_strategy, NullStrategy.PRESERVE)
         self.assertEqual(op.consistency_mechanism, "prgn")
         self.assertEqual(op.mapping_store_path, "C:/fake_data/phone_operation/mappings.json")
@@ -393,7 +393,7 @@ class PrepareData:
             "preserve_country_code": True,
             "preserve_operator_code": False,
             "region": "us",
-            "batch_size": 10000,
+            "chunk_size": 10000,
             "null_strategy": "PRESERVE",
             "consistency_mechanism": "prgn",
             "mapping_store_path": "C:/fake_data/phone_operation/mappings.json",
@@ -464,7 +464,7 @@ class TestFakePhoneOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)
@@ -518,7 +518,7 @@ class TestFakePhoneOperationExecute(unittest.TestCase):
                 msg=f"Unexpected artifact file type: {artifact.path}"
             )
             self.assertIsInstance(artifact.description, str)
-            self.assertIn(artifact.category, ["output", "metric", "visualization"])
+            self.assertIn(artifact.category, ["output", "metrics", "visualization"])
             self.assertIsInstance(artifact.tags, list)
             self.assertIsInstance(artifact.creation_time, str)
             self.assertIsInstance(artifact.size, int)


### PR DESCRIPTION
# PR Manifest – Sprint 8 (02/06/2025 - 13/06/2025)

## Key points
- Encryption integration: fake_data, profiling, transformation packages
- Parallel processing with Dask and JobLib: fake_data, profiling, transformation packages
- Cache and progress tracking: fake_data, profiling, transformation packages
- Thread-safe visualization context: fake_data, profiling, transformation packages
- Enhancement log to file for Task execution, including operation log

---

## Functionalities

### Summary of functionalities per each package
| Functionality | Fake Data | Profiling | Transformation |
| --- | --- | --- | --- |
| Encryption | 100% | 100% | 100% |
| Dask | 100% | 100% | 100% |
| JobLib | 100% | 100% | 100% |
| Metrics & Visualization | 100% | 100% | 100% |
| Threads for Visualization | 0% | 85% | 78% |
| Cache | 100% | 100% | 100% |
| Standardized Error Handling | 100% | 100% | 100% |
| Progress Tracker | 100% | 100% | 100% |
| Reporter | 100% | 100% | 100% |


### Details of functionalities

| Packages | Operations | DataSource utils | Encryption | Encryption mode per Task | Encryption provider for output dataset | Encryption provider for artifacts | Dask | JobLib | Metrics & Visualization | Threads for Visualization | Cache | Standardized Error Handling | Tracker Progress | Reporter | Log to files | Notes |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| core/profiling/ | Anonymity | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. - To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward. |
| core/profiling/ | Attribute | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Dask chunking and joblist cannot be applied by splitting the dataframe because k-anonymity and attribute profiling require global statistics across the entire dataset. - To enable Dask or parallel processing, each calculation must operate on the full dataframe, not on separate chunks, and results should be aggregated afterward. |
| core/profiling/ | Categorical | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Parallelizing categorical by splitting rows is not feasible because the function requires the entire column to compute accurate statistics such as value_counts, entropy, and top_n. Row-wise chunking would result in incorrect results since partial calculations from chunks cannot be simply merged to match the global column statistics. |
| core/profiling/ | Correlation | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Parallelizing correlation analysis by splitting rows using Dask or joblib (joblist) is not feasible because accurate correlation statisticssuch as value_counts, contingency tables, and correlation coefficientsrequire access to the entire columns or all relevant data for each field. |
| core/profiling/ | Date | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/profiling/ | Email | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/profiling/ | Group | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Parallelizing group-based analysis by splitting rows or partitions is not feasible because group metrics such as variance and duplication require access to all records of each group. If groups are fragmented across partitions, the calculated statistics will be incorrect |
| core/profiling/ | Identity | Yes | Yes | Yes | Simple | Simple | No | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Identity analysis cannot be parallelized by splitting rows using Dask or joblib. This is because accurate statisticssuch as value_counts, groupby, distribution, and top_nrequire access to the entire column or all groups to compute correct results. If the data is split by rows, partial results from each chunk cannot be simply merged to produce the correct global statistics. - Do not use output_format because the data only returns analysis results. |
| core/profiling/ | Mvf | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/profiling/ | Numeric | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/profiling/ | Phone | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/profiling/ | Text | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | The flow will get a sample to detect if it's a large dataset, so there's no need to apply parallelization |
| core/profiling/ | Currency | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/fake_data/ | Email | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
| core/fake_data/ | Name | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
| core/fake_data/ | Organization | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
| core/fake_data/ | Phone | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | split_fields | Yes | Yes | Yes | Auto-determined  | Simple | No | No | Yes | Todo | Yes | Yes | Yes | Yes | Yes | - Dask and Joblib are not used here because we are only splitting the DataFrame by column groups, which is a lightweight operation. Pandas handles column selection efficiently even with millions of rows, so adding parallelism would introduce unnecessary overhead without performance benefits. |
| core/transformation/ | split_by_id_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Todo | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | clean_invalid_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | impute_missing_values | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | aggregate_records | Yes | Yes | Yes | Auto-determined  | Simple | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.) |
| core/transformation/ | merge_datasets | Yes | Yes | Yes | Auto-determined  | Simple | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | - Only using dask (Using joblib requires manually dividing the data into chunks and later concatenating the results, which may lead to inaccuracies in the final processed data.) |
| core/transformation/ | remove_fields | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | add_modify_fields | Yes | Yes | Yes | Auto-determined  | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |
| core/transformation/ | base_transformation_op | Yes | Yes | Yes | Simple | Simple | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | nan |

---